### PR TITLE
Feat: add whole library

### DIFF
--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -114,6 +114,7 @@ mpris = true
 # library_refresh     = "Ctrl+g"      # "" disables; forced refresh if still Ctrl+g
 #                       # If you set library_refresh to Ctrl+r while album replace is also Ctrl+r,
 #                       # the app treats refresh as unset so Ctrl+g default wins.
+# library_index_append_queue = "Ctrl+a"  # append full indexed library to queue (y/n); "" disables
 # toggle_help         = "i"
 # toggle_dynamic_theme = "t"          # cycles dynamic accent (ignored when theme preset is terminal)
 # toggle_lyrics       = "Shift+l"

--- a/ratune/src/action.rs
+++ b/ratune/src/action.rs
@@ -131,6 +131,10 @@ pub enum Action {
     LibraryIndexRefresh,
     /// Confirm a pending full library index refresh.
     ConfirmLibraryIndexRefresh,
+    /// Propose appending all indexed library tracks to the queue (shows y/n first).
+    LibraryIndexAppendQueue,
+    /// Confirm pending append of the full metadata index to the queue.
+    ConfirmLibraryIndexAppendQueue,
     /// Dismiss a global confirmation prompt (e.g. library refresh).
     CancelGlobalConfirm,
     Quit,

--- a/ratune/src/action.rs
+++ b/ratune/src/action.rs
@@ -135,6 +135,8 @@ pub enum Action {
     LibraryIndexAppendQueue,
     /// Confirm pending append of the full metadata index to the queue.
     ConfirmLibraryIndexAppendQueue,
+    /// Confirm pending append of the full server library (non-index) to the queue.
+    ConfirmLibraryServerAppendQueue,
     /// Dismiss a global confirmation prompt (e.g. library refresh).
     CancelGlobalConfirm,
     Quit,

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -2099,6 +2099,35 @@ impl App {
                     self.spawn_library_index_refresh(true);
                 }
             }
+            Action::LibraryIndexAppendQueue => {
+                if self.pending_global_confirm.is_some() {
+                    self.flash_status("Already confirming — press y or n");
+                } else if !self.config.library_index_enabled {
+                    self.flash_status("Library index is disabled in config");
+                } else if self.library_index_refreshing {
+                    self.flash_status_secs(
+                        "Library index refresh in progress — try again shortly",
+                        8,
+                    );
+                } else if self.library_index_tracks.is_empty() {
+                    self.flash_status(
+                        "Library index empty — wait for refresh or use the index refresh shortcut",
+                    );
+                } else {
+                    let n = self.library_index_tracks.len();
+                    self.pending_global_confirm = Some(GlobalConfirm::LibraryIndexAppendQueue);
+                    self.flash_status_secs(
+                        format!("Append all {n} indexed tracks to queue? (y/n)"),
+                        12,
+                    );
+                }
+            }
+            Action::ConfirmLibraryIndexAppendQueue => {
+                if self.pending_global_confirm == Some(GlobalConfirm::LibraryIndexAppendQueue) {
+                    self.pending_global_confirm = None;
+                    self.handle_confirm_library_index_append_queue();
+                }
+            }
             Action::CancelGlobalConfirm => {
                 if self.pending_global_confirm.take().is_some() {
                     self.flash_status("Cancelled");
@@ -3083,6 +3112,33 @@ impl App {
                 self.queue.cursor = 0;
                 self.play_current();
             }
+        }
+    }
+
+    /// Append every track from the on-disk metadata index to the queue (after y/n confirm).
+    fn handle_confirm_library_index_append_queue(&mut self) {
+        if !self.config.library_index_enabled {
+            self.flash_status("Library index is disabled in config");
+            return;
+        }
+        if self.library_index_tracks.is_empty() {
+            self.flash_status("Library index empty");
+            return;
+        }
+        let n = self.library_index_tracks.len();
+        let was_empty = self.queue.songs.is_empty();
+        for song in self.library_index_tracks.iter().cloned() {
+            self.queue.push(song);
+        }
+        if was_empty && !self.queue.songs.is_empty() {
+            self.queue.cursor = 0;
+            self.queue.scroll = 0;
+            self.play_current();
+        }
+        if n == 1 {
+            self.flash_status_secs("Added 1 track to queue", 3);
+        } else {
+            self.flash_status_secs(format!("Added {n} tracks to queue"), 3);
         }
     }
 

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -303,6 +303,10 @@ pub enum LibraryUpdate {
     LibraryIndexRefreshComplete {
         result: Result<(Vec<ratune_subsonic::Song>, Option<String>, bool), String>,
     },
+    /// Full-library fetch (from server) finished for "append whole library" when index is disabled.
+    LibraryServerAppendQueueComplete {
+        result: Result<Vec<ratune_subsonic::Song>, String>,
+    },
 }
 
 #[derive(Clone, Copy)]
@@ -394,6 +398,11 @@ pub struct App {
     pub library_index_refreshing: bool,
     /// When the current refresh started; drives status-bar animation until complete.
     pub library_index_refresh_started: Option<Instant>,
+    /// True while a background full-library fetch is running for "append whole library"
+    /// when the local index is disabled/empty.
+    pub library_server_append_fetching: bool,
+    /// When the current server fetch started; drives status-bar animation until complete.
+    pub library_server_append_started: Option<Instant>,
 
     // ── Offline cache (Feature 5.3) ───────────────────────────────────────────
     /// Track file cache (LRU, persisted to `~/.cache/ratune/`).
@@ -573,6 +582,8 @@ impl App {
             library_index_refreshed_at,
             library_index_refreshing: false,
             library_index_refresh_started: None,
+            library_server_append_fetching: false,
+            library_server_append_started: None,
             cache: track_cache,
             prefetch_gen: Arc::new(AtomicU64::new(0)),
             help_visible: false,
@@ -1106,6 +1117,34 @@ impl App {
         });
     }
 
+    /// Fetch the full library from the server (without requiring the on-disk index)
+    /// and append it to the queue.
+    pub fn spawn_library_server_append_queue(&mut self) {
+        if self.library_server_append_fetching {
+            self.flash_status_secs("Library fetch already in progress", 8);
+            return;
+        }
+        self.library_server_append_fetching = true;
+        self.library_server_append_started = Some(Instant::now());
+
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        let album_p = self.config.library_fetch_album_parallelism;
+        let artist_p = self.config.library_fetch_artist_parallelism;
+        tokio::spawn(async move {
+            let opts = ratune_subsonic::FetchLibraryOptions {
+                album_parallelism: album_p,
+                artist_parallelism: artist_p,
+            };
+            let result = ratune_subsonic::fetch_all_library_songs_with_options(&client, opts)
+                .await
+                .map_err(|e| e.to_string());
+            let _ = tx
+                .send(LibraryUpdate::LibraryServerAppendQueueComplete { result })
+                .await;
+        });
+    }
+
     pub fn flash_status(&mut self, msg: impl Into<String>) {
         self.flash_status_secs(msg, 3);
     }
@@ -1617,6 +1656,33 @@ impl App {
                     }
                 }
             }
+            LibraryUpdate::LibraryServerAppendQueueComplete { result } => {
+                self.library_server_append_fetching = false;
+                self.library_server_append_started = None;
+                match result {
+                    Ok(tracks) => {
+                        let n = tracks.len();
+                        if n == 0 {
+                            self.flash_status_secs("No tracks found in library", 5);
+                            return;
+                        }
+                        let was_empty = self.queue.songs.is_empty();
+                        for s in tracks {
+                            self.queue.push(s);
+                        }
+                        if was_empty && !self.queue.songs.is_empty() {
+                            self.queue.cursor = 0;
+                            self.queue.scroll = 0;
+                            self.play_current();
+                        }
+                        self.flash_status_secs(format!("Added {n} tracks to queue"), 3);
+                    }
+                    Err(e) => {
+                        eprintln!("library fetch for append queue: {e}");
+                        self.flash_status_secs(format!("Library fetch failed: {e}"), 6);
+                    }
+                }
+            }
         }
     }
 
@@ -2102,22 +2168,26 @@ impl App {
             Action::LibraryIndexAppendQueue => {
                 if self.pending_global_confirm.is_some() {
                     self.flash_status("Already confirming — press y or n");
-                } else if !self.config.library_index_enabled {
-                    self.flash_status("Library index is disabled in config");
                 } else if self.library_index_refreshing {
                     self.flash_status_secs(
                         "Library index refresh in progress — try again shortly",
                         8,
                     );
-                } else if self.library_index_tracks.is_empty() {
-                    self.flash_status(
-                        "Library index empty — wait for refresh or use the index refresh shortcut",
-                    );
-                } else {
+                } else if self.library_server_append_fetching {
+                    self.flash_status_secs("Library fetch already in progress", 8);
+                } else if self.config.library_index_enabled && !self.library_index_tracks.is_empty() {
+                    // Fast path: local metadata index already loaded.
                     let n = self.library_index_tracks.len();
                     self.pending_global_confirm = Some(GlobalConfirm::LibraryIndexAppendQueue);
                     self.flash_status_secs(
                         format!("Append all {n} indexed tracks to queue? (y/n)"),
+                        12,
+                    );
+                } else {
+                    // Slow path: no local index available; fetch full library from server.
+                    self.pending_global_confirm = Some(GlobalConfirm::LibraryServerAppendQueue);
+                    self.flash_status_secs(
+                        "Fetch full library from server and append to queue? (y/n)",
                         12,
                     );
                 }
@@ -2126,6 +2196,12 @@ impl App {
                 if self.pending_global_confirm == Some(GlobalConfirm::LibraryIndexAppendQueue) {
                     self.pending_global_confirm = None;
                     self.handle_confirm_library_index_append_queue();
+                }
+            }
+            Action::ConfirmLibraryServerAppendQueue => {
+                if self.pending_global_confirm == Some(GlobalConfirm::LibraryServerAppendQueue) {
+                    self.pending_global_confirm = None;
+                    self.spawn_library_server_append_queue();
                 }
             }
             Action::CancelGlobalConfirm => {

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -2175,7 +2175,8 @@ impl App {
                     );
                 } else if self.library_server_append_fetching {
                     self.flash_status_secs("Library fetch already in progress", 8);
-                } else if self.config.library_index_enabled && !self.library_index_tracks.is_empty() {
+                } else if self.config.library_index_enabled && !self.library_index_tracks.is_empty()
+                {
                     // Fast path: local metadata index already loaded.
                     let n = self.library_index_tracks.len();
                     self.pending_global_confirm = Some(GlobalConfirm::LibraryIndexAppendQueue);

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -79,6 +79,8 @@ pub struct KeybindsSection {
     pub library_fzf: Option<String>,
     /// Force library index refresh. Default: Ctrl+g
     pub library_refresh: Option<String>,
+    /// Append all indexed tracks to the queue (y/n confirm). Default: Ctrl+a (`""` disables)
+    pub library_index_append_queue: Option<String>,
     /// Toggle this help popup. Default: i
     pub toggle_help: Option<String>,
     /// Toggle dynamic accent from album art. Default: t
@@ -1188,6 +1190,7 @@ max_bit_rate = 0   # 0 = unlimited; set e.g. 320 to cap streaming bitrate
 # quit          = "q"
 # library_fzf     = "Ctrl+f"
 # library_refresh = "Ctrl+g"
+# library_index_append_queue = "Ctrl+a"   # append full index to queue (y/n); "" to disable
 # toggle_help = "i"
 # toggle_dynamic_theme = "t"
 # toggle_lyrics = "Shift+l"

--- a/ratune/src/keybinds.rs
+++ b/ratune/src/keybinds.rs
@@ -164,6 +164,8 @@ pub struct Keybinds {
     pub library_fzf: Option<KeySpec>,
     /// Force library index refresh (`None` = disabled).
     pub library_refresh: Option<KeySpec>,
+    /// Append entire metadata index to queue after y/n (`None` = disabled).
+    pub library_index_append_queue: Option<KeySpec>,
     pub toggle_help: KeySpec,
     pub toggle_dynamic_theme: KeySpec,
     pub toggle_lyrics: KeySpec,
@@ -252,6 +254,13 @@ impl Keybinds {
                 modifiers: KeyModifiers::CONTROL,
             }),
         );
+        let library_index_append_queue = resolve_opt(
+            sec.library_index_append_queue.as_deref(),
+            Some(KeySpec {
+                code: KeyCode::Char('a'),
+                modifiers: KeyModifiers::CONTROL,
+            }),
+        );
 
         Self {
             scroll_up: resolve(sec.scroll_up.as_deref(), KeySpec::new(KeyCode::Char('k'))),
@@ -312,6 +321,7 @@ impl Keybinds {
             quit: resolve(sec.quit.as_deref(), KeySpec::new(KeyCode::Char('q'))),
             library_fzf,
             library_refresh,
+            library_index_append_queue,
             toggle_help: resolve(sec.toggle_help.as_deref(), KeySpec::new(KeyCode::Char('i'))),
             toggle_dynamic_theme: resolve(
                 sec.toggle_dynamic_theme.as_deref(),

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -666,6 +666,17 @@ async fn run_loop(
                                                     _ => Action::None,
                                                 }
                                             }
+                                            GlobalConfirm::LibraryServerAppendQueue => {
+                                                match key.code {
+                                                    KeyCode::Char('y') | KeyCode::Char('Y') => {
+                                                        Action::ConfirmLibraryServerAppendQueue
+                                                    }
+                                                    KeyCode::Char('n')
+                                                    | KeyCode::Char('N')
+                                                    | KeyCode::Esc => Action::CancelGlobalConfirm,
+                                                    _ => Action::None,
+                                                }
+                                            }
                                         }
                                     } else {
                                         map_key(

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -642,17 +642,30 @@ async fn run_loop(
                                         map_help_key(key.code, key.modifiers, &app.keybinds)
                                     } else if app.search_mode.active {
                                         map_search_key(key.code)
-                                    } else if app.pending_global_confirm
-                                        == Some(GlobalConfirm::LibraryIndexRefresh)
-                                    {
-                                        match key.code {
-                                            KeyCode::Char('y') | KeyCode::Char('Y') => {
-                                                Action::ConfirmLibraryIndexRefresh
+                                    } else if let Some(pending) = app.pending_global_confirm {
+                                        match pending {
+                                            GlobalConfirm::LibraryIndexRefresh => {
+                                                match key.code {
+                                                    KeyCode::Char('y') | KeyCode::Char('Y') => {
+                                                        Action::ConfirmLibraryIndexRefresh
+                                                    }
+                                                    KeyCode::Char('n')
+                                                    | KeyCode::Char('N')
+                                                    | KeyCode::Esc => Action::CancelGlobalConfirm,
+                                                    _ => Action::None,
+                                                }
                                             }
-                                            KeyCode::Char('n')
-                                            | KeyCode::Char('N')
-                                            | KeyCode::Esc => Action::CancelGlobalConfirm,
-                                            _ => Action::None,
+                                            GlobalConfirm::LibraryIndexAppendQueue => {
+                                                match key.code {
+                                                    KeyCode::Char('y') | KeyCode::Char('Y') => {
+                                                        Action::ConfirmLibraryIndexAppendQueue
+                                                    }
+                                                    KeyCode::Char('n')
+                                                    | KeyCode::Char('N')
+                                                    | KeyCode::Esc => Action::CancelGlobalConfirm,
+                                                    _ => Action::None,
+                                                }
+                                            }
                                         }
                                     } else {
                                         map_key(
@@ -1245,6 +1258,11 @@ fn map_key(
     if let Some(spec) = &kb.library_refresh {
         if spec.matches(code, modifiers) {
             return Action::LibraryIndexRefresh;
+        }
+    }
+    if let Some(spec) = &kb.library_index_append_queue {
+        if spec.matches(code, modifiers) {
+            return Action::LibraryIndexAppendQueue;
         }
     }
 

--- a/ratune/src/state.rs
+++ b/ratune/src/state.rs
@@ -194,6 +194,8 @@ impl QueueState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GlobalConfirm {
     LibraryIndexRefresh,
+    /// Append every track in the on-disk metadata index to the queue (after y/n).
+    LibraryIndexAppendQueue,
 }
 
 // ── PlaylistOverlay ───────────────────────────────────────────────────────────

--- a/ratune/src/state.rs
+++ b/ratune/src/state.rs
@@ -196,6 +196,8 @@ pub enum GlobalConfirm {
     LibraryIndexRefresh,
     /// Append every track in the on-disk metadata index to the queue (after y/n).
     LibraryIndexAppendQueue,
+    /// Fetch the full library from the server and append it to the queue (after y/n).
+    LibraryServerAppendQueue,
 }
 
 // ── PlaylistOverlay ───────────────────────────────────────────────────────────

--- a/ratune/src/ui/popup.rs
+++ b/ratune/src/ui/popup.rs
@@ -49,6 +49,7 @@ fn sections() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
             vec![
                 ("a", "Add track to queue"),
                 ("A", "On artist / album add to queue"),
+                ("Ctrl+a", "Append full index to queue (y/n)"),
                 ("D", "Clear queue"),
             ],
         ),

--- a/ratune/src/ui/queue.rs
+++ b/ratune/src/ui/queue.rs
@@ -56,15 +56,18 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         app.config.queue_template.as_str()
     };
 
-    let items: Vec<ListItem> = app
-        .queue
-        .songs
+    // Only render the currently visible window of the queue instead of all rows.
+    let total = app.queue.songs.len();
+    let start = app.queue.scroll.min(total.saturating_sub(1));
+    let end = (start + visible).min(total);
+    let items: Vec<ListItem> = app.queue.songs[start..end]
         .iter()
         .enumerate()
-        .map(|(i, s)| {
+        .map(|(offset, s)| {
+            let idx = start + offset;
             let label = format_queue_line(template, s);
 
-            let style = if i == app.queue.cursor {
+            let style = if idx == app.queue.cursor {
                 Style::default()
                     .fg(app.accent())
                     .add_modifier(Modifier::BOLD)
@@ -84,8 +87,10 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         )
         .style(Style::default().bg(t.surface));
 
-    let mut state = ListState::default().with_offset(app.queue.scroll);
-    state.select(Some(app.queue.cursor));
+    // Offset is handled by slicing, so keep ListState offset at 0 and select within window.
+    let mut state = ListState::default();
+    let selected = app.queue.cursor.saturating_sub(start);
+    state.select(Some(selected));
     frame.render_stateful_widget(list, area, &mut state);
 }
 

--- a/ratune/src/ui/status_bar.rs
+++ b/ratune/src/ui/status_bar.rs
@@ -25,6 +25,20 @@ fn library_index_refresh_status_text(app: &App) -> String {
     format!("Refreshing library index {sp}  ·  {secs}s")
 }
 
+fn library_fetch_status_text(app: &App) -> String {
+    let (idx, secs) = match app.library_server_append_started {
+        Some(start) => {
+            let idx = (Instant::now().duration_since(start).as_millis() / 80) as usize
+                % LIB_SPINNER.len();
+            let secs = start.elapsed().as_secs();
+            (idx, secs)
+        }
+        None => (0, 0),
+    };
+    let sp = LIB_SPINNER[idx];
+    format!("Fetching full library {sp}  ·  {secs}s")
+}
+
 // ── Public render ─────────────────────────────────────────────────────────────
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect) {
@@ -50,6 +64,10 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
     } else if app.library_index_refreshing {
         let w = area.width as usize;
         let shown = fit_status_bar_text(&library_index_refresh_status_text(app), w);
+        Line::from(vec![Span::styled(shown, Style::default().fg(app.accent()))])
+    } else if app.library_server_append_fetching {
+        let w = area.width as usize;
+        let shown = fit_status_bar_text(&library_fetch_status_text(app), w);
         Line::from(vec![Span::styled(shown, Style::default().fg(app.accent()))])
     } else if let Some((msg, _)) = &app.status_flash {
         // Flash message: left-aligned, truncated to the bar width (centred long


### PR DESCRIPTION
Address request in #1 

Allows a user to add their whole library to the queue.

Default binding is `ctrl+a` which then prompts the user to confirm.

Utilizes the library metadata cache if it is available. If not, loads normally with spinner to show it is working.

I tested with `library = false` in config and it took about 45 seconds for about 13000 songs. With metadata cache it is instant.

Also includes some optimization for queue rendering.

