### PR TITLE
feat: add password_command as option in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,18 +150,38 @@ Press `q` or Esc to exit.
 
 On first start, ratune creates a short default file at `~/.config/ratune/config.toml` (server fields plus common UI defaults). For every key with comments, use the sample file and copy the sections you need: [`docs/sample-config.toml`](docs/sample-config.toml).
 
-Set Subsonic URL and username. For the secret you can either put it in the file (**plaintext**) or leave **`password` empty** (**default**) and use the OS keyring:
+Set Subsonic **url** and **username**, then choose how to supply the secret (most secure first):
 
-**Plaintext in config:**
+1. **OS keyring (default)** — leave `password = ""` or remove field entirely.
+2. **`password_command`** — run a shell command; stdout is the secret (e.g. `secret-tool`, `pass`, KeePassXC CLI).
+3. **Plaintext** — `password = "..."` in the file, or env vars (convenient for scripts; avoid in shared configs).
+
+**Keyring:** leave `password` empty. Ratune uses [`keyring-core`](https://crates.io/crates/keyring-core) with a platform store: [**kernel keyutils**](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/) on Linux (no Secret Service or gnome-keyring), **Keychain** on macOS, **Credential Manager** on Windows. On first run you are prompted once ([inquire](https://crates.io/crates/inquire)); the secret is stored under service **`ratune`** and user **`{url}|{username}`** — not in `config.toml`. Linux keys live in the kernel keyring ([persistence](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/#persistence)); a reboot may require entering the secret again. If the store is unavailable (e.g. container), you get a one-time session prompt — use **`password_command`** or **`SUBSONIC_PASS`** instead.
 
 ```toml
 [server]
 url = "https://your-navidrome.example.com"
 username = "you"
-password = "your_password"
+password = ""
 ```
 
-**Keyring (default starter config):** leave `password = ""`. The app uses [`keyring-core`](https://crates.io/crates/keyring-core) with a platform store: [**kernel keyutils**](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/) on Linux (no Secret Service, D-Bus, or gnome-keyring), **Keychain** on macOS, **Credential Manager** on Windows. Linux uses the in-kernel keyring ([persistence and lifetimes](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/#persistence)); a reboot clears keys, so you may be prompted again after restart. On first run you are prompted (via [inquire](https://crates.io/crates/inquire)); the secret is stored under service **`ratune`** and user **`{url}|{username}`** (not in `config.toml`). If the store cannot be opened (e.g. restricted container), you get a session-only prompt — use **`SUBSONIC_PASS`** or **`password`** in config. On macOS/Windows you can remove the saved login from the usual credential UI; on Linux, clearing happens on reboot or when kernel keyring entries expire per the docs linked above.
+**External secret store (`password_command`):** when you already use a wallet (e.g. GNOME Keyring via `secret-tool`, `pass`, KeePassXC):
+
+```toml
+[server]
+url = "https://your-navidrome.example.com"
+username = "you"
+password = ""
+password_command = "secret-tool lookup --label=ratune service subsonic user you"
+```
+
+The command runs under `/bin/sh -c` on Unix (or `cmd /C` on Windows); only trimmed stdout is used. Plaintext `password` or `SUBSONIC_PASS` take precedence if set.
+
+**Plaintext:**
+
+```toml
+password = "your_password"
+```
 
 Subsonic auth uses a random salt per request and `MD5(secret + salt)` ([Navidrome / Subsonic API](https://www.navidrome.org/docs/developers/subsonic-api/)).
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Set Subsonic **url** and **username**, then choose how to supply the secret (mos
 [server]
 url = "https://your-navidrome.example.com"
 username = "you"
-password = ""
+password = "" # or remove entirely
 ```
 
 **External secret store (`password_command`):** when you already use a wallet (e.g. GNOME Keyring via `secret-tool`, `pass`, KeePassXC):
@@ -171,7 +171,6 @@ password = ""
 [server]
 url = "https://your-navidrome.example.com"
 username = "you"
-password = ""
 password_command = "secret-tool lookup --label=ratune service subsonic user you"
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,13 +150,17 @@ Press `q` or Esc to exit.
 
 On first start, ratune creates a short default file at `~/.config/ratune/config.toml` (server fields plus common UI defaults). For every key with comments, use the sample file and copy the sections you need: [`docs/sample-config.toml`](docs/sample-config.toml).
 
+### Connecting
+
 Set Subsonic **url** and **username**, then choose how to supply the secret (most secure first):
 
 1. **OS keyring (default)** — leave `password = ""` or remove field entirely.
 2. **`password_command`** — run a shell command; stdout is the secret (e.g. `secret-tool`, `pass`, KeePassXC CLI).
 3. **Plaintext** — `password = "..."` in the file, or env vars (convenient for scripts; avoid in shared configs).
 
-**Keyring:** leave `password` empty. Ratune uses [`keyring-core`](https://crates.io/crates/keyring-core) with a platform store: [**kernel keyutils**](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/) on Linux (no Secret Service or gnome-keyring), **Keychain** on macOS, **Credential Manager** on Windows. On first run you are prompted once ([inquire](https://crates.io/crates/inquire)); the secret is stored under service **`ratune`** and user **`{url}|{username}`** — not in `config.toml`. Linux keys live in the kernel keyring ([persistence](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/#persistence)); a reboot may require entering the secret again. If the store is unavailable (e.g. container), you get a one-time session prompt — use **`password_command`** or **`SUBSONIC_PASS`** instead.
+#### Keyring
+
+Leave `password` empty. Ratune uses [`keyring-core`](https://crates.io/crates/keyring-core) with a platform store: [**kernel keyutils**](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/) on Linux (no Secret Service or gnome-keyring), **Keychain** on macOS, **Credential Manager** on Windows. On first run you are prompted once ([inquire](https://crates.io/crates/inquire)); the secret is stored under service **`ratune`** and user **`{url}|{username}`** — not in `config.toml`. Linux keys live in the kernel keyring ([persistence](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/#persistence)); a reboot may require entering the secret again. If the store is unavailable (e.g. container), you get a one-time session prompt — use **`password_command`** or **`SUBSONIC_PASS`** instead.
 
 ```toml
 [server]
@@ -165,7 +169,9 @@ username = "you"
 password = "" # or remove entirely
 ```
 
-**External secret store (`password_command`):** when you already use a wallet (e.g. GNOME Keyring via `secret-tool`, `pass`, KeePassXC):
+#### External secret store (`password_command`)
+
+When you already use a wallet (e.g. `secret-tool`, `pass`, KeePassXC):
 
 ```toml
 [server]
@@ -176,7 +182,7 @@ password_command = "secret-tool lookup --label=ratune service subsonic user you"
 
 The command runs under `/bin/sh -c` on Unix (or `cmd /C` on Windows); only trimmed stdout is used. Plaintext `password` or `SUBSONIC_PASS` take precedence if set.
 
-**Plaintext:**
+#### Plaintext
 
 ```toml
 password = "your_password"

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -49,9 +49,15 @@
 #
 # url       — Base URL of the server (no trailing path required in most setups).
 # username  — Subsonic username.
-# password  — Subsonic password or token. Empty (default) = keyring-core + native store (Linux:
-#             kernel keyutils; macOS: Keychain; Windows: Credential Manager) when available; else a
-#             one-time session prompt. Non-empty = plaintext. SUBSONIC_PASS overrides.
+#
+# Secret (pick one):
+#   password = "" (default) — OS keyring via keyring-core (Linux: kernel keyutils; macOS:
+#             Keychain; Windows: Credential Manager). First run prompts once; stored as service
+#             "ratune", user "{url}|{username}". Needs url + username set.
+#   password_command — Shell command; stdout (trimmed) is the secret. Good for secret-tool,
+#             pass, KeePassXC CLI, etc. Example:
+#             password_command = "secret-tool lookup --label=ratune service subsonic user you"
+#   password — Plaintext in config (least secure). SUBSONIC_PASS / TERMUSIC_SUBSONIC_PASS override.
 #
 # Subsonic API auth (v1.16.1): random salt per request + MD5(secret+salt). See:
 # https://www.navidrome.org/docs/developers/subsonic-api/
@@ -60,6 +66,7 @@
 url = ""
 username = ""
 password = ""
+# password_command = "secret-tool lookup service subsonic user you"
 
 # -----------------------------------------------------------------------------
 # [player]

--- a/ratune-subsonic/src/error.rs
+++ b/ratune-subsonic/src/error.rs
@@ -18,6 +18,9 @@ impl std::fmt::Display for SubsonicError {
 
 impl std::error::Error for SubsonicError {}
 
+/// Subsonic API error code for invalid username or password.
+pub const AUTH_ERROR_CODE: u32 = 40;
+
 /// Check a raw `status`/`error` pair from any Subsonic response body.
 pub(crate) fn check_status(status: &str, error: Option<&SubsonicError>) -> Result<()> {
     if status == "ok" {
@@ -27,6 +30,29 @@ pub(crate) fn check_status(status: &str, error: Option<&SubsonicError>) -> Resul
         bail!("{e}");
     }
     bail!("Subsonic returned non-ok status: {status}");
+}
+
+/// Whether `err` (or its source chain) is a Subsonic credential failure (code 40 or equivalent message).
+pub fn is_auth_failure(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut cur = Some(err);
+    while let Some(e) = cur {
+        if let Some(se) = e.downcast_ref::<SubsonicError>() {
+            if se.code == AUTH_ERROR_CODE {
+                return true;
+            }
+        }
+        let msg = e.to_string().to_ascii_lowercase();
+        if msg.contains("wrong username")
+            || msg.contains("wrong password")
+            || msg.contains("invalid username")
+            || msg.contains("invalid password")
+            || msg.contains("bad credentials")
+        {
+            return true;
+        }
+        cur = e.source();
+    }
+    false
 }
 
 #[cfg(test)]
@@ -62,5 +88,25 @@ mod tests {
             message: "x".into(),
         };
         assert_eq!(e.to_string(), "Subsonic error 0: x");
+    }
+
+    #[test]
+    fn is_auth_failure_detects_code_40() {
+        let err = SubsonicError {
+            code: super::AUTH_ERROR_CODE,
+            message: "Wrong username or password.".into(),
+        };
+        let wrapped = anyhow::anyhow!(err);
+        assert!(super::is_auth_failure(wrapped.as_ref()));
+    }
+
+    #[test]
+    fn is_auth_failure_ignores_other_codes() {
+        let err = SubsonicError {
+            code: 70,
+            message: "not found".into(),
+        };
+        let wrapped = anyhow::anyhow!(err);
+        assert!(!super::is_auth_failure(wrapped.as_ref()));
     }
 }

--- a/ratune-subsonic/src/lib.rs
+++ b/ratune-subsonic/src/lib.rs
@@ -6,7 +6,7 @@ pub use client::{
     fetch_all_library_songs, fetch_all_library_songs_with_options, fetch_library,
     fetch_songs_for_artist, FetchLibraryOptions, SubsonicClient, DEFAULT_SERVER_URL,
 };
-pub use error::SubsonicError;
+pub use error::{is_auth_failure, SubsonicError, AUTH_ERROR_CODE};
 pub use models::{
     music_library_root_cache_key, parse_music_library_root_folder_id, Album, Artist, ArtistIndex,
     Artists, DirectoryChild, Indexes, LyricLine, MusicDirectory, MusicFolder, Playlist,

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -661,10 +661,14 @@ struct ServerSection {
     url: String,
     #[serde(default)]
     username: String,
-    /// Plain Subsonic password or token. Leave empty (default) to use the OS keyring: prompted
-    /// once ([`inquire`]), then stored under service `ratune` and user `{url}|{username}`.
+    /// Plain Subsonic password or token (least secure). Prefer empty `password` with OS keyring
+    /// or `password_command`. `SUBSONIC_PASS` overrides this field.
     #[serde(default)]
     password: String,
+    /// Shell command whose stdout is the Subsonic secret (trimmed). Used when `password` is empty.
+    /// Example: `secret-tool lookup --label=ratune service subsonic`.
+    #[serde(default)]
+    password_command: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -823,7 +827,7 @@ impl Config {
 
         let subsonic_pass = resolve_subsonic_secret(&file_cfg.server).with_context(|| {
             format!(
-                "Subsonic credentials failed (config {}). Hint: with password empty you need [server].url, [server].username, a working OS keyring, and a TTY for the first-time password prompt.",
+                "Subsonic credentials failed (config {}). Hint: set [server].password_command, leave password empty for the OS keyring (needs url + username + TTY on first run), or set SUBSONIC_PASS.",
                 config_path.display()
             )
         })?;
@@ -832,8 +836,8 @@ impl Config {
         if subsonic_pass.is_empty() {
             bail!(
                 "No Subsonic password configured.\n\
-                 Set [server].password in {} or SUBSONIC_PASS / TERMUSIC_SUBSONIC_PASS,\n\
-                 or leave password empty and use the keyring prompt (needs url + username).",
+                 In {} set [server].password_command, SUBSONIC_PASS / TERMUSIC_SUBSONIC_PASS,\n\
+                 [server].password (plaintext), or leave password empty for the keyring (needs url + username).",
                 config_path.display()
             );
         }
@@ -1324,30 +1328,82 @@ fn subsonic_keyring_user(server_url: &str, username: &str) -> String {
     format!("{}|{}", server_url.trim_end_matches('/'), username.trim())
 }
 
-/// Plaintext `[server].password` or env `SUBSONIC_PASS` wins; otherwise OS keyring (`ratune` /
-/// `subsonic_keyring_user`) or interactive prompt via [`inquire`]. If the keyring is unavailable
-/// (e.g. no Secret Service / D-Bus), prompt once and keep the secret in memory for this process only.
+/// Resolution order: plaintext `[server].password` (incl. env `SUBSONIC_PASS`), then
+/// `[server].password_command`, then OS keyring (`ratune` / `subsonic_keyring_user`) or
+/// interactive prompt via [`inquire`].
 fn resolve_subsonic_secret(server: &ServerSection) -> Result<String> {
     let pass = server.password.trim();
     if !pass.is_empty() {
         return Ok(pass.to_string());
     }
 
+    let cmd = server.password_command.trim();
+    if !cmd.is_empty() {
+        return run_password_command(cmd);
+    }
+
+    resolve_subsonic_secret_from_keyring(server)
+}
+
+fn run_password_command(shell_cmd: &str) -> Result<String> {
+    let output = {
+        #[cfg(unix)]
+        {
+            std::process::Command::new("sh")
+                .arg("-c")
+                .arg(shell_cmd)
+                .output()
+        }
+        #[cfg(windows)]
+        {
+            std::process::Command::new("cmd")
+                .args(["/C", shell_cmd])
+                .output()
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            anyhow::bail!("password_command is not supported on this platform");
+        }
+    }
+    .with_context(|| format!("running [server].password_command: {shell_cmd}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let hint = stderr.trim();
+        bail!(
+            "[server].password_command exited with {}: {}",
+            output.status,
+            if hint.is_empty() { "(no stderr)" } else { hint }
+        );
+    }
+
+    let secret = String::from_utf8(output.stdout)
+        .context("password_command stdout is not valid UTF-8")?
+        .trim()
+        .to_string();
+    if secret.is_empty() {
+        bail!("[server].password_command produced empty output");
+    }
+    Ok(secret)
+}
+
+/// OS keyring or one-time [`inquire`] prompt when `password` and `password_command` are empty.
+fn resolve_subsonic_secret_from_keyring(server: &ServerSection) -> Result<String> {
     let url = server.url.trim();
     let user = server.username.trim();
     if url.is_empty() && user.is_empty() {
         bail!(
-            "With an empty [server].password, you must set [server].url and [server].username (or SUBSONIC_URL and SUBSONIC_USER) for keyring auth — both are still empty."
+            "With empty [server].password and no password_command, set [server].url and [server].username (or SUBSONIC_URL and SUBSONIC_USER) for keyring auth — both are still empty."
         );
     }
     if url.is_empty() {
         bail!(
-            "With an empty [server].password, [server].url must be set (or SUBSONIC_URL) for keyring auth."
+            "With empty [server].password and no password_command, [server].url must be set (or SUBSONIC_URL) for keyring auth."
         );
     }
     if user.is_empty() {
         bail!(
-            "With an empty [server].password, [server].username must be set (or SUBSONIC_USER) for keyring auth."
+            "With empty [server].password and no password_command, [server].username must be set (or SUBSONIC_USER) for keyring auth."
         );
     }
 
@@ -1377,7 +1433,7 @@ fn resolve_subsonic_secret(server: &ServerSection) -> Result<String> {
             eprintln!(
                 "warning: keyring store is not available ({e}).\n\
                  Using a one-time password prompt; the secret is not saved and applies only to this run.\n\
-                 To persist without typing each time: set [server].password or SUBSONIC_PASS."
+                 To persist without typing each time: set [server].password_command, [server].password, or SUBSONIC_PASS."
             );
             inquire_subsonic_password_session()
         }
@@ -1475,6 +1531,34 @@ password = "secret"
         assert_eq!(fc.server.url, "http://music.example:4533");
         assert_eq!(fc.server.username, "alice");
         assert_eq!(fc.server.password, "secret");
+    }
+
+    #[test]
+    fn parses_password_command() {
+        let text = r#"
+[server]
+password_command = "secret-tool lookup service ratune"
+"#;
+        let fc: FileConfig = toml::from_str(text).expect("toml");
+        assert_eq!(
+            fc.server.password_command,
+            "secret-tool lookup service ratune"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn password_command_shell_output() {
+        let server = ServerSection {
+            url: String::new(),
+            username: String::new(),
+            password: String::new(),
+            password_command: "printf '%s' 'from-cmd'".into(),
+        };
+        assert_eq!(
+            resolve_subsonic_secret(&server).expect("command"),
+            "from-cmd"
+        );
     }
 
     #[test]

--- a/ratune/src/keyring_init.rs
+++ b/ratune/src/keyring_init.rs
@@ -12,7 +12,7 @@ pub fn install_default_keyring_store() {
             Err(e) => {
                 eprintln!(
                     "warning: could not open Linux kernel keyutils store: {e}\n\
-                     Keyring storage disabled for this run — use a session password or [server].password / SUBSONIC_PASS."
+                     Keyring storage disabled for this run — use password_command, a session password, [server].password, or SUBSONIC_PASS."
                 );
             }
         }
@@ -49,7 +49,7 @@ pub fn install_default_keyring_store() {
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
         eprintln!(
-            "warning: no keyring backend is bundled for this OS; use [server].password or SUBSONIC_PASS."
+            "warning: no keyring backend is bundled for this OS; use [server].password_command, [server].password, or SUBSONIC_PASS."
         );
     }
 }

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -53,6 +53,21 @@ pub async fn run() -> Result<()> {
     });
     let mut app = App::new(config)?;
 
+    if let Err(e) = app.subsonic.ping().await {
+        eprintln!(
+            "error: could not connect to Subsonic server at {}",
+            app.config.subsonic_url
+        );
+        if ratune_subsonic::is_auth_failure(e.as_ref()) {
+            eprintln!(
+                "Authentication failed (wrong username or password).\n\
+                 Check [server] url, username, password, password_command, OS keyring, or SUBSONIC_PASS."
+            );
+        }
+        eprintln!("{e:#}");
+        process::exit(1);
+    }
+
     // Detect tmux first: $TMUX is set when running inside a tmux session.
     app.in_tmux = std::env::var("TMUX").is_ok();
     if app.in_tmux {


### PR DESCRIPTION
Adds `password_command` as an option. See #11.

User can set `password_command` in config to pipe any command to password output.

Example:
```bash
password_command= 'secret-tool lookup user "acmagn" service "subsonic"'
```

Change also includes update to README to put less emphasis on plaintext password option, encouraging users to use more secure options.