### PR TITLE
fix: touch up visualizer gradient color for terminal theme

### DIFF
--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -318,6 +318,9 @@ location = "right"
 #   - "gradient_theme" ignores this list and uses theme dimmed→foreground→accent.
 #   - "#RRGGBB" uses truecolor.
 #   - "0".."255" uses 256-color indices.
+# tmux + gradient_theme / gradient_height with indexed or reset colours: enable palette readback
+#   on the outer terminal by adding to ~/.tmux.conf:  set -g allow-passthrough on
+#   (tmux 3.2+). Ratune wraps OSC queries in DCS passthrough when $TMUX is set.
 type = "spectrum"
 fps = 30
 fft_size = 2048

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -367,6 +367,8 @@ pub struct App {
     /// Terminal cell pixel dimensions `(width_px, height_px)`.
     /// Queried once at startup; `None` if unavailable (fallback: 8×16).
     pub cell_px: Option<(u16, u16)>,
+    /// OSC 4 / OSC 10 readback for smooth visualizer gradients with indexed or reset colours.
+    pub visualizer_gradient_rgb_cache: Option<crate::ui::terminal_palette::GradientRgbCache>,
     /// Cached cover art: `(cover_art_id, raw_image_bytes)`.
     /// Updated whenever a new track starts with a different cover ID.
     pub art_cache: Option<(String, Vec<u8>)>,
@@ -568,6 +570,7 @@ impl App {
             in_tmux: false,
             tmux_status_offset: 0,
             cell_px: None,
+            visualizer_gradient_rgb_cache: None,
             art_cache: None,
             art_cache_fingerprint: None,
             art_cache_decoded: None,

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -59,6 +59,13 @@ pub async fn run() -> Result<()> {
         app.tmux_status_offset = tmux_status_offset();
     }
 
+    app.visualizer_gradient_rgb_cache =
+        ui::terminal_palette::try_query_visualizer_gradient_cache(
+            &app.theme,
+            &app.config,
+            app.in_tmux,
+        );
+
     // kitty-apc backend: probe before raw mode / alternate screen (see `kitty_art`).
     // `ratatui-image` uses `Picker::from_query_stdio()` after the alternate screen.
     match app.config.album_art_backend {

--- a/ratune/src/ui/mod.rs
+++ b/ratune/src/ui/mod.rs
@@ -13,6 +13,7 @@ pub mod popup;
 pub mod queue;
 pub mod status_bar;
 pub mod tab_bar;
+pub mod terminal_palette;
 pub mod tracks;
 pub mod visualizer;
 

--- a/ratune/src/ui/nowplaying_tab.rs
+++ b/ratune/src/ui/nowplaying_tab.rs
@@ -209,6 +209,7 @@ fn render_visualizer_pane(app: &App, frame: &mut Frame, area: Rect) {
         &app.config.visualizer_color_mode,
         &app.config.visualizer_colors,
         accent,
+        app.visualizer_gradient_rgb_cache.as_ref(),
     );
 }
 

--- a/ratune/src/ui/terminal_palette.rs
+++ b/ratune/src/ui/terminal_palette.rs
@@ -1,0 +1,362 @@
+//! Query the running terminal for palette RGB (OSC 4) and default foreground (OSC 10)
+//! so the spectrum visualizer can interpolate `gradient_theme` / `gradient_height` stops
+//! without guessing indexed colours. When queries fail, the visualizer falls back to
+//! ordered dithering between exact `Color` stops (no fake RGB).
+
+use std::collections::{BTreeSet, HashMap};
+
+use ratatui::style::Color;
+
+use crate::config::Config;
+
+/// RGB values read from the terminal (OSC 4 for indices, OSC 10 for default fg).
+#[derive(Debug, Default, Clone)]
+pub struct GradientRgbCache {
+    pub indexed: HashMap<u8, (u8, u8, u8)>,
+    pub default_fg: Option<(u8, u8, u8)>,
+}
+
+/// Populate a cache when a gradient visualizer mode may use non-`Rgb` [`Color`] values.
+///
+/// On Unix, opens `/dev/tty` and issues OSC sequences (before the alternate screen is fine).
+/// Inside **tmux**, queries are wrapped with `\ePtmux;…\e\\` so they reach the outer terminal;
+/// that requires tmux 3.2+ with `allow-passthrough on` (or `all`) in `~/.tmux.conf`. If the
+/// outer terminal does not answer OSC readback, the visualizer falls back to ordered dithering.
+/// On non-Unix, returns [`None`].
+pub fn try_query_visualizer_gradient_cache(
+    theme: &crate::theme::Theme,
+    config: &Config,
+    in_tmux: bool,
+) -> Option<GradientRgbCache> {
+    #[cfg(not(unix))]
+    {
+        let _ = (theme, config, in_tmux);
+        return None;
+    }
+
+    #[cfg(unix)]
+    {
+        let mode = config.visualizer_color_mode.trim().to_ascii_lowercase();
+        if !mode.starts_with("gradient") {
+            return None;
+        }
+
+        let mut indices: BTreeSet<u8> = BTreeSet::new();
+        let mut need_default_fg = false;
+
+        match mode.as_str() {
+            "gradient_theme" => {
+                collect_color_refs(theme.dimmed, &mut indices, &mut need_default_fg);
+                collect_color_refs(theme.foreground, &mut indices, &mut need_default_fg);
+                collect_color_refs(theme.accent, &mut indices, &mut need_default_fg);
+            }
+            "gradient_height" => {
+                let accent = theme.accent;
+                for s in &config.visualizer_colors {
+                    collect_color_refs(
+                        parse_visualizer_color_token(s, accent),
+                        &mut indices,
+                        &mut need_default_fg,
+                    );
+                }
+            }
+            _ => return None,
+        }
+
+        if indices.is_empty() && !need_default_fg {
+            return None;
+        }
+
+        let mut cache = GradientRgbCache::default();
+        for &i in &indices {
+            if let Some(rgb) = query_osc4_indexed_rgb(i, in_tmux) {
+                cache.indexed.insert(i, rgb);
+            }
+        }
+        if need_default_fg {
+            cache.default_fg = query_osc10_default_fg(in_tmux);
+        }
+        if cache.indexed.is_empty() && cache.default_fg.is_none() {
+            None
+        } else {
+            Some(cache)
+        }
+    }
+}
+
+fn parse_visualizer_color_token(s: &str, accent: Color) -> Color {
+    let s = s.trim();
+    if s.is_empty() || s.eq_ignore_ascii_case("accent") {
+        return accent;
+    }
+    if let Some(hex) = s.strip_prefix('#') {
+        if hex.len() == 6 {
+            if let (Ok(r), Ok(g), Ok(b)) = (
+                u8::from_str_radix(&hex[0..2], 16),
+                u8::from_str_radix(&hex[2..4], 16),
+                u8::from_str_radix(&hex[4..6], 16),
+            ) {
+                return Color::Rgb(r, g, b);
+            }
+        }
+    }
+    if let Ok(idx) = s.parse::<u8>() {
+        return Color::Indexed(idx);
+    }
+    accent
+}
+
+fn collect_color_refs(c: Color, indices: &mut BTreeSet<u8>, need_default_fg: &mut bool) {
+    match c {
+        Color::Indexed(i) => {
+            indices.insert(i);
+        }
+        Color::Reset => *need_default_fg = true,
+        Color::Black => {
+            indices.insert(0);
+        }
+        Color::Red => {
+            indices.insert(1);
+        }
+        Color::Green => {
+            indices.insert(2);
+        }
+        Color::Yellow => {
+            indices.insert(3);
+        }
+        Color::Blue => {
+            indices.insert(4);
+        }
+        Color::Magenta => {
+            indices.insert(5);
+        }
+        Color::Cyan => {
+            indices.insert(6);
+        }
+        Color::Gray => {
+            indices.insert(7);
+        }
+        Color::DarkGray => {
+            indices.insert(8);
+        }
+        Color::LightRed => {
+            indices.insert(9);
+        }
+        Color::LightGreen => {
+            indices.insert(10);
+        }
+        Color::LightYellow => {
+            indices.insert(11);
+        }
+        Color::LightBlue => {
+            indices.insert(12);
+        }
+        Color::LightMagenta => {
+            indices.insert(13);
+        }
+        Color::LightCyan => {
+            indices.insert(14);
+        }
+        Color::White => {
+            indices.insert(15);
+        }
+        Color::Rgb(_, _, _) => {}
+    }
+}
+
+/// Resolve a stop to sRGB for lerping. [`Color::Rgb`] always resolves; indexed / reset / named
+/// resolve only when present in `cache` from a successful terminal query.
+pub fn stop_to_rgb(c: Color, cache: Option<&GradientRgbCache>) -> Option<(u8, u8, u8)> {
+    match c {
+        Color::Rgb(r, g, b) => Some((r, g, b)),
+        Color::Indexed(i) => cache?.indexed.get(&i).copied(),
+        Color::Reset => cache?.default_fg,
+        Color::Black => cache?.indexed.get(&0).copied(),
+        Color::Red => cache?.indexed.get(&1).copied(),
+        Color::Green => cache?.indexed.get(&2).copied(),
+        Color::Yellow => cache?.indexed.get(&3).copied(),
+        Color::Blue => cache?.indexed.get(&4).copied(),
+        Color::Magenta => cache?.indexed.get(&5).copied(),
+        Color::Cyan => cache?.indexed.get(&6).copied(),
+        Color::Gray => cache?.indexed.get(&7).copied(),
+        Color::DarkGray => cache?.indexed.get(&8).copied(),
+        Color::LightRed => cache?.indexed.get(&9).copied(),
+        Color::LightGreen => cache?.indexed.get(&10).copied(),
+        Color::LightYellow => cache?.indexed.get(&11).copied(),
+        Color::LightBlue => cache?.indexed.get(&12).copied(),
+        Color::LightMagenta => cache?.indexed.get(&13).copied(),
+        Color::LightCyan => cache?.indexed.get(&14).copied(),
+        Color::White => cache?.indexed.get(&15).copied(),
+    }
+}
+
+// ── OSC query (Unix) ──────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+/// Wrap a full escape sequence for tmux DCS passthrough (same doubling rules as `kitty_art::apc`).
+fn tmux_passthrough_wrap(inner: &str) -> String {
+    let mut doubled = String::with_capacity(inner.len() + 8);
+    for ch in inner.chars() {
+        if ch == '\x1b' {
+            doubled.push('\x1b');
+            doubled.push('\x1b');
+        } else {
+            doubled.push(ch);
+        }
+    }
+    format!("\x1bPtmux;\x1b{doubled}\x1b\x1b\\\x1b\\")
+}
+
+#[cfg(unix)]
+fn query_osc4_indexed_rgb(index: u8, in_tmux: bool) -> Option<(u8, u8, u8)> {
+    // ESC ] 4 ; Ps ; ? BEL — xterm / many VTEs reply with OSC 4 ; Ps ; spec ST|BEL
+    let inner = format!("\x1b]4;{};?\x07", index);
+    let q = if in_tmux {
+        tmux_passthrough_wrap(&inner)
+    } else {
+        inner
+    };
+    let reply = query_tty_raw(&q)?;
+    parse_osc4_reply_rgb(&reply, index)
+}
+
+#[cfg(unix)]
+fn query_osc10_default_fg(in_tmux: bool) -> Option<(u8, u8, u8)> {
+    let inner = "\x1b]10;?\x07";
+    let q = if in_tmux {
+        tmux_passthrough_wrap(inner)
+    } else {
+        inner.to_string()
+    };
+    let reply = query_tty_raw(&q)?;
+    parse_osc10_reply_rgb(&reply)
+}
+
+#[cfg(unix)]
+fn query_tty_raw(query: &str) -> Option<String> {
+    use std::fs::OpenOptions;
+    use std::io::{Read, Write};
+    use std::time::{Duration, Instant};
+
+    let mut tty = OpenOptions::new().read(true).write(true).open("/dev/tty").ok()?;
+    if crossterm::terminal::enable_raw_mode().is_err() {
+        return None;
+    }
+    let write_ok = tty.write_all(query.as_bytes()).is_ok() && tty.flush().is_ok();
+    if !write_ok {
+        let _ = crossterm::terminal::disable_raw_mode();
+        return None;
+    }
+
+    let mut buf = Vec::with_capacity(128);
+    let mut byte = [0u8; 1];
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_millis(60) {
+        if tty.read(&mut byte).ok()? != 1 {
+            continue;
+        }
+        buf.push(byte[0]);
+        if buf.ends_with(&[0x07]) {
+            break;
+        }
+        if buf.len() >= 2 && buf[buf.len() - 2] == 0x1b && buf[buf.len() - 1] == b'\\' {
+            break;
+        }
+        if buf.len() >= 512 {
+            break;
+        }
+    }
+    let _ = crossterm::terminal::disable_raw_mode();
+    String::from_utf8(buf).ok()
+}
+
+fn parse_rgb_triplet_after_label(s: &str) -> Option<(u8, u8, u8)> {
+    let lower = s.to_ascii_lowercase();
+    let rest = if let Some(i) = lower.find("rgb:") {
+        &s[i + 4..]
+    } else if let Some(i) = lower.find('#') {
+        &s[i + 1..]
+    } else {
+        return None;
+    };
+    let end = rest
+        .find('\x07')
+        .or_else(|| rest.find('\x1b'))
+        .unwrap_or(rest.len());
+    let body = rest[..end].trim_end_matches('\\').trim();
+    if body.starts_with('#') {
+        let h = body.trim_start_matches('#');
+        if h.len() == 6 {
+            let r = u8::from_str_radix(&h[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&h[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&h[4..6], 16).ok()?;
+            return Some((r, g, b));
+        }
+        return None;
+    }
+    let parts: Vec<&str> = body.split('/').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let comp = |p: &str| -> Option<u8> {
+        let p = p.trim();
+        if p.is_empty() {
+            return None;
+        }
+        let v = u32::from_str_radix(p, 16).ok()?;
+        Some(if p.len() <= 2 {
+            v as u8
+        } else {
+            // 4-digit xterm components are 0..65535
+            ((v * 255 + 32_767) / 65_535).min(255) as u8
+        })
+    };
+    Some((comp(parts[0])?, comp(parts[1])?, comp(parts[2])?))
+}
+
+fn parse_osc4_reply_rgb(reply: &str, index: u8) -> Option<(u8, u8, u8)> {
+    // Expect "...4;<idx>;rgb:rrrr/gggg/bbbb..." or "#rrggbb"
+    let needle = format!("4;{};", index);
+    if let Some(pos) = reply.find(&needle) {
+        if let Some(rgb) = parse_rgb_triplet_after_label(&reply[pos..]) {
+            return Some(rgb);
+        }
+    }
+    parse_rgb_triplet_after_label(reply)
+}
+
+fn parse_osc10_reply_rgb(reply: &str) -> Option<(u8, u8, u8)> {
+    if let Some(pos) = reply.find("10;") {
+        if let Some(rgb) = parse_rgb_triplet_after_label(&reply[pos..]) {
+            return Some(rgb);
+        }
+    }
+    parse_rgb_triplet_after_label(reply)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn tmux_wrap_doubles_esc_and_closes_dcs() {
+        let w = tmux_passthrough_wrap("\x1b]4;8;?\x07");
+        assert!(w.starts_with("\x1bPtmux;\x1b\x1b\x1b]4;8;?\x07"));
+        assert!(w.ends_with("\x1b\x1b\\\x1b\\"));
+    }
+
+    #[test]
+    fn parse_osc4_rgb_slash_form() {
+        let s = "\x1b]4;8;rgb:e5e5/e5e5/e5e5\x1b\\";
+        let rgb = parse_osc4_reply_rgb(s, 8).expect("rgb");
+        assert_eq!(rgb, (229, 229, 229));
+    }
+
+    #[test]
+    fn parse_osc10_rgb() {
+        let s = "\x1b]10;rgb:aaaa/bbbb/cccc\x07";
+        let rgb = parse_osc10_reply_rgb(s).expect("rgb");
+        assert_eq!(rgb, (170, 187, 204));
+    }
+}

--- a/ratune/src/ui/visualizer.rs
+++ b/ratune/src/ui/visualizer.rs
@@ -25,6 +25,8 @@ use ratatui::Frame;
 
 use crate::theme::Theme;
 
+use super::terminal_palette::{stop_to_rgb, GradientRgbCache};
+
 /// Braille codepoints for 0-4 left-column dots filled from the bottom.
 /// Index = number of filled dots.
 const LEFT_COL: [u32; 5] = [
@@ -54,13 +56,23 @@ pub fn render_visualizer_ex(
     color_mode: &str,
     colors: &[String],
     accent: Color,
+    gradient_rgb_cache: Option<&GradientRgbCache>,
 ) {
     if area.width == 0 || area.height == 0 || bands.is_empty() {
         // For waveform, bands may be empty; handle below.
     }
     let vtype = visualizer_type.trim().to_lowercase();
     if vtype.as_str() == "wave" {
-        render_wave(f, area, theme, waveform, color_mode, colors, accent);
+        render_wave(
+            f,
+            area,
+            theme,
+            waveform,
+            color_mode,
+            colors,
+            accent,
+            gradient_rgb_cache,
+        );
         return;
     }
 
@@ -118,6 +130,8 @@ pub fn render_visualizer_ex(
                     color_mode,
                     colors,
                     accent,
+                    gradient_rgb_cache,
+                    i,
                 )),
             )));
         }
@@ -132,6 +146,8 @@ pub fn render_visualizer_ex(
                     color_mode,
                     colors,
                     accent,
+                    gradient_rgb_cache,
+                    i,
                 )),
             )));
         }
@@ -143,6 +159,7 @@ pub fn render_visualizer_ex(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_wave(
     f: &mut Frame,
     area: Rect,
@@ -151,6 +168,7 @@ fn render_wave(
     color_mode: &str,
     colors: &[String],
     accent: Color,
+    gradient_rgb_cache: Option<&GradientRgbCache>,
 ) {
     if area.width == 0 || area.height == 0 || waveform.is_empty() {
         return;
@@ -186,7 +204,16 @@ fn render_wave(
         let y1 = y_min.max(y_max).clamp(0, (h as i32).saturating_sub(1));
 
         for yy in y0..=y1 {
-            let color = color_for_row(yy as usize, h, theme, color_mode, colors, accent);
+            let color = color_for_row(
+                yy as usize,
+                h,
+                theme,
+                color_mode,
+                colors,
+                accent,
+                gradient_rgb_cache,
+                x,
+            );
             // Keep the waveform readable (min/max envelope) but render with simple,
             // widely-supported glyphs.
             let ch = "•";
@@ -198,6 +225,7 @@ fn render_wave(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn color_for_row(
     row: usize,
     height: usize,
@@ -205,6 +233,8 @@ fn color_for_row(
     color_mode: &str,
     colors: &[String],
     accent: Color,
+    gradient_rgb_cache: Option<&GradientRgbCache>,
+    dither_col: usize,
 ) -> Color {
     let mode = color_mode.trim().to_lowercase();
     match mode.as_str() {
@@ -216,7 +246,13 @@ fn color_for_row(
             // Theme palette gradient: dimmed → foreground → accent (top).
             // This stays "in theme" and works well with dynamic accent mode.
             let stops = [theme.dimmed, theme.foreground, accent];
-            gradient_color(stops.as_slice(), row, height)
+            gradient_color(
+                stops.as_slice(),
+                row,
+                height,
+                gradient_rgb_cache,
+                dither_col,
+            )
         }
         "gradient_height" => {
             if colors.is_empty() {
@@ -226,13 +262,25 @@ fn color_for_row(
                 return parse_color_spec(&colors[0], accent);
             }
             let parsed: Vec<Color> = colors.iter().map(|c| parse_color_spec(c, accent)).collect();
-            gradient_color(&parsed, row, height)
+            gradient_color(
+                &parsed,
+                row,
+                height,
+                gradient_rgb_cache,
+                dither_col,
+            )
         }
         _ => accent, // "accent"
     }
 }
 
-fn gradient_color(stops: &[Color], row: usize, height: usize) -> Color {
+fn gradient_color(
+    stops: &[Color],
+    row: usize,
+    height: usize,
+    cache: Option<&GradientRgbCache>,
+    dither_col: usize,
+) -> Color {
     if stops.is_empty() {
         return Color::Reset;
     }
@@ -247,27 +295,41 @@ fn gradient_color(stops: &[Color], row: usize, height: usize) -> Color {
     let frac = pos - (i as f32);
     let a = stops[i];
     let b = stops[(i + 1).min(stops.len() - 1)];
-    lerp_color(a, b, frac)
+    lerp_color(a, b, frac, cache, row, dither_col)
 }
 
-fn lerp_color(a: Color, b: Color, t: f32) -> Color {
-    match (a, b) {
-        (Color::Rgb(ar, ag, ab), Color::Rgb(br, bg, bb)) => {
-            let lerp = |x: u8, y: u8| -> u8 {
+/// Bayer 4×4 for ordered dither when OSC readback is missing or incomplete.
+const BAYER4: [[u8; 4]; 4] = [
+    [0, 8, 2, 10],
+    [12, 4, 14, 6],
+    [3, 11, 1, 9],
+    [15, 7, 13, 5],
+];
+
+#[inline]
+fn dither_two_colors(a: Color, b: Color, frac: f32, row: usize, col: usize) -> Color {
+    let m = BAYER4[row % 4][col % 4] as f32;
+    if frac * 16.0 > m { b } else { a }
+}
+
+fn lerp_color(
+    a: Color,
+    b: Color,
+    t: f32,
+    cache: Option<&GradientRgbCache>,
+    row: usize,
+    col: usize,
+) -> Color {
+    match (stop_to_rgb(a, cache), stop_to_rgb(b, cache)) {
+        (Some((ar, ag, ab)), Some((br, bg, bb))) => {
+            let lerp_u8 = |x: u8, y: u8| -> u8 {
                 (x as f32 + (y as f32 - x as f32) * t)
                     .round()
                     .clamp(0.0, 255.0) as u8
             };
-            Color::Rgb(lerp(ar, br), lerp(ag, bg), lerp(ab, bb))
+            Color::Rgb(lerp_u8(ar, br), lerp_u8(ag, bg), lerp_u8(ab, bb))
         }
-        // For indexed/other color types, fall back to nearest stop (discrete gradient).
-        _ => {
-            if t < 0.5 {
-                a
-            } else {
-                b
-            }
-        }
+        _ => dither_two_colors(a, b, t, row, col),
     }
 }
 


### PR DESCRIPTION
Visualizer gradient didn't look right on terminal theme. Colors snapped into defined theme amounts due to not being rgb.