### PR TITLE
Feat/folder navigation

### DIFF
--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -124,6 +124,7 @@ mpris = true
 # home_section_next   = "Shift+j"   # home: focus next panel block
 # home_section_prev   = "Shift+k"
 # home_refresh        = "r"          # home: refresh / re-roll where applicable
+# toggle_folder_browse = "Ctrl+b"   # browse: toggle folder view (needs [ui.browsetab] folder_navigation); "" disables
 
 # -----------------------------------------------------------------------------
 # [theme]
@@ -245,9 +246,15 @@ panels = ["recent_albums", "recent_tracks", "rediscover"]
 # [ui.browsetab]
 # -----------------------------------------------------------------------------
 #
-# mode — "artists" (implemented), "genre" / "files" (placeholders: use artists).
+# folder_navigation — When true, Ctrl+b toggles the Browse tab between the
+#   normal artist/album/track columns and folder view (getMusicFolders for
+#   libraries, getIndexes + getMusicDirectory under the hood). Default: false.
+# mode — Default layout on startup when folder_navigation is true: "artists" or
+#   "files". When folder_navigation is false, the Browse tab always starts as
+#   artists. "genre" is still a stub.
 
 [ui.browsetab]
+folder_navigation = false
 mode = "artists"
 
 # -----------------------------------------------------------------------------
@@ -318,8 +325,6 @@ location = "right"
 #   - "gradient_theme" ignores this list and uses theme dimmed→foreground→accent.
 #   - "#RRGGBB" uses truecolor.
 #   - "0".."255" uses 256-color indices.
-# tmux + gradient_theme / gradient_height with indexed or reset colours: enable palette readback
-#   on the outer terminal by adding to ~/.tmux.conf:  set -g allow-passthrough on
 #   (tmux 3.2+). Ratune wraps OSC queries in DCS passthrough when $TMUX is set.
 type = "spectrum"
 fps = 30

--- a/ratune-subsonic/src/client.rs
+++ b/ratune-subsonic/src/client.rs
@@ -25,9 +25,11 @@ use tokio::task::JoinSet;
 
 use crate::error::check_status;
 use crate::models::{
-    Album, AlbumEnvelope, Artist, ArtistEnvelope, Artists, ArtistsEnvelope, PingEnvelope, Playlist,
-    PlaylistDetail, PlaylistEnvelope, PlaylistsEnvelope, ScanStatus, ScanStatusEnvelope,
-    SearchEnvelope, SearchResult3, Song, SongEnvelope, SubsonicLibrary,
+    parse_music_library_root_folder_id, Album, AlbumEnvelope, Artist, ArtistEnvelope, Artists,
+    ArtistsEnvelope, DirectoryChild, IndexesEnvelope, MusicDirectory, MusicDirectoryEnvelope,
+    MusicFolder, MusicFoldersEnvelope, PingEnvelope, Playlist, PlaylistDetail, PlaylistEnvelope,
+    PlaylistsEnvelope, ScanStatus, ScanStatusEnvelope, SearchEnvelope, SearchResult3, Song,
+    SongEnvelope, SubsonicLibrary,
 };
 
 // ── Constants ──────────────────────────────────────────────────────────────────
@@ -89,6 +91,38 @@ pub struct SubsonicClient {
     username: String,
     password: String,
     http: Client,
+}
+
+fn music_directory_from_library_indexes(music_folder_id: &str, data: &Artists) -> MusicDirectory {
+    let mut directories: Vec<DirectoryChild> = data
+        .index
+        .iter()
+        .flat_map(|bucket| bucket.artist.iter())
+        .map(|a| DirectoryChild {
+            id: a.id.clone(),
+            parent: None,
+            is_dir: true,
+            title: a.name.clone(),
+            artist: Some(a.name.clone()),
+            album: None,
+            album_id: None,
+            artist_id: None,
+            track: None,
+            disc_number: None,
+            duration: None,
+            cover_art: None,
+            path: None,
+            suffix: None,
+            content_type: None,
+        })
+        .collect();
+    directories.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+    MusicDirectory {
+        id: music_folder_id.to_string(),
+        name: String::new(),
+        directories,
+        songs: vec![],
+    }
 }
 
 impl SubsonicClient {
@@ -162,6 +196,104 @@ impl SubsonicClient {
             .json()
             .await?;
         check_status(&env.response.status, env.response.error.as_ref())
+    }
+
+    /// Top-level music folders (`getMusicFolders`).
+    pub async fn get_music_folders(&self) -> Result<Vec<MusicFolder>> {
+        let env: MusicFoldersEnvelope = self
+            .http
+            .get(self.endpoint_url("getMusicFolders"))
+            .query(&self.auth_params())
+            .send()
+            .await?
+            .json()
+            .await?;
+        let r = &env.response;
+        check_status(&r.status, r.error.as_ref())?;
+        let folders = r
+            .music_folders
+            .as_ref()
+            .map(|c| {
+                c.music_folder
+                    .iter()
+                    .map(|f| MusicFolder {
+                        id: f.id.clone(),
+                        name: f.name.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(folders)
+    }
+
+    /// Letter-bucket index for folder browsing (`getIndexes`).
+    ///
+    /// Pass `music_folder_id` as the **`id` from [`get_music_folders`](Self::get_music_folders)**.
+    pub async fn get_indexes(&self, music_folder_id: Option<&str>) -> Result<Artists> {
+        let mut params = self.auth_params();
+        if let Some(m) = music_folder_id {
+            params.push(("musicFolderId", m.to_string()));
+        }
+        let env: IndexesEnvelope = self
+            .http
+            .get(self.endpoint_url("getIndexes"))
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        let r = &env.response;
+        check_status(&r.status, r.error.as_ref())?;
+        r.indexes
+            .clone()
+            .ok_or_else(|| anyhow!("missing 'indexes' field in getIndexes response"))
+    }
+
+    /// One Browse-tab folder pane: synthetic [`crate::models::music_library_root_cache_key`] ids
+    /// call `getIndexes?musicFolderId=<id>`; anything else goes to [`get_music_directory`](Self::get_music_directory).
+    pub async fn browse_folder_listing(&self, cache_directory_id: &str) -> Result<MusicDirectory> {
+        if let Some(folder_id) = parse_music_library_root_folder_id(cache_directory_id) {
+            let ix = self.get_indexes(Some(folder_id)).await?;
+            return Ok(music_directory_from_library_indexes(folder_id, &ix));
+        }
+        self.get_music_directory(cache_directory_id).await
+    }
+
+    /// Directory listing for folder navigation (`getMusicDirectory`).
+    pub async fn get_music_directory(&self, id: &str) -> Result<MusicDirectory> {
+        let mut params = self.auth_params();
+        params.push(("id", id.to_string()));
+        let env: MusicDirectoryEnvelope = self
+            .http
+            .get(self.endpoint_url("getMusicDirectory"))
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        let r = &env.response;
+        check_status(&r.status, r.error.as_ref())?;
+        let dir = r
+            .directory
+            .clone()
+            .ok_or_else(|| anyhow!("missing 'directory' in getMusicDirectory response"))?;
+        let mut directories = Vec::new();
+        let mut songs = Vec::new();
+        for child in dir.child {
+            if child.is_dir {
+                directories.push(child);
+            } else {
+                songs.push(child.to_song());
+            }
+        }
+        directories.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+        songs.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+        Ok(MusicDirectory {
+            id: dir.id,
+            name: dir.name.unwrap_or_else(|| id.to_string()),
+            directories,
+            songs,
+        })
     }
 
     /// Fetch all artists, grouped by index letter (`getArtists`).

--- a/ratune-subsonic/src/lib.rs
+++ b/ratune-subsonic/src/lib.rs
@@ -8,6 +8,7 @@ pub use client::{
 };
 pub use error::SubsonicError;
 pub use models::{
-    Album, Artist, ArtistIndex, Artists, LyricLine, Playlist, PlaylistDetail, ScanStatus,
-    SearchResult3, Song, SubsonicLibrary,
+    music_library_root_cache_key, parse_music_library_root_folder_id, Album, Artist, ArtistIndex,
+    Artists, DirectoryChild, Indexes, LyricLine, MusicDirectory, MusicFolder, Playlist,
+    PlaylistDetail, ScanStatus, SearchResult3, Song, SubsonicLibrary, MUSIC_FOLDER_ROOT_ID_PREFIX,
 };

--- a/ratune-subsonic/src/models.rs
+++ b/ratune-subsonic/src/models.rs
@@ -3,6 +3,38 @@ use std::time::Duration;
 use crate::error::SubsonicError;
 use serde::{Deserialize, Serialize};
 
+fn deserialize_artists_bucket<'de, D>(deserializer: D) -> Result<Vec<Artist>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Bucket {
+        Single(Artist),
+        Many(Vec<Artist>),
+    }
+    Bucket::deserialize(deserializer).map(|b| match b {
+        Bucket::Single(a) => vec![a],
+        Bucket::Many(v) => v,
+    })
+}
+
+fn deserialize_indexes_bucket<'de, D>(deserializer: D) -> Result<Vec<ArtistIndex>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Bucket {
+        Single(ArtistIndex),
+        Many(Vec<ArtistIndex>),
+    }
+    Bucket::deserialize(deserializer).map(|b| match b {
+        Bucket::Single(x) => vec![x],
+        Bucket::Many(v) => v,
+    })
+}
+
 // ── Public domain types ───────────────────────────────────────────────────────
 
 /// A single artist entry as returned by `getArtists`, `getArtist`, or `search3`.
@@ -22,28 +54,52 @@ pub struct Artist {
     pub album: Vec<Album>,
 }
 
-/// One letter-bucket from a `getArtists` index response.
+/// One letter-bucket from a `getArtists` / `getIndexes` index response.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ArtistIndex {
     /// The index letter or prefix (e.g. `"A"`, `"#"`).
     pub name: String,
-    #[serde(default)]
+    /// Some APIs return one `artist` object instead of an array.
+    #[serde(default, deserialize_with = "deserialize_artists_bucket")]
     pub artist: Vec<Artist>,
 }
 
-/// Top-level `artists` object from a `getArtists` response.
+/// Top-level `artists` / `indexes` object from `getArtists` / `getIndexes`.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Artists {
     /// Space-separated articles the server strips when alphabetising names.
     #[serde(default)]
     pub ignored_articles: String,
-    /// Alphabetical buckets, each containing one or more artists.
-    #[serde(default)]
+    /// Alphabetical buckets; some payloads use a single `index` object instead of an array.
+    #[serde(default, deserialize_with = "deserialize_indexes_bucket")]
     pub index: Vec<ArtistIndex>,
 }
 
-/// A single track (song) as returned by `getSong`, `getAlbum`, or `search3`.
+/// Same JSON shape as [`Artists`], nested under `indexes` (`getIndexes`) instead of `artists`.
+pub type Indexes = Artists;
+
+/// Cache key prefix for the first Browse level under a **`getMusicFolders` entry**.
+///
+/// The segment after this prefix must be exactly that entry's **`id` attribute**, which is passed
+/// as **`musicFolderId`** to `getIndexes` (matches Subsonic/OpenSubsonic; avoids assuming array indices).
+pub const MUSIC_FOLDER_ROOT_ID_PREFIX: &str = "__mf_root_";
+
+#[inline]
+#[must_use]
+pub fn music_library_root_cache_key(music_folder_id: impl AsRef<str>) -> String {
+    format!(
+        "{}{}",
+        MUSIC_FOLDER_ROOT_ID_PREFIX,
+        music_folder_id.as_ref()
+    )
+}
+
+/// Returns the **`musicFolder` id substring** encoded in `cache_id` (see [`music_library_root_cache_key`]).
+#[inline]
+pub fn parse_music_library_root_folder_id(cache_id: &str) -> Option<&str> {
+    cache_id.strip_prefix(MUSIC_FOLDER_ROOT_ID_PREFIX)
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Song {
@@ -139,6 +195,72 @@ pub struct SubsonicLibrary {
     pub artists: Vec<Artist>,
 }
 
+/// Top-level music library folder from `getMusicFolders`.
+#[derive(Debug, Clone)]
+pub struct MusicFolder {
+    pub id: String,
+    pub name: String,
+}
+
+/// One row from `getMusicDirectory` (`child` in the API).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DirectoryChild {
+    #[serde(deserialize_with = "deserialize_flexible_id")]
+    pub id: String,
+    #[serde(default, deserialize_with = "deserialize_optional_flexible_id")]
+    pub parent: Option<String>,
+    #[serde(rename = "isDir", default)]
+    pub is_dir: bool,
+    pub title: String,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub album_id: Option<String>,
+    pub artist_id: Option<String>,
+    pub track: Option<u32>,
+    pub disc_number: Option<u32>,
+    pub duration: Option<u32>,
+    pub cover_art: Option<String>,
+    pub path: Option<String>,
+    pub suffix: Option<String>,
+    pub content_type: Option<String>,
+}
+
+impl DirectoryChild {
+    /// Convert a file entry into a [`Song`] for queue/playback.
+    pub fn to_song(&self) -> Song {
+        Song {
+            id: self.id.clone(),
+            title: self.title.clone(),
+            album: self.album.clone(),
+            artist: self.artist.clone(),
+            album_id: self.album_id.clone(),
+            artist_id: self.artist_id.clone(),
+            track: self.track,
+            disc_number: self.disc_number,
+            year: None,
+            genre: None,
+            cover_art: self.cover_art.clone(),
+            duration: self.duration,
+            bit_rate: None,
+            content_type: self.content_type.clone(),
+            suffix: self.suffix.clone(),
+            size: None,
+            path: self.path.clone(),
+            starred: None,
+        }
+    }
+}
+
+/// Parsed listing for one directory (`getMusicDirectory`).
+#[derive(Debug, Clone)]
+pub struct MusicDirectory {
+    pub id: String,
+    pub name: String,
+    pub directories: Vec<DirectoryChild>,
+    pub songs: Vec<Song>,
+}
+
 /// Library scan state from `getScanStatus` (Subsonic 1.15+). Navidrome includes
 /// `last_scan` as an RFC3339 timestamp after a completed scan.
 #[derive(Debug, Clone, Deserialize)]
@@ -169,6 +291,19 @@ pub struct LyricLine {
 }
 
 // ── Private serde envelope types ──────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub(crate) struct IndexesEnvelope {
+    #[serde(rename = "subsonic-response")]
+    pub response: IndexesBody,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct IndexesBody {
+    pub status: String,
+    pub error: Option<SubsonicError>,
+    pub indexes: Option<Indexes>,
+}
 
 #[derive(Deserialize)]
 pub(crate) struct PingEnvelope {
@@ -280,6 +415,130 @@ pub(crate) struct PlaylistBody {
     pub playlist: Option<PlaylistDetail>,
 }
 
+fn deserialize_music_folder_list<'de, D>(deserializer: D) -> Result<Vec<MusicFolderRaw>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        Single(MusicFolderRaw),
+        List(Vec<MusicFolderRaw>),
+    }
+    match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::Single(o) => Ok(vec![o]),
+        OneOrMany::List(v) => Ok(v),
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MusicFolderRaw {
+    #[serde(deserialize_with = "deserialize_flexible_id")]
+    pub(crate) id: String,
+    pub(crate) name: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MusicFoldersContainer {
+    #[serde(
+        default,
+        rename = "musicFolder",
+        deserialize_with = "deserialize_music_folder_list"
+    )]
+    pub(crate) music_folder: Vec<MusicFolderRaw>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MusicFoldersEnvelope {
+    #[serde(rename = "subsonic-response")]
+    pub response: MusicFoldersBody,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MusicFoldersBody {
+    pub status: String,
+    pub error: Option<SubsonicError>,
+    #[serde(rename = "musicFolders")]
+    pub music_folders: Option<MusicFoldersContainer>,
+}
+
+#[derive(Clone, Deserialize)]
+pub(crate) struct DirectoryRaw {
+    #[serde(deserialize_with = "deserialize_flexible_id")]
+    pub(crate) id: String,
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+    #[serde(default)]
+    pub(crate) child: Vec<DirectoryChild>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MusicDirectoryEnvelope {
+    #[serde(rename = "subsonic-response")]
+    pub response: MusicDirectoryBody,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MusicDirectoryBody {
+    pub status: String,
+    pub error: Option<SubsonicError>,
+    pub directory: Option<DirectoryRaw>,
+}
+
+fn deserialize_flexible_id<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+    struct IdVisitor;
+    impl Visitor<'_> for IdVisitor {
+        type Value = String;
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a string or integer id")
+        }
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<String, E> {
+            Ok(v.to_string())
+        }
+        fn visit_string<E: de::Error>(self, v: String) -> Result<String, E> {
+            Ok(v)
+        }
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<String, E> {
+            Ok(v.to_string())
+        }
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<String, E> {
+            Ok(v.to_string())
+        }
+    }
+    deserializer.deserialize_any(IdVisitor)
+}
+
+fn deserialize_optional_flexible_id<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+    struct OptIdVisitor;
+    impl<'de> Visitor<'de> for OptIdVisitor {
+        type Value = Option<String>;
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("an optional string or integer id")
+        }
+        fn visit_none<E: de::Error>(self) -> Result<Option<String>, E> {
+            Ok(None)
+        }
+        fn visit_unit<E: de::Error>(self) -> Result<Option<String>, E> {
+            Ok(None)
+        }
+        fn visit_some<D2>(self, deserializer: D2) -> Result<Option<String>, D2::Error>
+        where
+            D2: serde::Deserializer<'de>,
+        {
+            deserialize_flexible_id(deserializer).map(Some)
+        }
+    }
+    deserializer.deserialize_option(OptIdVisitor)
+}
+
 #[derive(Deserialize)]
 pub(crate) struct ScanStatusEnvelope {
     #[serde(rename = "subsonic-response")]
@@ -323,6 +582,56 @@ mod tests {
         let d: PlaylistDetail = serde_json::from_str(j).unwrap();
         assert_eq!(d.songs.len(), 1);
         assert_eq!(d.songs[0].title, "A");
+    }
+
+    #[test]
+    fn deserialize_music_directory_splits_dirs_and_songs() {
+        let j = r#"{
+            "id": "1",
+            "name": "music",
+            "child": [
+                {"id": "2", "parent": "1", "isDir": true, "title": "VA"},
+                {"id": "9", "parent": "1", "isDir": false, "title": "Track One", "duration": 200}
+            ]
+        }"#;
+        let d: DirectoryRaw = serde_json::from_str(j).unwrap();
+        assert_eq!(d.child.len(), 2);
+        assert!(d.child[0].is_dir);
+        assert!(!d.child[1].is_dir);
+    }
+
+    #[test]
+    fn deserialize_music_folders_single_object() {
+        let j = r#"{"musicFolder":{"id":0,"name":"music"}}"#;
+        let c: MusicFoldersContainer = serde_json::from_str(j).unwrap();
+        assert_eq!(c.music_folder.len(), 1);
+        assert_eq!(c.music_folder[0].id.as_str(), "0");
+        assert_eq!(c.music_folder[0].name, "music");
+    }
+
+    #[test]
+    fn deserialize_indexes_single_bucket_and_single_artist() {
+        let j = r#"{"ignoredArticles":"","index":{"name":"A","artist":{"id":"1","name":"Solo"}}}"#;
+        let a: Artists = serde_json::from_str(j).unwrap();
+        assert_eq!(a.index.len(), 1);
+        assert_eq!(a.index[0].artist.len(), 1);
+        assert_eq!(a.index[0].artist[0].id, "1");
+    }
+
+    #[test]
+    fn music_library_root_cache_key_roundtrip() {
+        let k = music_library_root_cache_key("4");
+        assert_eq!(parse_music_library_root_folder_id(&k), Some("4"));
+    }
+
+    #[test]
+    fn deserialize_indexes_envelope() {
+        let j = r#"{"subsonic-response":{"status":"ok","indexes":{"ignoredArticles":"","index":[{"name":"V","artist":[{"id":"abc","name":"VA"}]}]}}}"#;
+        let env: IndexesEnvelope = serde_json::from_str(j).unwrap();
+        let ix = env.response.indexes.expect("indexes");
+        assert_eq!(ix.index.len(), 1);
+        assert_eq!(ix.index[0].artist[0].id, "abc");
+        assert_eq!(ix.index[0].artist[0].name, "VA");
     }
 
     #[test]

--- a/ratune/src/action.rs
+++ b/ratune/src/action.rs
@@ -23,6 +23,8 @@ pub enum Action {
     GoToHome,
     /// Jump directly to Browser tab (key '2')
     GoToBrowser,
+    /// Toggle Browse tab between artist columns and folder layout (requires config).
+    ToggleBrowserFolder,
     /// Jump directly to NowPlaying tab (key '3')
     GoToNowPlaying,
     FocusLeft,

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -17,12 +17,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::action::{Action, Direction};
 use crate::color::{extract_accent, lerp_color};
-use crate::config::{AlbumArtBackend, Config};
+use crate::config::{AlbumArtBackend, BrowseMode, Config};
 use crate::history::PlayRecord;
 use crate::keybinds::Keybinds;
 use crate::state::{
-    ConfirmAction, GlobalConfirm, LibraryState, LoadingState, PlaybackState, PlaylistFocus,
-    PlaylistInputMode, PlaylistOverlay, QueueState,
+    folder_left_default_row, folder_preview_rows, ConfirmAction, DirectoryListing,
+    FolderBrowseState, FolderPreviewRow, GlobalConfirm, LibraryState, LoadingState, PlaybackState,
+    PlaylistFocus, PlaylistInputMode, PlaylistOverlay, QueueState,
 };
 use crate::theme::Theme;
 use image::{imageops::FilterType, DynamicImage};
@@ -307,6 +308,13 @@ pub enum LibraryUpdate {
     LibraryServerAppendQueueComplete {
         result: Result<Vec<ratune_subsonic::Song>, String>,
     },
+    /// Top-level folders from `getMusicFolders` (file browse mode).
+    MusicFolders(Result<Vec<ratune_subsonic::MusicFolder>, String>),
+    /// One directory listing from `getMusicDirectory`.
+    MusicDirectory {
+        id: String,
+        result: Result<DirectoryListing, String>,
+    },
 }
 
 #[derive(Clone, Copy)]
@@ -337,9 +345,12 @@ pub struct App {
     pub active_tab: Tab,
     pub browser_focus: BrowserColumn,
     pub library: LibraryState,
+    pub folders: FolderBrowseState,
     pub queue: QueueState,
     pub playback: PlaybackState,
     pub config: Config,
+    /// Effective Browse tab layout: toggled at runtime when folder navigation is enabled.
+    pub browser_browse_mode: BrowseMode,
     pub subsonic: Arc<SubsonicClient>,
     /// Receives library data from background tokio tasks.
     pub library_rx: mpsc::Receiver<LibraryUpdate>,
@@ -550,10 +561,17 @@ impl App {
                 None => (Vec::new(), None),
             };
         let library_index_by_id = crate::library_index::index_by_id(&library_index_tracks);
+        let browser_browse_mode = match config.browse_mode {
+            BrowseMode::Genre => BrowseMode::Genre,
+            _ if !config.browse_folder_navigation => BrowseMode::Artists,
+            BrowseMode::Files => BrowseMode::Files,
+            BrowseMode::Artists => BrowseMode::Artists,
+        };
         Ok(Self {
             active_tab: Tab::Home,
             browser_focus: BrowserColumn::Artists,
             library: LibraryState::default(),
+            folders: FolderBrowseState::default(),
             queue: QueueState::default(),
             playback: PlaybackState::default(),
             subsonic: Arc::new(subsonic),
@@ -563,6 +581,7 @@ impl App {
             player_rx,
             player_join: Some(player_join),
             config,
+            browser_browse_mode,
             should_quit: false,
             search_mode: SearchMode::default(),
             search_filter: None,
@@ -1030,6 +1049,404 @@ impl App {
     }
 
     // ── Background fetch helpers ──────────────────────────────────────────────
+
+    fn browse_files(&self) -> bool {
+        self.browser_browse_mode == BrowseMode::Files
+    }
+
+    /// Spawn a task to fetch top-level music folders (file browse mode).
+    pub fn fetch_music_folders(&self) {
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        tokio::spawn(async move {
+            let result = client.get_music_folders().await.map_err(|e| e.to_string());
+            let _ = tx.send(LibraryUpdate::MusicFolders(result)).await;
+        });
+    }
+
+    /// Spawn [`SubsonicClient::browse_folder_listing`] (indexes for library roots, directory API below).
+    pub fn fetch_music_directory(&self, id: String) {
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        tokio::spawn(async move {
+            let result = client
+                .browse_folder_listing(&id)
+                .await
+                .map(|dir| DirectoryListing {
+                    name: dir.name,
+                    directories: dir
+                        .directories
+                        .into_iter()
+                        .map(|c| (c.id, c.title))
+                        .collect(),
+                    tracks: dir.songs,
+                })
+                .map_err(|e| e.to_string());
+            let _ = tx.send(LibraryUpdate::MusicDirectory { id, result }).await;
+        });
+    }
+
+    /// Subsonic cache id for the folder shown in the preview pane from the current left-column selection.
+    pub fn folder_preview_source_id(&self) -> Option<String> {
+        if !self.browse_files() {
+            return None;
+        }
+        if self.folders.path.is_empty() {
+            let roots = match &self.folders.roots {
+                LoadingState::Loaded(r) => r,
+                _ => return None,
+            };
+            if roots.is_empty() {
+                return None;
+            }
+            let indices: Vec<usize> = if let Some(q) = &self.search_filter {
+                roots
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, r)| r.name.to_lowercase().contains(q.as_str()))
+                    .map(|(i, _)| i)
+                    .collect()
+            } else {
+                (0..roots.len()).collect()
+            };
+            if indices.is_empty() {
+                return None;
+            }
+            let pos = self
+                .folders
+                .selected_dir
+                .unwrap_or(0)
+                .min(indices.len() - 1);
+            let slot = indices[pos];
+            Some(ratune_subsonic::music_library_root_cache_key(
+                &roots[slot].id,
+            ))
+        } else {
+            let sel = self.folders.selected_dir.unwrap_or(0);
+            if sel == 0 {
+                // `..` is highlighted: preview **this** folder (tracks / dirs here), not the parent.
+                return self.folders.current_dir_id().map(|id| id.to_string());
+            }
+            let listing = match self.folders.current_listing()? {
+                LoadingState::Loaded(l) => l,
+                _ => return None,
+            };
+            let dir_indices: Vec<usize> = if let Some(q) = &self.search_filter {
+                listing
+                    .directories
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, (_, name))| name.to_lowercase().contains(q.as_str()))
+                    .map(|(i, _)| i)
+                    .collect()
+            } else {
+                (0..listing.directories.len()).collect()
+            };
+            let dir_pos = sel.saturating_sub(1);
+            if dir_pos >= dir_indices.len() {
+                return None;
+            }
+            let orig_i = dir_indices[dir_pos];
+            Some(listing.directories[orig_i].0.clone())
+        }
+    }
+
+    pub fn sync_folder_preview_from_left(&mut self) {
+        if !self.browse_files() {
+            return;
+        }
+        let Some(pid) = self.folder_preview_source_id() else {
+            self.folders.preview_dir_id = None;
+            self.folders.preview_selected_row = 0;
+            self.folders.tracks_scroll = 0;
+            return;
+        };
+        if self.folders.preview_dir_id.as_deref() != Some(pid.as_str()) {
+            self.folders.preview_dir_id = Some(pid.clone());
+            self.folders.preview_selected_row = 0;
+            self.folders.tracks_scroll = 0;
+        }
+        if !self.folders.listings.contains_key(&pid) {
+            self.folders
+                .listings
+                .insert(pid.clone(), LoadingState::Loading);
+            self.fetch_music_directory(pid);
+        }
+    }
+
+    fn folder_display_name_for_cache_id(&self, cache_id: &str) -> Option<String> {
+        if let Some(fid) = ratune_subsonic::parse_music_library_root_folder_id(cache_id) {
+            if let LoadingState::Loaded(roots) = &self.folders.roots {
+                if let Some(r) = roots.iter().find(|r| r.id == fid) {
+                    return Some(r.name.clone());
+                }
+            }
+        }
+        if let Some(LoadingState::Loaded(li)) = self.folders.listings.get(cache_id) {
+            let n = li.name.trim();
+            if !n.is_empty() {
+                return Some(n.to_string());
+            }
+        }
+        None
+    }
+
+    fn ensure_left_at_preview_folder(&mut self, preview_key: &str) {
+        let max_ops = self.folders.path.len().saturating_add(8).max(16);
+        for _ in 0..max_ops {
+            let cur = self.folders.current_dir_id().map(|s| s.to_string());
+            if cur.as_deref() == Some(preview_key) {
+                return;
+            }
+            match cur {
+                None => {
+                    let name = self
+                        .folder_display_name_for_cache_id(preview_key)
+                        .unwrap_or_else(|| "Library".into());
+                    self.folder_enter(preview_key.to_string(), name);
+                    return;
+                }
+                Some(cur_id) => {
+                    if self.folders.path.len() >= 2 {
+                        let parent_id = self.folders.path[self.folders.path.len() - 2].0.clone();
+                        if parent_id == preview_key {
+                            self.folder_go_up();
+                            continue;
+                        }
+                    }
+                    match self.folders.listings.get(&cur_id) {
+                        Some(LoadingState::Loaded(listing)) => {
+                            if let Some((_, name)) =
+                                listing.directories.iter().find(|(id, _)| id == preview_key)
+                            {
+                                self.folder_enter(preview_key.to_string(), name.clone());
+                                continue;
+                            }
+                        }
+                        Some(LoadingState::Loading) => return,
+                        Some(LoadingState::NotLoaded) | None => {
+                            self.folders
+                                .listings
+                                .insert(cur_id.clone(), LoadingState::Loading);
+                            self.fetch_music_directory(cur_id.clone());
+                            return;
+                        }
+                        Some(LoadingState::Error(_)) => {}
+                    }
+                    if self.folders.path.len() > 1 {
+                        self.folder_go_up();
+                        continue;
+                    }
+                    let name = self
+                        .folder_display_name_for_cache_id(preview_key)
+                        .unwrap_or_else(|| "...".into());
+                    self.folder_enter(preview_key.to_string(), name);
+                    return;
+                }
+            }
+        }
+    }
+
+    fn folder_enter_preview_child(&mut self, child_id: String, child_name: String) {
+        let Some(ref preview_key) = self.folders.preview_dir_id.clone() else {
+            return;
+        };
+        let pk = preview_key.clone();
+        self.ensure_left_at_preview_folder(&pk);
+        self.folder_enter(child_id, child_name);
+    }
+
+    /// Activate the highlighted preview row (enter subdirectory or enqueue track).
+    pub fn folder_activate_preview_selection(&mut self) {
+        let Some(ref preview_key) = self.folders.preview_dir_id.clone() else {
+            return;
+        };
+        let listing = match self.folders.listings.get(preview_key) {
+            Some(LoadingState::Loaded(l)) => l,
+            _ => return,
+        };
+        let rows = folder_preview_rows(listing, self.search_filter.as_deref());
+        if rows.is_empty() {
+            return;
+        }
+        let row_ix = self
+            .folders
+            .preview_selected_row
+            .min(rows.len().saturating_sub(1));
+        match rows[row_ix] {
+            FolderPreviewRow::Dir(i) => {
+                let (id, name) = listing.directories[i].clone();
+                self.folder_enter_preview_child(id, name);
+                if self.active_tab == Tab::Browser && self.browse_files() {
+                    self.browser_focus = BrowserColumn::Artists;
+                }
+            }
+            FolderPreviewRow::Track(i) => {
+                let song = listing.tracks[i].clone();
+                let was_empty = self.queue.songs.is_empty();
+                self.queue.push(song);
+                if was_empty {
+                    self.queue.cursor = 0;
+                    self.play_current();
+                }
+            }
+        }
+    }
+
+    /// Open the **music folder row** using its API `id` (scoped via `getIndexes?musicFolderId=`).
+    pub fn folder_enter_music_library_root(
+        &mut self,
+        music_folder_id: String,
+        display_name: String,
+    ) {
+        let cache_id = ratune_subsonic::music_library_root_cache_key(&music_folder_id);
+        self.folder_enter(cache_id, display_name);
+    }
+
+    pub fn folder_enter(&mut self, id: String, name: String) {
+        self.folders.path.push((id.clone(), name));
+        self.folders.dirs_scroll = 0;
+        self.folders.tracks_scroll = 0;
+
+        let mut need_fetch = false;
+        match self.folders.listings.get(&id) {
+            Some(LoadingState::Loaded(listing)) => {
+                self.folders.folder_default_row_pending = false;
+                let row = folder_left_default_row(listing, self.search_filter.as_deref());
+                self.folders.selected_dir = Some(row);
+            }
+            Some(LoadingState::Loading) => {
+                self.folders.folder_default_row_pending = true;
+                self.folders.selected_dir = Some(0);
+            }
+            Some(LoadingState::NotLoaded) | None => {
+                self.folders.folder_default_row_pending = true;
+                self.folders.selected_dir = Some(0);
+                need_fetch = true;
+            }
+            Some(LoadingState::Error(_)) => {
+                self.folders.folder_default_row_pending = true;
+                self.folders.selected_dir = Some(0);
+                need_fetch = true;
+            }
+        }
+        if need_fetch {
+            self.folders
+                .listings
+                .insert(id.clone(), LoadingState::Loading);
+            self.fetch_music_directory(id);
+        }
+        self.sync_folder_preview_from_left();
+    }
+
+    pub fn folder_go_up(&mut self) {
+        if !self.folders.path.pop().is_some() {
+            return;
+        }
+        self.folders.dirs_scroll = 0;
+        self.folders.tracks_scroll = 0;
+
+        if self.folders.path.is_empty() {
+            self.folders.folder_default_row_pending = false;
+            self.sync_folder_preview_from_left();
+            return;
+        }
+
+        let Some(cur) = self.folders.current_dir_id().map(|s| s.to_string()) else {
+            self.folders.folder_default_row_pending = false;
+            self.sync_folder_preview_from_left();
+            return;
+        };
+
+        let mut need_fetch = false;
+        match self.folders.listings.get(&cur) {
+            Some(LoadingState::Loaded(listing)) => {
+                self.folders.folder_default_row_pending = false;
+                let row = folder_left_default_row(listing, self.search_filter.as_deref());
+                self.folders.selected_dir = Some(row);
+            }
+            Some(LoadingState::Loading) => {
+                self.folders.folder_default_row_pending = true;
+                self.folders.selected_dir = Some(0);
+            }
+            Some(LoadingState::NotLoaded) | None => {
+                self.folders.folder_default_row_pending = true;
+                self.folders.selected_dir = Some(0);
+                need_fetch = true;
+            }
+            Some(LoadingState::Error(_)) => {
+                self.folders.folder_default_row_pending = true;
+                self.folders.selected_dir = Some(0);
+                need_fetch = true;
+            }
+        }
+        if need_fetch {
+            self.folders
+                .listings
+                .insert(cur.clone(), LoadingState::Loading);
+            self.fetch_music_directory(cur);
+        }
+        self.sync_folder_preview_from_left();
+    }
+
+    /// Enter the highlighted row in the folders column (root, parent, or subfolder).
+    pub fn folder_activate_selected_dir(&mut self) {
+        if self.folders.path.is_empty() {
+            let roots = match &self.folders.roots {
+                LoadingState::Loaded(r) => r,
+                _ => return,
+            };
+            let indices: Vec<usize> = if let Some(q) = &self.search_filter {
+                roots
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, r)| r.name.to_lowercase().contains(q.as_str()))
+                    .map(|(i, _)| i)
+                    .collect()
+            } else {
+                (0..roots.len()).collect()
+            };
+            if indices.is_empty() {
+                return;
+            }
+            let pos = self
+                .folders
+                .selected_dir
+                .unwrap_or(0)
+                .min(indices.len() - 1);
+            let slot = indices[pos];
+            let root = &roots[slot];
+            self.folder_enter_music_library_root(root.id.clone(), root.name.clone());
+            return;
+        }
+
+        let listing = match self.folders.current_listing() {
+            Some(LoadingState::Loaded(l)) => l,
+            _ => return,
+        };
+        let sel = self.folders.selected_dir.unwrap_or(0);
+        if sel == 0 {
+            self.folder_go_up();
+            return;
+        }
+        let dir_indices: Vec<usize> = if let Some(q) = &self.search_filter {
+            listing
+                .directories
+                .iter()
+                .enumerate()
+                .filter(|(_, (_, name))| name.to_lowercase().contains(q.as_str()))
+                .map(|(i, _)| i)
+                .collect()
+        } else {
+            (0..listing.directories.len()).collect()
+        };
+        let dir_pos = sel.saturating_sub(1);
+        if dir_pos >= dir_indices.len() {
+            return;
+        }
+        let (id, name) = listing.directories[dir_indices[dir_pos]].clone();
+        self.folder_enter(id, name);
+    }
 
     /// Spawn a task to fetch the artist list.
     pub fn fetch_artists(&self) {
@@ -1619,6 +2036,72 @@ impl App {
                 if let Some(ref mut picker) = self.playlist_picker {
                     picker.playlists = playlists;
                     picker.loading = false;
+                }
+            }
+            LibraryUpdate::MusicFolders(result) => {
+                self.folders.roots = match result {
+                    Ok(roots) => {
+                        if self.folders.selected_dir.is_none() && !roots.is_empty() {
+                            self.folders.selected_dir = Some(0);
+                        }
+                        if roots.len() == 1 && self.folders.path.is_empty() {
+                            let id = roots[0].id.clone();
+                            let name = roots[0].name.clone();
+                            self.folder_enter_music_library_root(id, name);
+                        }
+                        LoadingState::Loaded(roots)
+                    }
+                    Err(e) => LoadingState::Error(e),
+                };
+                if self.browse_files() {
+                    self.sync_folder_preview_from_left();
+                }
+            }
+            LibraryUpdate::MusicDirectory { id, result } => {
+                let loaded = match result {
+                    Ok(listing) => LoadingState::Loaded(listing),
+                    Err(e) => LoadingState::Error(e),
+                };
+                self.folders.listings.insert(id.clone(), loaded);
+
+                match self.folders.listings.get(&id) {
+                    Some(LoadingState::Loaded(listing)) => {
+                        if self.browse_files() && self.folders.current_dir_id() == Some(id.as_str())
+                        {
+                            if self.folders.folder_default_row_pending {
+                                let row =
+                                    folder_left_default_row(listing, self.search_filter.as_deref());
+                                self.folders.selected_dir = Some(row);
+                                self.folders.folder_default_row_pending = false;
+                            } else if self.folders.selected_dir.is_none() {
+                                let row =
+                                    folder_left_default_row(listing, self.search_filter.as_deref());
+                                self.folders.selected_dir = Some(row);
+                            }
+                        }
+                    }
+                    Some(LoadingState::Error(_)) => {
+                        if self.browse_files() && self.folders.current_dir_id() == Some(id.as_str())
+                        {
+                            self.folders.folder_default_row_pending = false;
+                        }
+                    }
+                    _ => {}
+                }
+
+                if self.browse_files() {
+                    self.sync_folder_preview_from_left();
+                }
+
+                if let Some(LoadingState::Loaded(listing)) = self.folders.listings.get(&id) {
+                    if self.browse_files()
+                        && self.folders.preview_dir_id.as_deref() == Some(id.as_str())
+                    {
+                        let rows = folder_preview_rows(listing, self.search_filter.as_deref());
+                        let max_r = rows.len().saturating_sub(1);
+                        self.folders.preview_selected_row =
+                            self.folders.preview_selected_row.min(max_r);
+                    }
                 }
             }
             LibraryUpdate::LibraryIndexRefreshComplete { result } => {
@@ -2256,6 +2739,40 @@ impl App {
                 self.search_filter = None;
                 self.apply_pending_artist_select();
             }
+            Action::ToggleBrowserFolder => {
+                self.playlist_overlay.visible = false;
+                self.playlist_picker = None;
+                self.clear_art_on_tab_switch();
+                self.pending_gg = false;
+                if !self.config.browse_folder_navigation {
+                    self.flash_status_secs(
+                        "Folder browse disabled — set [ui.browsetab] folder_navigation = true",
+                        5,
+                    );
+                } else if self.browser_browse_mode == BrowseMode::Genre {
+                    self.flash_status("Genre browse is not implemented (change mode in config)");
+                } else {
+                    self.browser_browse_mode = match self.browser_browse_mode {
+                        BrowseMode::Files => BrowseMode::Artists,
+                        _ => BrowseMode::Files,
+                    };
+                    self.active_tab = Tab::Browser;
+                    self.search_filter = None;
+                    if self.browser_browse_mode == BrowseMode::Files {
+                        if matches!(
+                            &self.folders.roots,
+                            LoadingState::NotLoaded | LoadingState::Error(_)
+                        ) {
+                            self.fetch_music_folders();
+                        }
+                        self.sync_folder_preview_from_left();
+                    }
+                    self.flash_status(match self.browser_browse_mode {
+                        BrowseMode::Files => "Browse: folders",
+                        _ => "Browse: artists / albums / tracks",
+                    });
+                }
+            }
             Action::GoToNowPlaying => {
                 self.playlist_overlay.visible = false;
                 self.playlist_picker = None;
@@ -2706,6 +3223,16 @@ impl App {
             return;
         }
         self.search_filter = None;
+        if self.browse_files() {
+            match self.browser_focus {
+                BrowserColumn::Artists => {
+                    self.browser_focus = BrowserColumn::Tracks;
+                    self.sync_folder_preview_from_left();
+                }
+                BrowserColumn::Albums | BrowserColumn::Tracks => {}
+            }
+            return;
+        }
         match self.browser_focus {
             BrowserColumn::Artists => {
                 if let Some(artist) = self.library.current_artist() {
@@ -2740,6 +3267,16 @@ impl App {
             return;
         }
         self.search_filter = None;
+        if self.browse_files() {
+            match self.browser_focus {
+                BrowserColumn::Tracks => {
+                    self.browser_focus = BrowserColumn::Artists;
+                    self.sync_folder_preview_from_left();
+                }
+                BrowserColumn::Artists | BrowserColumn::Albums => {}
+            }
+            return;
+        }
         self.browser_focus = self.browser_focus.left();
     }
 
@@ -2883,6 +3420,10 @@ impl App {
     }
 
     fn handle_navigate_browser(&mut self, dir: Direction) {
+        if self.browse_files() {
+            self.handle_navigate_browser_files(dir);
+            return;
+        }
         match self.browser_focus {
             BrowserColumn::Artists => {
                 let result = if let LoadingState::Loaded(artists) = &self.library.artists {
@@ -3022,6 +3563,81 @@ impl App {
         }
     }
 
+    fn handle_navigate_browser_files(&mut self, dir: Direction) {
+        let page = self.browser_list_viewport_rows.max(1);
+        match self.browser_focus {
+            BrowserColumn::Artists | BrowserColumn::Albums => {
+                let len = if self.folders.path.is_empty() {
+                    match &self.folders.roots {
+                        LoadingState::Loaded(roots) => {
+                            if let Some(q) = &self.search_filter {
+                                roots
+                                    .iter()
+                                    .filter(|r| r.name.to_lowercase().contains(q.as_str()))
+                                    .count()
+                            } else {
+                                roots.len()
+                            }
+                        }
+                        _ => return,
+                    }
+                } else {
+                    match self.folders.current_listing() {
+                        Some(LoadingState::Loaded(listing)) => {
+                            let sub = if let Some(q) = &self.search_filter {
+                                listing
+                                    .directories
+                                    .iter()
+                                    .filter(|(_, name)| name.to_lowercase().contains(q.as_str()))
+                                    .count()
+                            } else {
+                                listing.directories.len()
+                            };
+                            1 + sub
+                        }
+                        _ => return,
+                    }
+                };
+                if len == 0 {
+                    return;
+                }
+                let cur = self.folders.selected_dir.unwrap_or(0).min(len - 1);
+                let new_pos = match dir {
+                    Direction::Up => cur.saturating_sub(1),
+                    Direction::Down => (cur + 1).min(len - 1),
+                    Direction::Top => 0,
+                    Direction::Bottom => len - 1,
+                    Direction::PageUp => cur.saturating_sub(page),
+                    Direction::PageDown => (cur + page).min(len - 1),
+                };
+                self.folders.selected_dir = Some(new_pos);
+                self.folders.folder_default_row_pending = false;
+                self.sync_folder_preview_from_left();
+            }
+            BrowserColumn::Tracks => {
+                let Some(ref pid) = self.folders.preview_dir_id.clone() else {
+                    return;
+                };
+                if let Some(LoadingState::Loaded(listing)) = self.folders.listings.get(pid) {
+                    let rows = folder_preview_rows(listing, self.search_filter.as_deref());
+                    if rows.is_empty() {
+                        return;
+                    }
+                    let cur_pos = self.folders.preview_selected_row.min(rows.len() - 1);
+                    let new_pos = match dir {
+                        Direction::Up => cur_pos.saturating_sub(1),
+                        Direction::Down => (cur_pos + 1).min(rows.len() - 1),
+                        Direction::Top => 0,
+                        Direction::Bottom => rows.len() - 1,
+                        Direction::PageUp => cur_pos.saturating_sub(page),
+                        Direction::PageDown => (cur_pos + page).min(rows.len() - 1),
+                    };
+                    self.folders.preview_selected_row = new_pos;
+                }
+            }
+        }
+    }
+
     fn handle_navigate_queue(&mut self, dir: Direction) {
         let len = self.queue.songs.len();
         if len == 0 {
@@ -3043,12 +3659,21 @@ impl App {
     fn handle_select(&mut self) {
         match self.active_tab {
             Tab::Home => self.handle_select_home(),
-            Tab::Browser => match self.browser_focus {
-                // Enter on Artists or Albums: same as pressing l
-                BrowserColumn::Artists | BrowserColumn::Albums => self.handle_focus_right(),
-                // Enter on Tracks: add the highlighted track to the queue
-                BrowserColumn::Tracks => self.handle_add_to_queue(),
-            },
+            Tab::Browser => {
+                if self.browse_files() {
+                    match self.browser_focus {
+                        BrowserColumn::Artists | BrowserColumn::Albums => {
+                            self.folder_activate_selected_dir()
+                        }
+                        BrowserColumn::Tracks => self.folder_activate_preview_selection(),
+                    }
+                } else {
+                    match self.browser_focus {
+                        BrowserColumn::Artists | BrowserColumn::Albums => self.handle_focus_right(),
+                        BrowserColumn::Tracks => self.handle_add_to_queue(),
+                    }
+                }
+            }
             Tab::NowPlaying => {
                 // Enter: jump playback to the highlighted queue row.
                 if !self.queue.songs.is_empty() {
@@ -3185,6 +3810,21 @@ impl App {
     // ── Queue helpers ─────────────────────────────────────────────────────────
 
     fn handle_add_to_queue(&mut self) {
+        if self.browse_files() {
+            if let Some(song) = self
+                .folders
+                .current_preview_track(self.search_filter.as_deref())
+                .cloned()
+            {
+                let was_empty = self.queue.songs.is_empty();
+                self.queue.push(song);
+                if was_empty {
+                    self.queue.cursor = 0;
+                    self.play_current();
+                }
+            }
+            return;
+        }
         if let Some(song) = self.library.current_track().cloned() {
             let was_empty = self.queue.songs.is_empty();
             self.queue.push(song);
@@ -3223,6 +3863,54 @@ impl App {
     }
 
     fn handle_add_all_to_queue(&mut self, mode: AddAllMode) {
+        if self.browse_files() {
+            let id = match self.folders.preview_dir_id.clone() {
+                Some(id) => id,
+                None => {
+                    self.flash_status("Nothing to add");
+                    return;
+                }
+            };
+            let songs = match self.folders.listings.get(&id) {
+                Some(LoadingState::Loaded(l)) if !l.tracks.is_empty() => l.tracks.clone(),
+                _ => {
+                    self.flash_status("No tracks in this folder");
+                    return;
+                }
+            };
+            let prepend = matches!(mode, AddAllMode::Prepend);
+            match mode {
+                AddAllMode::ReplaceAlbum | AddAllMode::ReplaceArtist => {
+                    self.queue.songs = songs;
+                    self.queue.cursor = 0;
+                    self.queue.scroll = 0;
+                    self.queue.pre_shuffle_order = None;
+                    let _ = self.player_tx.send(PlayerCommand::Stop);
+                    self.playback.current_song = None;
+                    self.playback.elapsed = std::time::Duration::ZERO;
+                    self.playback.paused = false;
+                    self.playback.player_loaded = false;
+                    if !self.queue.songs.is_empty() {
+                        self.play_current();
+                    }
+                }
+                AddAllMode::Append | AddAllMode::Prepend => {
+                    let was_empty = self.queue.songs.is_empty();
+                    if prepend {
+                        self.queue.prepend_songs(songs);
+                    } else {
+                        for song in songs {
+                            self.queue.push(song);
+                        }
+                    }
+                    if was_empty && !self.queue.songs.is_empty() {
+                        self.queue.cursor = 0;
+                        self.play_current();
+                    }
+                }
+            }
+            return;
+        }
         match mode {
             AddAllMode::ReplaceAlbum => self.handle_replace_queue_with_current_album(),
             AddAllMode::ReplaceArtist => self.handle_replace_queue_with_current_artist(),
@@ -3366,50 +4054,129 @@ impl App {
         }
         match self.active_tab {
             Tab::Home => {} // no search targets yet
-            Tab::Browser => match self.browser_focus {
-                BrowserColumn::Artists => {
-                    if let crate::state::LoadingState::Loaded(artists) = &self.library.artists {
-                        if let Some(idx) = artists
-                            .iter()
-                            .position(|a| a.name.to_lowercase().contains(&q))
-                        {
-                            self.library.selected_artist = Some(idx);
+            Tab::Browser => {
+                if self.browse_files() {
+                    match self.browser_focus {
+                        BrowserColumn::Artists | BrowserColumn::Albums => {
+                            if self.folders.path.is_empty() {
+                                if let LoadingState::Loaded(roots) = &self.folders.roots {
+                                    let filtered_slots: Vec<usize> =
+                                        if let Some(sf) = &self.search_filter {
+                                            roots
+                                                .iter()
+                                                .enumerate()
+                                                .filter(|(_, r)| {
+                                                    r.name.to_lowercase().contains(sf.as_str())
+                                                })
+                                                .map(|(i, _)| i)
+                                                .collect()
+                                        } else {
+                                            (0..roots.len()).collect()
+                                        };
+                                    if let Some(visible_pos) =
+                                        filtered_slots.iter().position(|&slot| {
+                                            roots[slot].name.to_lowercase().contains(&q)
+                                        })
+                                    {
+                                        self.folders.selected_dir = Some(visible_pos);
+                                    }
+                                }
+                            } else if let Some(LoadingState::Loaded(listing)) =
+                                self.folders.current_listing()
+                            {
+                                let dir_indices: Vec<usize> = if let Some(sf) = &self.search_filter
+                                {
+                                    listing
+                                        .directories
+                                        .iter()
+                                        .enumerate()
+                                        .filter(|(_, (_, n))| {
+                                            n.to_lowercase().contains(sf.as_str())
+                                        })
+                                        .map(|(i, _)| i)
+                                        .collect()
+                                } else {
+                                    (0..listing.directories.len()).collect()
+                                };
+                                if let Some(dp) = dir_indices.iter().position(|&orig_i| {
+                                    listing.directories[orig_i].1.to_lowercase().contains(&q)
+                                }) {
+                                    self.folders.selected_dir = Some(1 + dp);
+                                }
+                            }
+                            self.folders.folder_default_row_pending = false;
+                            self.sync_folder_preview_from_left();
+                        }
+                        BrowserColumn::Tracks => {
+                            if let Some(ref pid) = self.folders.preview_dir_id.clone() {
+                                if let Some(LoadingState::Loaded(listing)) =
+                                    self.folders.listings.get(pid)
+                                {
+                                    let rows =
+                                        folder_preview_rows(listing, self.search_filter.as_deref());
+                                    if let Some(ix) = rows.iter().position(|row| match row {
+                                        FolderPreviewRow::Dir(i) => {
+                                            listing.directories[*i].1.to_lowercase().contains(&q)
+                                        }
+                                        FolderPreviewRow::Track(i) => {
+                                            listing.tracks[*i].title.to_lowercase().contains(&q)
+                                        }
+                                    }) {
+                                        self.folders.preview_selected_row = ix;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    match self.browser_focus {
+                        BrowserColumn::Artists => {
+                            if let crate::state::LoadingState::Loaded(artists) =
+                                &self.library.artists
+                            {
+                                if let Some(idx) = artists
+                                    .iter()
+                                    .position(|a| a.name.to_lowercase().contains(&q))
+                                {
+                                    self.library.selected_artist = Some(idx);
+                                }
+                            }
+                        }
+                        BrowserColumn::Albums => {
+                            let artist_id = match self.library.current_artist() {
+                                Some(a) => a.id.clone(),
+                                None => return,
+                            };
+                            if let Some(crate::state::LoadingState::Loaded(albums)) =
+                                self.library.albums.get(&artist_id)
+                            {
+                                if let Some(idx) = albums
+                                    .iter()
+                                    .position(|a| a.name.to_lowercase().contains(&q))
+                                {
+                                    self.library.selected_album = Some(idx);
+                                }
+                            }
+                        }
+                        BrowserColumn::Tracks => {
+                            let album_id = match self.library.current_album() {
+                                Some(a) => a.id.clone(),
+                                None => return,
+                            };
+                            if let Some(crate::state::LoadingState::Loaded(songs)) =
+                                self.library.tracks.get(&album_id)
+                            {
+                                if let Some(idx) = songs
+                                    .iter()
+                                    .position(|s| s.title.to_lowercase().contains(&q))
+                                {
+                                    self.library.selected_track = Some(idx);
+                                }
+                            }
                         }
                     }
                 }
-                BrowserColumn::Albums => {
-                    let artist_id = match self.library.current_artist() {
-                        Some(a) => a.id.clone(),
-                        None => return,
-                    };
-                    if let Some(crate::state::LoadingState::Loaded(albums)) =
-                        self.library.albums.get(&artist_id)
-                    {
-                        if let Some(idx) = albums
-                            .iter()
-                            .position(|a| a.name.to_lowercase().contains(&q))
-                        {
-                            self.library.selected_album = Some(idx);
-                        }
-                    }
-                }
-                BrowserColumn::Tracks => {
-                    let album_id = match self.library.current_album() {
-                        Some(a) => a.id.clone(),
-                        None => return,
-                    };
-                    if let Some(crate::state::LoadingState::Loaded(songs)) =
-                        self.library.tracks.get(&album_id)
-                    {
-                        if let Some(idx) = songs
-                            .iter()
-                            .position(|s| s.title.to_lowercase().contains(&q))
-                        {
-                            self.library.selected_track = Some(idx);
-                        }
-                    }
-                }
-            },
+            }
             Tab::NowPlaying => {
                 if let Some(idx) = self
                     .queue
@@ -3503,6 +4270,37 @@ impl App {
                 .tracks
                 .insert(album_id.clone(), LoadingState::Loading);
             self.fetch_tracks(album_id);
+        }
+    }
+
+    pub fn click_folder_dir(&mut self, visible_pos: usize) {
+        self.folders.folder_default_row_pending = false;
+        self.folders.selected_dir = Some(visible_pos);
+        self.folder_activate_selected_dir();
+    }
+
+    pub fn click_folder_preview_row(&mut self, visible_row: usize) {
+        let Some(ref pid) = self.folders.preview_dir_id.clone() else {
+            return;
+        };
+        let listing = match self.folders.listings.get(pid) {
+            Some(LoadingState::Loaded(l)) => l,
+            _ => return,
+        };
+        let rows = folder_preview_rows(listing, self.search_filter.as_deref());
+        if rows.is_empty() {
+            return;
+        }
+        let vh = self.browser_list_viewport_rows.max(1);
+        let sel_pos = self
+            .folders
+            .preview_selected_row
+            .min(rows.len().saturating_sub(1));
+        FolderBrowseState::clamp_scroll(&mut self.folders.tracks_scroll, sel_pos, rows.len(), vh);
+        let scroll = self.folders.tracks_scroll;
+        let clicked = scroll + visible_row;
+        if clicked < rows.len() {
+            self.folders.preview_selected_row = clicked;
         }
     }
 
@@ -3791,7 +4589,13 @@ impl App {
                 }
             }
             Action::BrowserAddToPlaylist => {
-                if let Some(song) = self.library.current_track() {
+                let song = if self.browse_files() {
+                    self.folders
+                        .current_preview_track(self.search_filter.as_deref())
+                } else {
+                    self.library.current_track()
+                };
+                if let Some(song) = song {
                     let song_id = song.id.clone();
                     match &self.playlist_overlay.playlists {
                         LoadingState::Loaded(playlists) => {

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -99,6 +99,8 @@ pub struct KeybindsSection {
     pub home_section_prev: Option<String>,
     /// Home: re-roll / refresh. Default: r
     pub home_refresh: Option<String>,
+    /// Browse: toggle folder navigation (requires `[ui.browsetab] folder_navigation`). Default: Ctrl+b
+    pub toggle_folder_browse: Option<String>,
 }
 
 // ── [theme] ───────────────────────────────────────────────────────────────────
@@ -392,7 +394,12 @@ pub struct UiHomeTabSection {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct UiBrowseTabSection {
-    /// `artists` (default), `genre`, or `files`. Genre/files are placeholders until implemented.
+    /// When true, folder (`getMusicFolders` / `getMusicDirectory`) browsing is available and
+    /// the configured key toggles between artist columns and folder view. Default: false.
+    #[serde(default)]
+    pub folder_navigation: Option<bool>,
+    /// Default browse layout on startup: `artists` (default), `genre` (stub), or `files` (only
+    /// applies when [`folder_navigation`](Self::folder_navigation) is true).
     #[serde(default)]
     pub mode: Option<String>,
 }
@@ -577,7 +584,7 @@ fn parse_home_panels(v: Option<Vec<String>>) -> [HomePanel; 3] {
     out
 }
 
-/// Browse tab mode (`artists` is the only fully implemented path today).
+/// Browse tab mode: `artists` (artist/album/track) or `files` (folder navigation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BrowseMode {
     #[default]
@@ -786,6 +793,8 @@ pub struct Config {
     pub home_panels: [HomePanel; 3],
     /// Browse tab: `artists` (default), or placeholder `genre` / `files`.
     pub browse_mode: BrowseMode,
+    /// When true, folder browsing can be toggled with the keybind and used from the Browse tab.
+    pub browse_folder_navigation: bool,
 }
 
 impl Config {
@@ -1048,6 +1057,11 @@ impl Config {
             .and_then(|b| b.mode.as_deref())
             .and_then(BrowseMode::parse)
             .unwrap_or_default();
+        let browse_folder_navigation = ui
+            .browsetab
+            .as_ref()
+            .and_then(|b| b.folder_navigation)
+            .unwrap_or(false);
 
         Ok(Config {
             subsonic_url: file_cfg.server.url,
@@ -1106,6 +1120,7 @@ impl Config {
             home_top_height_percent,
             home_panels,
             browse_mode,
+            browse_folder_navigation,
         })
     }
 

--- a/ratune/src/keybinds.rs
+++ b/ratune/src/keybinds.rs
@@ -178,6 +178,8 @@ pub struct Keybinds {
     pub home_section_next: KeySpec,
     pub home_section_prev: KeySpec,
     pub home_refresh: KeySpec,
+    /// `None` = disabled — folder toggle from keybinds
+    pub toggle_folder_browse: Option<KeySpec>,
 }
 
 impl Keybinds {
@@ -258,6 +260,13 @@ impl Keybinds {
             sec.library_index_append_queue.as_deref(),
             Some(KeySpec {
                 code: KeyCode::Char('a'),
+                modifiers: KeyModifiers::CONTROL,
+            }),
+        );
+        let toggle_folder_browse = resolve_opt(
+            sec.toggle_folder_browse.as_deref(),
+            Some(KeySpec {
+                code: KeyCode::Char('b'),
                 modifiers: KeyModifiers::CONTROL,
             }),
         );
@@ -370,6 +379,7 @@ impl Keybinds {
                 sec.home_refresh.as_deref(),
                 KeySpec::new(KeyCode::Char('r')),
             ),
+            toggle_folder_browse,
         }
     }
 }

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -38,7 +38,7 @@ use ratatui::Terminal;
 
 use action::{Action, Direction};
 use app::{App, BrowserColumn, Tab};
-use config::{AlbumArtBackend, Config, HomePanel};
+use config::{AlbumArtBackend, BrowseMode, Config, HomePanel};
 use keybinds::Keybinds;
 use state::{GlobalConfirm, PlaylistFocus, PlaylistInputMode};
 
@@ -59,12 +59,11 @@ pub async fn run() -> Result<()> {
         app.tmux_status_offset = tmux_status_offset();
     }
 
-    app.visualizer_gradient_rgb_cache =
-        ui::terminal_palette::try_query_visualizer_gradient_cache(
-            &app.theme,
-            &app.config,
-            app.in_tmux,
-        );
+    app.visualizer_gradient_rgb_cache = ui::terminal_palette::try_query_visualizer_gradient_cache(
+        &app.theme,
+        &app.config,
+        app.in_tmux,
+    );
 
     // kitty-apc backend: probe before raw mode / alternate screen (see `kitty_art`).
     // `ratatui-image` uses `Picker::from_query_stdio()` after the alternate screen.
@@ -103,8 +102,12 @@ pub async fn run() -> Result<()> {
         app.home_art_needs_redraw = true;
     }
 
-    // Begin fetching artists immediately.
-    app.fetch_artists();
+    // Begin fetching library metadata for the browse tab.
+    if app.browser_browse_mode == crate::config::BrowseMode::Files {
+        app.fetch_music_folders();
+    } else {
+        app.fetch_artists();
+    }
     // Background metadata index refresh when missing or stale (Milestone 2).
     app.spawn_library_index_refresh(false);
 
@@ -1187,6 +1190,11 @@ fn map_key(
     if kb.go_to_nowplaying.matches(code, modifiers) {
         return Action::GoToNowPlaying;
     }
+    if let Some(spec) = &kb.toggle_folder_browse {
+        if spec.matches(code, modifiers) {
+            return Action::ToggleBrowserFolder;
+        }
+    }
 
     // seek_forward / seek_backward are tab-aware: they also act as column
     // navigation in the Browser tab so Right/Left keep working there.
@@ -1444,15 +1452,26 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
             handle_home_click(x, y, app, center);
         }
         Tab::Browser => {
-            // 3 columns: [30% artists | 35% albums | 35% tracks]
-            let browser_cols = Layout::horizontal([
-                Constraint::Percentage(30),
-                Constraint::Percentage(35),
-                Constraint::Percentage(35),
-            ])
-            .split(center);
+            let files_mode = app.browser_browse_mode == BrowseMode::Files;
+            let browser_cols = if files_mode {
+                Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)])
+                    .split(center)
+            } else {
+                Layout::horizontal([
+                    Constraint::Percentage(30),
+                    Constraint::Percentage(35),
+                    Constraint::Percentage(35),
+                ])
+                .split(center)
+            };
 
-            let col_idx = if x < browser_cols[1].x {
+            let col_idx = if files_mode {
+                if x < browser_cols[1].x {
+                    0usize
+                } else {
+                    1
+                }
+            } else if x < browser_cols[1].x {
                 0usize
             } else if x < browser_cols[2].x {
                 1
@@ -1470,11 +1489,35 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
             let visible_height = col_area.height.saturating_sub(2) as usize;
 
             // Switch focus to the clicked column.
-            app.browser_focus = match col_idx {
-                0 => BrowserColumn::Artists,
-                1 => BrowserColumn::Albums,
-                _ => BrowserColumn::Tracks,
+            app.browser_focus = if files_mode {
+                match col_idx {
+                    0 => BrowserColumn::Artists,
+                    _ => BrowserColumn::Tracks,
+                }
+            } else {
+                match col_idx {
+                    0 => BrowserColumn::Artists,
+                    1 => BrowserColumn::Albums,
+                    _ => BrowserColumn::Tracks,
+                }
             };
+
+            if files_mode {
+                match col_idx {
+                    0 => {
+                        let visible_pos = {
+                            let scroll = app.folders.dirs_scroll;
+                            scroll + visible_row
+                        };
+                        app.click_folder_dir(visible_pos);
+                    }
+                    _ => {
+                        app.click_folder_preview_row(visible_row);
+                        app.folder_activate_preview_selection();
+                    }
+                }
+                return;
+            }
 
             match col_idx {
                 0 => {

--- a/ratune/src/state.rs
+++ b/ratune/src/state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use ratune_subsonic::models::{Album, Artist, Song};
+use ratune_subsonic::models::{Album, Artist, MusicFolder, Song};
 
 // ── LoadingState ──────────────────────────────────────────────────────────────
 
@@ -80,6 +80,126 @@ impl LibraryState {
             self.selected_track.and_then(|i| songs.get(i))
         } else {
             None
+        }
+    }
+}
+
+// ── FolderBrowseState ─────────────────────────────────────────────────────────
+
+/// Cached contents of one `getMusicDirectory` response.
+#[derive(Debug, Clone)]
+pub struct DirectoryListing {
+    pub name: String,
+    pub directories: Vec<(String, String)>,
+    pub tracks: Vec<Song>,
+}
+
+/// One row in the folder preview pane (right column): subfolders first, then tracks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FolderPreviewRow {
+    Dir(usize),
+    Track(usize),
+}
+
+/// Build filtered preview rows for `listing` (directories then tracks).
+pub fn folder_preview_rows(
+    listing: &DirectoryListing,
+    filter: Option<&str>,
+) -> Vec<FolderPreviewRow> {
+    let mut out = Vec::new();
+    match filter {
+        Some(q) => {
+            let ql = q.to_lowercase();
+            for (i, (_, name)) in listing.directories.iter().enumerate() {
+                if name.to_lowercase().contains(&ql) {
+                    out.push(FolderPreviewRow::Dir(i));
+                }
+            }
+            for (i, s) in listing.tracks.iter().enumerate() {
+                if s.title.to_lowercase().contains(&ql) {
+                    out.push(FolderPreviewRow::Track(i));
+                }
+            }
+        }
+        None => {
+            for i in 0..listing.directories.len() {
+                out.push(FolderPreviewRow::Dir(i));
+            }
+            for i in 0..listing.tracks.len() {
+                out.push(FolderPreviewRow::Track(i));
+            }
+        }
+    }
+    out
+}
+
+/// Left folder column row count inside a directory: `..` plus search-filtered subdirectories.
+fn folder_left_visible_rows_len(listing: &DirectoryListing, filter: Option<&str>) -> usize {
+    let sub = if let Some(q) = filter {
+        listing
+            .directories
+            .iter()
+            .filter(|(_, name)| name.to_lowercase().contains(q))
+            .count()
+    } else {
+        listing.directories.len()
+    };
+    1 + sub
+}
+
+/// Default highlighted row: skip `..` when at least one subdirectory is visible.
+pub fn folder_left_default_row(listing: &DirectoryListing, filter: Option<&str>) -> usize {
+    let len = folder_left_visible_rows_len(listing, filter);
+    if len >= 2 {
+        1
+    } else {
+        0
+    }
+}
+
+/// File/folder browser state (`[ui.browsetab] mode = "files"`).
+#[derive(Debug, Default)]
+pub struct FolderBrowseState {
+    pub roots: LoadingState<Vec<MusicFolder>>,
+    /// `(id, display name)` from the selected root into the current folder.
+    pub path: Vec<(String, String)>,
+    pub listings: std::collections::HashMap<String, LoadingState<DirectoryListing>>,
+    pub selected_dir: Option<usize>,
+    /// After path changes, set selection when the current folder listing finishes loading.
+    pub folder_default_row_pending: bool,
+    /// Listing id shown in the right-hand preview column (`browse_folder_listing` cache key).
+    pub preview_dir_id: Option<String>,
+    /// Selected row in the preview list (filtered dirs + tracks).
+    pub preview_selected_row: usize,
+    pub dirs_scroll: usize,
+    pub tracks_scroll: usize,
+}
+
+impl FolderBrowseState {
+    pub fn clamp_scroll(scroll: &mut usize, sel: usize, len: usize, visible: usize) {
+        LibraryState::clamp_vertical_scroll(scroll, sel, len, visible);
+    }
+
+    pub fn current_dir_id(&self) -> Option<&str> {
+        self.path.last().map(|(id, _)| id.as_str())
+    }
+
+    pub fn current_listing(&self) -> Option<&LoadingState<DirectoryListing>> {
+        let id = self.current_dir_id()?;
+        self.listings.get(id)
+    }
+
+    pub fn current_preview_track(&self, filter: Option<&str>) -> Option<&Song> {
+        let pid = self.preview_dir_id.as_ref()?;
+        let listing = match self.listings.get(pid)? {
+            LoadingState::Loaded(l) => l,
+            _ => return None,
+        };
+        let rows = folder_preview_rows(listing, filter);
+        let row = rows.get(self.preview_selected_row)?;
+        match row {
+            FolderPreviewRow::Track(i) => listing.tracks.get(*i),
+            FolderPreviewRow::Dir(_) => None,
         }
     }
 }

--- a/ratune/src/ui/browser.rs
+++ b/ratune/src/ui/browser.rs
@@ -4,35 +4,73 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
-use super::{albums, artists, playlist_overlay, tracks};
+use super::{albums, artists, folder_tracks, folders, playlist_overlay, tracks};
 use crate::app::{App, BrowserColumn};
 use crate::config::BrowseMode;
 
 pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
-    match app.config.browse_mode {
-        BrowseMode::Artists => {}
+    match app.browser_browse_mode {
         BrowseMode::Genre => {
             frame.render_widget(
                 Paragraph::new(Line::from(Span::styled(
                     "Genre browsing is not implemented yet.\n\
-                     Use [ui.browsetab] mode = \"artists\" for the artist/album/track browser.",
+                     Use [ui.browsetab] mode = \"artists\" or \"files\".",
                     Style::default().fg(Color::DarkGray),
                 ))),
                 area,
             );
+            playlist_overlay::render_playlist_overlay(
+                frame,
+                area,
+                &app.playlist_overlay,
+                app.accent(),
+                &app.theme,
+            );
+            if let Some(picker) = &app.playlist_picker {
+                playlist_overlay::render_playlist_picker(
+                    frame,
+                    area,
+                    picker,
+                    app.accent(),
+                    &app.theme,
+                );
+            }
             return;
         }
         BrowseMode::Files => {
-            frame.render_widget(
-                Paragraph::new(Line::from(Span::styled(
-                    "File browsing is not implemented yet.\n\
-                     Use [ui.browsetab] mode = \"artists\" for the artist/album/track browser.",
-                    Style::default().fg(Color::DarkGray),
-                ))),
-                area,
+            let cols = Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)])
+                .split(area);
+            folders::render(
+                app,
+                frame,
+                cols[0],
+                matches!(app.browser_focus, BrowserColumn::Artists),
             );
+            folder_tracks::render(
+                app,
+                frame,
+                cols[1],
+                matches!(app.browser_focus, BrowserColumn::Tracks),
+            );
+            playlist_overlay::render_playlist_overlay(
+                frame,
+                area,
+                &app.playlist_overlay,
+                app.accent(),
+                &app.theme,
+            );
+            if let Some(picker) = &app.playlist_picker {
+                playlist_overlay::render_playlist_picker(
+                    frame,
+                    area,
+                    picker,
+                    app.accent(),
+                    &app.theme,
+                );
+            }
             return;
         }
+        BrowseMode::Artists => {}
     }
 
     let cols = Layout::horizontal([

--- a/ratune/src/ui/folder_tracks.rs
+++ b/ratune/src/ui/folder_tracks.rs
@@ -1,0 +1,165 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
+use ratatui::Frame;
+
+use crate::app::App;
+use crate::config::BrowseMode;
+use crate::state::{folder_preview_rows, FolderBrowseState, FolderPreviewRow, LoadingState};
+
+pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
+    let t = &app.theme;
+    let border_color = if is_active { app.accent() } else { t.border };
+    let title_color = if is_active { app.accent() } else { t.dimmed };
+
+    let border_style = if is_active {
+        Style::default()
+            .fg(border_color)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(border_color)
+    };
+
+    let preview_title: String = match &app.folders.preview_dir_id {
+        Some(id) => match app.folders.listings.get(id) {
+            Some(LoadingState::Loaded(li)) => {
+                let n = li.name.trim();
+                if n.is_empty() {
+                    " Preview ".to_string()
+                } else {
+                    format!(" {n} ")
+                }
+            }
+            _ => " Preview ".to_string(),
+        },
+        None => " Preview ".to_string(),
+    };
+
+    let block = Block::default()
+        .title(preview_title.as_str())
+        .title_style(
+            Style::default()
+                .fg(title_color)
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(border_style)
+        .style(Style::default().bg(t.surface));
+
+    if app.browser_browse_mode != BrowseMode::Files {
+        let list =
+            List::new(vec![ListItem::new("—").style(Style::default().fg(t.dimmed))]).block(block);
+        frame.render_widget(list, area);
+        return;
+    }
+
+    let Some(ref pid) = app.folders.preview_dir_id.clone() else {
+        let msg = if app.folders.path.is_empty() {
+            "← Select a library folder"
+        } else {
+            "No preview"
+        };
+        let list =
+            List::new(vec![ListItem::new(msg).style(Style::default().fg(t.dimmed))]).block(block);
+        frame.render_widget(list, area);
+        return;
+    };
+
+    match app.folders.listings.get(pid) {
+        None | Some(LoadingState::NotLoaded) | Some(LoadingState::Loading) => {
+            let item = ListItem::new("Loading…").style(Style::default().fg(t.dimmed));
+            let list = List::new(vec![item]).block(block);
+            frame.render_widget(list, area);
+        }
+        Some(LoadingState::Error(e)) => {
+            let item =
+                ListItem::new(format!("Error: {e}")).style(Style::default().fg(app.accent()));
+            let list = List::new(vec![item]).block(block);
+            frame.render_widget(list, area);
+        }
+        Some(LoadingState::Loaded(listing)) => {
+            let make_track_label = |s: &ratune_subsonic::Song| {
+                let dur = s
+                    .duration
+                    .map(|d| {
+                        let m = d / 60;
+                        let sec = d % 60;
+                        format!("  {m}:{sec:02}")
+                    })
+                    .unwrap_or_default();
+                format!("{}{}", s.title, dur)
+            };
+
+            let rows = folder_preview_rows(listing, app.search_filter.as_deref());
+
+            let visible: Vec<(FolderPreviewRow, String)> = rows
+                .into_iter()
+                .map(|row| {
+                    let label = match row {
+                        FolderPreviewRow::Dir(i) => {
+                            format!("📁 {}", listing.directories[i].1)
+                        }
+                        FolderPreviewRow::Track(i) => make_track_label(&listing.tracks[i]),
+                    };
+                    (row, label)
+                })
+                .collect();
+
+            let items: Vec<ListItem> = if visible.is_empty() {
+                vec![ListItem::new("Empty folder").style(Style::default().fg(t.dimmed))]
+            } else {
+                visible
+                    .iter()
+                    .map(|(_, label)| {
+                        ListItem::new(label.as_str()).style(Style::default().fg(t.foreground))
+                    })
+                    .collect()
+            };
+
+            let sel_ix = if visible.is_empty() {
+                None
+            } else {
+                Some(
+                    app.folders
+                        .preview_selected_row
+                        .min(visible.len().saturating_sub(1)),
+                )
+            };
+
+            let list = List::new(items)
+                .block(block)
+                .highlight_style(
+                    Style::default()
+                        .bg(app.accent())
+                        .fg(t.background)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .highlight_symbol("▶ ")
+                .style(Style::default().bg(t.surface));
+
+            let vh = area.height.saturating_sub(2) as usize;
+            let vh = vh.max(1);
+            app.browser_list_viewport_rows = vh;
+
+            let mut state = ListState::default();
+            if !visible.is_empty() {
+                if let Some(sel_ix) = sel_ix {
+                    FolderBrowseState::clamp_scroll(
+                        &mut app.folders.tracks_scroll,
+                        sel_ix,
+                        visible.len(),
+                        vh,
+                    );
+                    state = ListState::default().with_offset(app.folders.tracks_scroll);
+                    state.select(Some(sel_ix));
+                } else {
+                    let max_first = visible.len().saturating_sub(vh);
+                    app.folders.tracks_scroll = app.folders.tracks_scroll.min(max_first);
+                    state = ListState::default().with_offset(app.folders.tracks_scroll);
+                }
+            }
+            frame.render_stateful_widget(list, area, &mut state);
+        }
+    }
+}

--- a/ratune/src/ui/folders.rs
+++ b/ratune/src/ui/folders.rs
@@ -1,0 +1,149 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
+use ratatui::Frame;
+
+use crate::app::App;
+use crate::config::BrowseMode;
+use crate::state::{FolderBrowseState, LoadingState};
+
+pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
+    let t = &app.theme;
+    let border_color = if is_active { app.accent() } else { t.border };
+    let title_color = if is_active { app.accent() } else { t.dimmed };
+
+    let title = if app.browser_browse_mode == BrowseMode::Files {
+        if app.folders.path.is_empty() {
+            " Libraries ".to_string()
+        } else {
+            app.folders
+                .path
+                .last()
+                .map(|(_, n)| format!(" {n} "))
+                .unwrap_or_else(|| " Folders ".to_string())
+        }
+    } else {
+        " Folders ".to_string()
+    };
+
+    let border_style = if is_active {
+        Style::default()
+            .fg(border_color)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(border_color)
+    };
+    let block = Block::default()
+        .title(title)
+        .title_style(
+            Style::default()
+                .fg(title_color)
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(border_style)
+        .style(Style::default().bg(t.surface));
+
+    if app.browser_browse_mode != BrowseMode::Files {
+        let list =
+            List::new(vec![ListItem::new("—").style(Style::default().fg(t.dimmed))]).block(block);
+        frame.render_widget(list, area);
+        return;
+    }
+
+    let labels: Vec<String> = if app.folders.path.is_empty() {
+        match &app.folders.roots {
+            LoadingState::NotLoaded | LoadingState::Loading => {
+                vec!["Loading…".into()]
+            }
+            LoadingState::Error(e) => {
+                vec![format!("Error: {e}")]
+            }
+            LoadingState::Loaded(roots) => {
+                if roots.is_empty() {
+                    vec!["No music folders".into()]
+                } else if let Some(q) = &app.search_filter {
+                    roots
+                        .iter()
+                        .filter(|r| r.name.to_lowercase().contains(q.as_str()))
+                        .map(|r| r.name.clone())
+                        .collect()
+                } else {
+                    roots.iter().map(|r| r.name.clone()).collect()
+                }
+            }
+        }
+    } else {
+        match app.folders.current_listing() {
+            None | Some(LoadingState::NotLoaded) | Some(LoadingState::Loading) => {
+                vec!["Loading…".into()]
+            }
+            Some(LoadingState::Error(e)) => {
+                vec![format!("Error: {e}")]
+            }
+            Some(LoadingState::Loaded(listing)) => {
+                let mut out = vec!["..".to_string()];
+                let dirs: Vec<String> = if let Some(q) = &app.search_filter {
+                    listing
+                        .directories
+                        .iter()
+                        .filter(|(_, name)| name.to_lowercase().contains(q.as_str()))
+                        .map(|(_, name)| name.clone())
+                        .collect()
+                } else {
+                    listing
+                        .directories
+                        .iter()
+                        .map(|(_, name)| name.clone())
+                        .collect()
+                };
+                out.extend(dirs);
+                out
+            }
+        }
+    };
+
+    let items: Vec<ListItem> = labels
+        .iter()
+        .map(|label| {
+            let style = if label == ".." {
+                Style::default().fg(t.dimmed)
+            } else {
+                Style::default().fg(t.foreground)
+            };
+            ListItem::new(label.as_str()).style(style)
+        })
+        .collect();
+
+    let sel = app.folders.selected_dir.filter(|&s| s < labels.len());
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(
+            Style::default()
+                .bg(app.accent())
+                .fg(t.background)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ")
+        .style(Style::default().bg(t.surface));
+
+    let vh = area.height.saturating_sub(2) as usize;
+    let vh = vh.max(1);
+    app.browser_list_viewport_rows = vh;
+
+    let mut state = ListState::default();
+    if !labels.is_empty() {
+        if let Some(sel_ix) = sel {
+            FolderBrowseState::clamp_scroll(&mut app.folders.dirs_scroll, sel_ix, labels.len(), vh);
+            state = ListState::default().with_offset(app.folders.dirs_scroll);
+            state.select(Some(sel_ix));
+        } else {
+            let max_first = labels.len().saturating_sub(vh);
+            app.folders.dirs_scroll = app.folders.dirs_scroll.min(max_first);
+            state = ListState::default().with_offset(app.folders.dirs_scroll);
+        }
+    }
+    frame.render_stateful_widget(list, area, &mut state);
+}

--- a/ratune/src/ui/mod.rs
+++ b/ratune/src/ui/mod.rs
@@ -2,6 +2,8 @@ pub mod albums;
 pub mod art_prepare;
 pub mod artists;
 pub mod browser;
+pub mod folder_tracks;
+pub mod folders;
 pub mod home_tab;
 pub mod kitty_art;
 pub mod layout;

--- a/ratune/src/ui/popup.rs
+++ b/ratune/src/ui/popup.rs
@@ -23,6 +23,10 @@ fn sections() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("Shift-Tab", "Previous tab"),
                 ("/", "Search current column"),
                 ("Enter", "Select / expand"),
+                (
+                    "Ctrl+b",
+                    "Browse: toggle folder view (if enabled in config)",
+                ),
             ],
         ),
         (

--- a/ratune/src/ui/terminal_palette.rs
+++ b/ratune/src/ui/terminal_palette.rs
@@ -238,7 +238,11 @@ fn query_tty_raw(query: &str) -> Option<String> {
     use std::io::{Read, Write};
     use std::time::{Duration, Instant};
 
-    let mut tty = OpenOptions::new().read(true).write(true).open("/dev/tty").ok()?;
+    let mut tty = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
     if crossterm::terminal::enable_raw_mode().is_err() {
         return None;
     }

--- a/ratune/src/ui/visualizer.rs
+++ b/ratune/src/ui/visualizer.rs
@@ -262,13 +262,7 @@ fn color_for_row(
                 return parse_color_spec(&colors[0], accent);
             }
             let parsed: Vec<Color> = colors.iter().map(|c| parse_color_spec(c, accent)).collect();
-            gradient_color(
-                &parsed,
-                row,
-                height,
-                gradient_rgb_cache,
-                dither_col,
-            )
+            gradient_color(&parsed, row, height, gradient_rgb_cache, dither_col)
         }
         _ => accent, // "accent"
     }
@@ -299,17 +293,16 @@ fn gradient_color(
 }
 
 /// Bayer 4×4 for ordered dither when OSC readback is missing or incomplete.
-const BAYER4: [[u8; 4]; 4] = [
-    [0, 8, 2, 10],
-    [12, 4, 14, 6],
-    [3, 11, 1, 9],
-    [15, 7, 13, 5],
-];
+const BAYER4: [[u8; 4]; 4] = [[0, 8, 2, 10], [12, 4, 14, 6], [3, 11, 1, 9], [15, 7, 13, 5]];
 
 #[inline]
 fn dither_two_colors(a: Color, b: Color, frac: f32, row: usize, col: usize) -> Color {
     let m = BAYER4[row % 4][col % 4] as f32;
-    if frac * 16.0 > m { b } else { a }
+    if frac * 16.0 > m {
+        b
+    } else {
+        a
+    }
 }
 
 fn lerp_color(


### PR DESCRIPTION
Add folder navigation to browser tab. Addresses #5.

User can switch between folder browsing and artist browsing using ctrl+b (default) if folder browsing is enabled.

Tested in Navidrome and Gonic. Gonic used to test multi-level folder layouts.

See docs/sample-config.toml for more details.