### PR TITLE
Feat/scrobbling support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,6 +2474,7 @@ dependencies = [
  "ratatui",
  "ratatui-image",
  "ratune-player",
+ "ratune-scrobble",
  "ratune-subsonic",
  "reqwest",
  "rustfft",
@@ -2492,6 +2493,17 @@ dependencies = [
  "anyhow",
  "reqwest",
  "rodio",
+]
+
+[[package]]
+name = "ratune-scrobble"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "md5",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["ratune-subsonic", "ratune-player", "ratune"]
+members = ["ratune-subsonic", "ratune-player", "ratune-scrobble", "ratune"]
 resolver = "2"
 
 # https://github.com/crate-ci/cargo-release — GitHub/binary releases only until you publish to crates.io.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Ratune was built to bring together a combination of features often missing from 
 - **Folder navigation**: Optional Browse layout that follows server music folders for servers that provide it.
 - **Customization**: Keybinds, theme, layout, now-playing lines, queue row template inspired by ncmpcpp.
 - **Integration**: Linux MPRIS (media keys, `playerctl`).
+- **Scrobbling**: Last.fm and Libre.fm (Audioscrobbler), plus optional Subsonic `/scrobble` for Navidrome play counts — no MPRIS guessing; Ratune owns playback.
 
 ---
 
@@ -240,6 +241,70 @@ folder_navigation = true
 
 **Toggle at runtime:** default **`Ctrl+b`** (`toggle_folder_browse` in `[keybinds]`). Switches between folder view and artist browsing and jumps to the Browse tab. If you start in `files` mode, the first toggle to artists loads the artist list if it was not fetched yet.
 
+### Scrobbling
+
+Ratune can scrobble listens to Last.fm or Libre.fm and optionally notify your Subsonic server so Navidrome records play counts. Because Ratune controls playback directly, scrobbles are based on actual listen progress — not MPRIS metadata.
+
+Full reference: [`[scrobble]`](docs/sample-config.toml) in the sample config.
+
+#### Enable
+
+Register an API account at [Last.fm](https://www.last.fm/api/account/create) (or Libre.fm equivalent), then add a `[scrobble]` block. 
+
+```toml
+[scrobble]
+enabled = true
+service = "lastfm"   # or "librefm"
+api_key = "your_application_key"
+scrobble_to_server = true   # Subsonic /scrobble (default: true; works without Last.fm)
+```
+
+Same options for secret handling as Subsonic password are provided.
+
+#### keyring or secret commands
+
+To not store secrets in the file (synced dotfiles, shared machines, etc.), leave `api_secret` / `session_key` empty and use either command in config or ratune functions to save to the keyring.
+
+| Secret | Resolution order |
+|--------|------------------|
+| `api_secret` | config → `api_secret_command` → OS keyring (`lastfm\|api_secret`) |
+| `session_key` | config → `session_key_command` → OS keyring (`lastfm\|session`) |
+
+Keyring entries use service **`ratune`**. Env vars (`LASTFM_API_SECRET`, `LASTFM_SESSION_KEY`, …) override the file, same as Subsonic.
+
+```sh
+# save directly to keyring
+ratune scrobble-api-secret --save-keyring
+ratune scrobble-auth --save-keyring
+```
+
+Without `--save-keyring`, each command prints the value to paste into config instead.
+
+#### plaintext
+
+You can optionally store either/both of these as plaintext instead.
+
+```toml
+[scrobble]
+enabled = true
+service = "lastfm"   # or "librefm"
+api_key = "your_application_key"
+api_secret = "your_shared_secret"
+session_key = "your_session_key"   # from `ratune scrobble-auth`
+scrobble_to_server = true   # Subsonic /scrobble (default: true; works without Last.fm)
+```
+
+Get `session_key` once with `ratune scrobble-auth` (prints the key for config unless you pass `--save-keyring`).
+
+#### Behaviour
+
+- **Now playing** is sent when a track starts.
+- **Scrobble** fires at min(`min_percent`% of track length, `max_listen_seconds`). Defaults for Last.fm: 50%, 4 minutes. Tracks ≤ `min_track_seconds` (default 30 s) are skipped.
+- **Subsonic scrobble** (if enabled) uses a separate local threshold (default: 50%, 30 s cap).
+- Both sets of thresholds are optional under `[scrobble.thresholds.local]` and `[scrobble.thresholds.audioscrobbler]` — see the sample config. Audioscrobbler defaults follow [Last.fm’s scrobbling rules](https://www.last.fm/api/scrobbling); deviating may cause ignored scrobbles.
+- Failed Last.fm submissions are queued in `~/.local/share/ratune/scrobble-queue.json` and retried on the next launch (entries older than 14 days are dropped).
+- The status bar shows the service name when scrobbling is enabled; a **✓** appears briefly after a successful submit. Pending queue items show as `Last.fm (N)`.
+
 ---
 
 ## Default keybinds
@@ -334,12 +399,13 @@ set -g focus-events on
 
 ## Project layout
 
-This repository is a Cargo workspace with three crates:
+This repository is a Cargo workspace with four crates:
 
 | Crate | Role |
 | --- | --- |
-| [`ratune`](ratune/) | TUI, event loop, state, art, fzf, MPRIS |
+| [`ratune`](ratune/) | TUI, event loop, state, art, fzf, MPRIS, scrobbling |
 | [`ratune-subsonic`](ratune-subsonic/) | Subsonic HTTP client and models |
+| [`ratune-scrobble`](ratune-scrobble/) | Last.fm / Libre.fm Audioscrobbler client and play thresholds |
 | [`ratune-player`](ratune-player/) | Audio (rodio), gapless, sample tap for the visualizer |
 
 Details: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
@@ -353,6 +419,7 @@ Details: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 | `~/.config/ratune/config.toml` | Config |
 | `~/.config/ratune/state.json` | UI state, queue, browser position |
 | `~/.local/share/ratune/history.json` | Play history |
+| `~/.local/share/ratune/scrobble-queue.json` | Pending Last.fm scrobbles (offline retry) |
 | `~/.cache/ratune/` | Track cache, library index JSON, etc. |
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,16 +1,19 @@
 # Architecture
 
-ratune is a Cargo workspace with three crates:
+ratune is a Cargo workspace with four crates:
 
 | Crate | Role |
 |-------|------|
 | `ratune-subsonic` | Subsonic API client — authentication, endpoints, models |
+| `ratune-scrobble` | Last.fm / Libre.fm Audioscrobbler client, auth helpers, listen thresholds |
 | `ratune-player` | Audio engine — rodio-based playback on a dedicated thread, gapless transitions, sample tap for FFT |
-| `ratune` | Binary — TUI, event loop, state management, Kitty graphics |
+| `ratune` | Binary — TUI, event loop, state management, Kitty graphics, scrobble integration |
 
 ## Crate responsibilities
 
-**`ratune-subsonic`** is a pure HTTP client with no TUI or audio dependencies. It handles Subsonic API authentication (MD5 token + salt per request), and exposes endpoints for browsing artists/albums/tracks, streaming URLs, search, cover art, and playlist operations.
+**`ratune-subsonic`** is a pure HTTP client with no TUI or audio dependencies. It handles Subsonic API authentication (MD5 token + salt per request), and exposes endpoints for browsing artists/albums/tracks, streaming URLs, search, cover art, playlist operations, and server-side scrobbling.
+
+**`ratune-scrobble`** implements the Audioscrobbler API v2.0 (Last.fm and Libre.fm): signed POST requests, browser auth (`auth.getToken` / `auth.getSession`), `track.updateNowPlaying`, and `track.scrobble`. Shared threshold logic distinguishes Ratune local listens from Last.fm scrobble rules.
 
 **`ratune-player`** runs the audio engine on its own `std::thread` (not tokio). It communicates with the TUI through two channels:
 
@@ -22,6 +25,8 @@ Progress events fire on a ~500ms tick. Gapless playback is handled via `EnqueueN
 A `SampleTap` wrapper copies decoded samples into a shared ring buffer for FFT analysis by the visualizer.
 
 **`ratune`** (binary) owns the `App` struct, which holds all application state. The event loop runs on tokio and uses `select!` to race crossterm key/mouse events, player events, library update channels, and timer ticks.
+
+Scrobbling hooks into `PlayerEvent::TrackStarted` (now playing) and progress ticks (listen thresholds). Failed Audioscrobbler submissions are persisted under `~/.local/share/ratune/scrobble-queue.json` and retried on startup via background tokio tasks, using the same `LibraryUpdate` channel as other network work.
 
 ## Key patterns
 

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -415,23 +415,41 @@ max_size_gb = 2.0
 #           base URL differs.
 #
 # Credentials for Audioscrobbler (all required when enabled):
-#   api_key     — Application id (semi-public; fine in config)
-#   api_secret  — Shared secret that signs POST requests (keep out of config if possible)
+#   api_key     — From https://www.last.fm/api/account/create (or Libre.fm equivalent)
+#   api_secret  — Shared secret paired with api_key (signs POST requests)
 #   session_key — Per-user token from `ratune scrobble-auth`
 #
-# api_secret resolution: api_secret → api_secret_command → OS keyring
-#   (service "ratune", user "lastfm|api_secret" or "librefm|api_secret").
-# session_key resolution: session_key → session_key_command → OS keyring
-#   (service "ratune", user "lastfm|session" or "librefm|session").
+# Plaintext in this file is fine for personal setups (same idea as [server].password).
+# Prefer keyring or *_command when the config is synced or shared.
 #
-# Run once after setting api_key:
-#   ratune scrobble-api-secret --save-keyring   # stores api_secret in OS keyring
-#   ratune scrobble-api-secret                  # prints api_secret for config.toml
-#   ratune scrobble-auth --save-keyring         # stores session key in OS keyring
-#   ratune scrobble-auth                        # prints session_key for config.toml
+# Resolution order (first match wins):
+#   api_secret  — api_secret → api_secret_command → OS keyring (lastfm|api_secret)
+#   session_key — session_key → session_key_command → OS keyring (lastfm|session)
+# Keyring service name is always "ratune".
+#
+# Quick start (all in config):
+#   api_key = "…"
+#   api_secret = "…"
+#   session_key = "…"    # from `ratune scrobble-auth` (no --save-keyring)
+#
+# Optional — keep secrets out of the file:
+#   ratune scrobble-api-secret --save-keyring
+#   ratune scrobble-auth --save-keyring
+#   # then leave api_secret / session_key empty and use command or keyring instead
 #
 # Failed scrobbles are queued in ~/.local/share/ratune/scrobble-queue.json
 # and retried on the next startup (entries older than 14 days are dropped).
+#
+# Optional listen thresholds (omit for defaults):
+#   [scrobble.thresholds.local] — history + Subsonic /scrobble
+#     min_percent = 50          # fraction of track length (1–100)
+#     max_listen_seconds = 30   # cap on listen time
+#   [scrobble.thresholds.audioscrobbler] — Last.fm / Libre.fm
+#     min_percent = 50
+#     max_listen_seconds = 240  # 4 minutes (Last.fm convention)
+#     min_track_seconds = 30    # skip tracks this long or shorter
+# WARNING: Audioscrobbler defaults match Last.fm’s documented rules; changing them may
+# cause the service to ignore scrobbles.
 #
 # Examples:
 #   api_secret_command = "secret-tool lookup service ratune user lastfm|api_secret"
@@ -451,8 +469,8 @@ max_size_gb = 2.0
 enabled = false
 service = "lastfm"
 # api_key = ""
-# api_secret = ""
-# api_secret_command = ""
-# session_key = ""
-# session_key_command = ""
+# api_secret = ""            # plaintext here is supported
+# session_key = ""           # from `ratune scrobble-auth`
+# api_secret_command = ""    # optional; checked if api_secret is empty
+# session_key_command = ""   # optional; checked if session_key is empty
 scrobble_to_server = true

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -403,3 +403,43 @@ notify_on_forced_index_refresh = true
 [cache]
 enabled = true
 max_size_gb = 2.0
+
+# -----------------------------------------------------------------------------
+# [scrobble] — Last.fm / Libre.fm + Subsonic play counts
+# -----------------------------------------------------------------------------
+#
+# Ratune owns playback, so scrobbling is reliable (no MPRIS guessing).
+#
+# enabled — Submit listens to Last.fm or Libre.fm. Default: false.
+# service — "lastfm" (default) or "librefm". Same Audioscrobbler API; only the
+#           base URL differs.
+#
+# Credentials for Audioscrobbler (all three required when enabled):
+#   api_key     — From https://www.last.fm/api/account/create (or Libre.fm equivalent)
+#   api_secret  — Shared secret paired with api_key (signs POST requests)
+#   session_key — From `ratune scrobble-auth` (browser flow) or auth.getSession
+#
+# Run once after setting api_key and api_secret:
+#   ratune scrobble-auth
+#
+# Prefer session_key_command over plaintext session_key (same idea as password_command):
+#   session_key_command = "secret-tool lookup service lastfm user you"
+#
+# Environment overrides (applied after the file):
+#   LASTFM_API_KEY / LIBREFM_API_KEY
+#   LASTFM_API_SECRET / LASTFM_SHARED_SECRET / LIBREFM_API_SECRET
+#   LASTFM_SESSION_KEY / LIBREFM_SESSION_KEY
+#
+# scrobble_to_server — When true (default), also call the Subsonic /scrobble REST
+#                      endpoint so Navidrome (etc.) records play counts. Uses the
+#                      local listen threshold (min(50%, 30 s)), independent of
+#                      Last.fm's min(50%, 4 min) rule.
+
+[scrobble]
+enabled = false
+service = "lastfm"
+# api_key = ""
+# api_secret = ""
+# session_key = ""
+# session_key_command = ""
+scrobble_to_server = true

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -414,16 +414,28 @@ max_size_gb = 2.0
 # service — "lastfm" (default) or "librefm". Same Audioscrobbler API; only the
 #           base URL differs.
 #
-# Credentials for Audioscrobbler (all three required when enabled):
-#   api_key     — From https://www.last.fm/api/account/create (or Libre.fm equivalent)
-#   api_secret  — Shared secret paired with api_key (signs POST requests)
-#   session_key — From `ratune scrobble-auth` (browser flow) or auth.getSession
+# Credentials for Audioscrobbler (all required when enabled):
+#   api_key     — Application id (semi-public; fine in config)
+#   api_secret  — Shared secret that signs POST requests (keep out of config if possible)
+#   session_key — Per-user token from `ratune scrobble-auth`
 #
-# Run once after setting api_key and api_secret:
-#   ratune scrobble-auth
+# api_secret resolution: api_secret → api_secret_command → OS keyring
+#   (service "ratune", user "lastfm|api_secret" or "librefm|api_secret").
+# session_key resolution: session_key → session_key_command → OS keyring
+#   (service "ratune", user "lastfm|session" or "librefm|session").
 #
-# Prefer session_key_command over plaintext session_key (same idea as password_command):
-#   session_key_command = "secret-tool lookup service lastfm user you"
+# Run once after setting api_key:
+#   ratune scrobble-api-secret --save-keyring   # stores api_secret in OS keyring
+#   ratune scrobble-api-secret                  # prints api_secret for config.toml
+#   ratune scrobble-auth --save-keyring         # stores session key in OS keyring
+#   ratune scrobble-auth                        # prints session_key for config.toml
+#
+# Failed scrobbles are queued in ~/.local/share/ratune/scrobble-queue.json
+# and retried on the next startup (entries older than 14 days are dropped).
+#
+# Examples:
+#   api_secret_command = "secret-tool lookup service ratune user lastfm|api_secret"
+#   session_key_command = "secret-tool lookup service ratune user lastfm|session"
 #
 # Environment overrides (applied after the file):
 #   LASTFM_API_KEY / LIBREFM_API_KEY
@@ -440,6 +452,7 @@ enabled = false
 service = "lastfm"
 # api_key = ""
 # api_secret = ""
+# api_secret_command = ""
 # session_key = ""
 # session_key_command = ""
 scrobble_to_server = true

--- a/ratune-player/src/lib.rs
+++ b/ratune-player/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod engine;
 pub mod queue;
-pub mod scrobble;
 pub mod stream;
 pub mod tap;
 

--- a/ratune-player/src/scrobble.rs
+++ b/ratune-player/src/scrobble.rs
@@ -1,1 +1,0 @@
-// Timing logic + Subsonic scrobble call — Phase 1

--- a/ratune-scrobble/Cargo.toml
+++ b/ratune-scrobble/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ratune-scrobble"
+version = "0.1.0"
+edition = "2021"
+description = "Audioscrobbler / Last.fm scrobbling for ratune"
+license = "MIT"
+repository = "https://github.com/acmagn/ratune"
+homepage = "https://github.com/acmagn/ratune"
+readme = "../README.md"
+keywords = ["lastfm", "librefm", "scrobble", "music"]
+categories = ["multimedia::audio", "api-bindings"]
+[package.metadata.release]
+release = false
+
+[dependencies]
+anyhow = "1"
+md5 = "0.7"
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/ratune-scrobble/src/auth.rs
+++ b/ratune-scrobble/src/auth.rs
@@ -1,0 +1,159 @@
+//! Browser authentication flow for obtaining a session key.
+
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Context, Result};
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::lastfm::{api_sig, ScrobbleService};
+
+/// Application credentials only — no session key yet.
+#[derive(Debug, Clone)]
+pub struct AuthClient {
+    http: Client,
+    api_key: String,
+    api_secret: String,
+    service: ScrobbleService,
+}
+
+impl AuthClient {
+    pub fn new(service: ScrobbleService, api_key: String, api_secret: String) -> Self {
+        Self {
+            http: Client::new(),
+            api_key,
+            api_secret,
+            service,
+        }
+    }
+
+    pub fn service(&self) -> ScrobbleService {
+        self.service
+    }
+
+    /// Step 1: request a short-lived token from the API.
+    pub async fn get_token(&self) -> Result<String> {
+        let mut params = BTreeMap::new();
+        params.insert("method".into(), "auth.getToken".into());
+        params.insert("api_key".into(), self.api_key.clone());
+        params.insert("format".into(), "json".into());
+
+        let body = self.post_signed(params).await?;
+        body.get("token")
+            .and_then(|t| t.as_str())
+            .map(str::to_string)
+            .context("auth.getToken response missing token")
+    }
+
+    /// Step 2: URL the user must open in a browser to approve the app.
+    pub fn authorize_url(&self, token: &str) -> String {
+        let base = match self.service {
+            ScrobbleService::LastFm => "https://www.last.fm/api/auth/",
+            ScrobbleService::LibreFm => "https://libre.fm/api/auth/",
+        };
+        format!("{base}?api_key={}&token={token}", self.api_key)
+    }
+
+    /// Step 3: exchange the approved token for a permanent session key.
+    pub async fn get_session(&self, token: &str) -> Result<AuthSession> {
+        let mut params = BTreeMap::new();
+        params.insert("method".into(), "auth.getSession".into());
+        params.insert("api_key".into(), self.api_key.clone());
+        params.insert("token".into(), token.to_string());
+        params.insert("format".into(), "json".into());
+
+        let body = self.post_signed(params).await?;
+        let session = body
+            .get("session")
+            .context("auth.getSession response missing session")?;
+        let key = session
+            .get("key")
+            .and_then(|k| k.as_str())
+            .context("session missing key")?
+            .to_string();
+        let name = session
+            .get("name")
+            .and_then(|n| n.as_str())
+            .unwrap_or("")
+            .to_string();
+        Ok(AuthSession { key, username: name })
+    }
+
+    async fn post_signed(&self, mut params: BTreeMap<String, String>) -> Result<Value> {
+        let sig = api_sig(&params, &self.api_secret);
+        params.insert("api_sig".into(), sig);
+
+        let resp = self
+            .http
+            .post(self.service.api_base())
+            .form(&params)
+            .send()
+            .await
+            .with_context(|| format!("POST {}", self.service.api_base()))?;
+
+        let status = resp.status();
+        let body: Value = resp
+            .json()
+            .await
+            .with_context(|| format!("parsing {} response", self.service.display_name()))?;
+
+        if let Some(err) = body.get("error") {
+            let code = err.as_i64().unwrap_or(-1);
+            let message = body
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            bail!(
+                "{} API error {code}: {message}",
+                self.service.display_name()
+            );
+        }
+
+        if !status.is_success() {
+            bail!(
+                "{} API HTTP {status}",
+                self.service.display_name()
+            );
+        }
+
+        Ok(body)
+    }
+}
+
+/// Result of a successful `auth.getSession` call.
+#[derive(Debug, Clone)]
+pub struct AuthSession {
+    pub key: String,
+    pub username: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorize_url_lastfm() {
+        let client = AuthClient::new(
+            ScrobbleService::LastFm,
+            "abc123".into(),
+            "secret".into(),
+        );
+        assert_eq!(
+            client.authorize_url("tok"),
+            "https://www.last.fm/api/auth/?api_key=abc123&token=tok"
+        );
+    }
+
+    #[test]
+    fn authorize_url_librefm() {
+        let client = AuthClient::new(
+            ScrobbleService::LibreFm,
+            "abc123".into(),
+            "secret".into(),
+        );
+        assert_eq!(
+            client.authorize_url("tok"),
+            "https://libre.fm/api/auth/?api_key=abc123&token=tok"
+        );
+    }
+}

--- a/ratune-scrobble/src/auth.rs
+++ b/ratune-scrobble/src/auth.rs
@@ -76,7 +76,10 @@ impl AuthClient {
             .and_then(|n| n.as_str())
             .unwrap_or("")
             .to_string();
-        Ok(AuthSession { key, username: name })
+        Ok(AuthSession {
+            key,
+            username: name,
+        })
     }
 
     async fn post_signed(&self, mut params: BTreeMap<String, String>) -> Result<Value> {
@@ -110,10 +113,7 @@ impl AuthClient {
         }
 
         if !status.is_success() {
-            bail!(
-                "{} API HTTP {status}",
-                self.service.display_name()
-            );
+            bail!("{} API HTTP {status}", self.service.display_name());
         }
 
         Ok(body)
@@ -133,11 +133,7 @@ mod tests {
 
     #[test]
     fn authorize_url_lastfm() {
-        let client = AuthClient::new(
-            ScrobbleService::LastFm,
-            "abc123".into(),
-            "secret".into(),
-        );
+        let client = AuthClient::new(ScrobbleService::LastFm, "abc123".into(), "secret".into());
         assert_eq!(
             client.authorize_url("tok"),
             "https://www.last.fm/api/auth/?api_key=abc123&token=tok"
@@ -146,11 +142,7 @@ mod tests {
 
     #[test]
     fn authorize_url_librefm() {
-        let client = AuthClient::new(
-            ScrobbleService::LibreFm,
-            "abc123".into(),
-            "secret".into(),
-        );
+        let client = AuthClient::new(ScrobbleService::LibreFm, "abc123".into(), "secret".into());
         assert_eq!(
             client.authorize_url("tok"),
             "https://libre.fm/api/auth/?api_key=abc123&token=tok"

--- a/ratune-scrobble/src/lastfm.rs
+++ b/ratune-scrobble/src/lastfm.rs
@@ -148,10 +148,7 @@ impl AudioscrobblerClient {
         }
 
         if !status.is_success() {
-            bail!(
-                "{} API HTTP {status}",
-                self.service.display_name()
-            );
+            bail!("{} API HTTP {status}", self.service.display_name());
         }
 
         Ok(())
@@ -190,8 +187,14 @@ mod tests {
 
     #[test]
     fn parses_service_names() {
-        assert_eq!(ScrobbleService::parse("Last.fm"), Some(ScrobbleService::LastFm));
-        assert_eq!(ScrobbleService::parse("librefm"), Some(ScrobbleService::LibreFm));
+        assert_eq!(
+            ScrobbleService::parse("Last.fm"),
+            Some(ScrobbleService::LastFm)
+        );
+        assert_eq!(
+            ScrobbleService::parse("librefm"),
+            Some(ScrobbleService::LibreFm)
+        );
         assert!(ScrobbleService::parse("spotify").is_none());
     }
 }

--- a/ratune-scrobble/src/lastfm.rs
+++ b/ratune-scrobble/src/lastfm.rs
@@ -1,0 +1,197 @@
+//! Last.fm / Libre.fm Audioscrobbler API v2.0 client.
+
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Context, Result};
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::track::TrackInfo;
+
+/// Which Audioscrobbler-compatible API endpoint to call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrobbleService {
+    LastFm,
+    LibreFm,
+}
+
+impl ScrobbleService {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "lastfm" | "last.fm" | "last_fm" => Some(Self::LastFm),
+            "librefm" | "libre.fm" | "libre_fm" => Some(Self::LibreFm),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn api_base(&self) -> &'static str {
+        match self {
+            Self::LastFm => "https://ws.audioscrobbler.com/2.0/",
+            Self::LibreFm => "https://libre.fm/2.0/",
+        }
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::LastFm => "Last.fm",
+            Self::LibreFm => "Libre.fm",
+        }
+    }
+}
+
+/// Authenticated client for `track.updateNowPlaying` and `track.scrobble`.
+#[derive(Debug, Clone)]
+pub struct AudioscrobblerClient {
+    http: Client,
+    api_key: String,
+    api_secret: String,
+    session_key: String,
+    service: ScrobbleService,
+}
+
+impl AudioscrobblerClient {
+    pub fn new(
+        service: ScrobbleService,
+        api_key: String,
+        api_secret: String,
+        session_key: String,
+    ) -> Self {
+        Self {
+            http: Client::new(),
+            api_key,
+            api_secret,
+            session_key,
+            service,
+        }
+    }
+
+    pub fn service(&self) -> ScrobbleService {
+        self.service
+    }
+
+    /// Announce the currently playing track (does not count as a scrobble).
+    pub async fn update_now_playing(&self, track: &TrackInfo) -> Result<()> {
+        let mut params = self.base_params("track.updateNowPlaying");
+        params.insert("artist".into(), track.artist.clone());
+        params.insert("track".into(), track.title.clone());
+        if let Some(ref album) = track.album {
+            if !album.is_empty() {
+                params.insert("album".into(), album.clone());
+            }
+        }
+        if let Some(n) = track.track_number {
+            params.insert("trackNumber".into(), n.to_string());
+        }
+        if let Some(d) = track.duration_secs {
+            params.insert("duration".into(), d.to_string());
+        }
+        self.post_signed(params).await
+    }
+
+    /// Submit a completed listen. `timestamp` is Unix seconds when playback started.
+    pub async fn scrobble(&self, track: &TrackInfo, timestamp: i64) -> Result<()> {
+        let mut params = self.base_params("track.scrobble");
+        params.insert("artist[0]".into(), track.artist.clone());
+        params.insert("track[0]".into(), track.title.clone());
+        params.insert("timestamp[0]".into(), timestamp.to_string());
+        if let Some(ref album) = track.album {
+            if !album.is_empty() {
+                params.insert("album[0]".into(), album.clone());
+            }
+        }
+        if let Some(n) = track.track_number {
+            params.insert("trackNumber[0]".into(), n.to_string());
+        }
+        if let Some(d) = track.duration_secs {
+            params.insert("duration[0]".into(), d.to_string());
+        }
+        self.post_signed(params).await
+    }
+
+    fn base_params(&self, method: &str) -> BTreeMap<String, String> {
+        let mut params = BTreeMap::new();
+        params.insert("method".into(), method.into());
+        params.insert("api_key".into(), self.api_key.clone());
+        params.insert("sk".into(), self.session_key.clone());
+        params.insert("format".into(), "json".into());
+        params
+    }
+
+    async fn post_signed(&self, mut params: BTreeMap<String, String>) -> Result<()> {
+        let sig = api_sig(&params, &self.api_secret);
+        params.insert("api_sig".into(), sig);
+
+        let resp = self
+            .http
+            .post(self.service.api_base())
+            .form(&params)
+            .send()
+            .await
+            .with_context(|| format!("POST {}", self.service.api_base()))?;
+
+        let status = resp.status();
+        let body: Value = resp
+            .json()
+            .await
+            .with_context(|| format!("parsing {} response", self.service.display_name()))?;
+
+        if let Some(err) = body.get("error") {
+            let code = err.as_i64().unwrap_or(-1);
+            let message = body
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            bail!(
+                "{} API error {code}: {message}",
+                self.service.display_name()
+            );
+        }
+
+        if !status.is_success() {
+            bail!(
+                "{} API HTTP {status}",
+                self.service.display_name()
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// MD5 signature required for all authenticated Last.fm POST requests.
+pub(crate) fn api_sig(params: &BTreeMap<String, String>, secret: &str) -> String {
+    let mut concat = String::new();
+    for (k, v) in params {
+        if k == "format" || k == "api_sig" {
+            continue;
+        }
+        concat.push_str(k);
+        concat.push_str(v);
+    }
+    concat.push_str(secret);
+    format!("{:x}", md5::compute(concat.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_sig_is_deterministic_and_excludes_format() {
+        let mut params = BTreeMap::new();
+        params.insert("api_key".into(), "myApiKey".into());
+        params.insert("method".into(), "auth.getSession".into());
+        params.insert("token".into(), "myToken".into());
+        params.insert("format".into(), "json".into());
+        let sig = api_sig(&params, "mySharedSecret");
+        assert_eq!(sig, "ad652a8ce50787750507e5686a235f01");
+        assert_eq!(sig, api_sig(&params, "mySharedSecret"));
+    }
+
+    #[test]
+    fn parses_service_names() {
+        assert_eq!(ScrobbleService::parse("Last.fm"), Some(ScrobbleService::LastFm));
+        assert_eq!(ScrobbleService::parse("librefm"), Some(ScrobbleService::LibreFm));
+        assert!(ScrobbleService::parse("spotify").is_none());
+    }
+}

--- a/ratune-scrobble/src/lib.rs
+++ b/ratune-scrobble/src/lib.rs
@@ -1,0 +1,11 @@
+//! Audioscrobbler scrobbling for Last.fm and Libre.fm, plus shared play-threshold logic.
+
+pub mod auth;
+pub mod lastfm;
+pub mod threshold;
+pub mod track;
+
+pub use auth::{AuthClient, AuthSession};
+pub use lastfm::{AudioscrobblerClient, ScrobbleService};
+pub use threshold::{audioscrobbler_eligible, play_threshold, ThresholdProfile};
+pub use track::TrackInfo;

--- a/ratune-scrobble/src/lib.rs
+++ b/ratune-scrobble/src/lib.rs
@@ -7,5 +7,7 @@ pub mod track;
 
 pub use auth::{AuthClient, AuthSession};
 pub use lastfm::{AudioscrobblerClient, ScrobbleService};
-pub use threshold::{audioscrobbler_eligible, play_threshold, ThresholdProfile};
+pub use threshold::{
+    audioscrobbler_eligible, play_threshold, AudioscrobblerRules, ListenThreshold,
+};
 pub use track::TrackInfo;

--- a/ratune-scrobble/src/threshold.rs
+++ b/ratune-scrobble/src/threshold.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+/// Which scrobbling rules to apply when deciding if a listen counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThresholdProfile {
+    /// Ratune local history and Subsonic server scrobble: min(50% of duration, 30 s).
+    Local,
+    /// Last.fm / Libre.fm (Audioscrobbler): min(50% of duration, 4 min).
+    Audioscrobbler,
+}
+
+/// Minimum playback time before a listen is recorded for `profile`.
+///
+/// When track duration is unknown, both profiles fall back to 30 seconds.
+pub fn play_threshold(total: Option<Duration>, profile: ThresholdProfile) -> Duration {
+    let cap = match profile {
+        ThresholdProfile::Local => Duration::from_secs(30),
+        ThresholdProfile::Audioscrobbler => Duration::from_secs(4 * 60),
+    };
+    match total {
+        Some(dur) => {
+            let half = dur / 2;
+            half.min(cap)
+        }
+        None => Duration::from_secs(30),
+    }
+}
+
+/// Audioscrobbler services ignore tracks that are 30 seconds or shorter.
+pub fn audioscrobbler_eligible(total: Option<Duration>) -> bool {
+    total.is_none_or(|d| d > Duration::from_secs(30))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_caps_at_thirty_seconds() {
+        let ten_min = Some(Duration::from_secs(600));
+        assert_eq!(
+            play_threshold(ten_min, ThresholdProfile::Local),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn audioscrobbler_caps_at_four_minutes() {
+        let ten_min = Some(Duration::from_secs(600));
+        assert_eq!(
+            play_threshold(ten_min, ThresholdProfile::Audioscrobbler),
+            Duration::from_secs(240)
+        );
+    }
+
+    #[test]
+    fn half_duration_when_shorter_than_cap() {
+        let three_min = Some(Duration::from_secs(180));
+        assert_eq!(
+            play_threshold(three_min, ThresholdProfile::Audioscrobbler),
+            Duration::from_secs(90)
+        );
+    }
+
+    #[test]
+    fn audioscrobbler_rejects_short_tracks() {
+        assert!(!audioscrobbler_eligible(Some(Duration::from_secs(30))));
+        assert!(audioscrobbler_eligible(Some(Duration::from_secs(31))));
+        assert!(audioscrobbler_eligible(None));
+    }
+}

--- a/ratune-scrobble/src/threshold.rs
+++ b/ratune-scrobble/src/threshold.rs
@@ -1,34 +1,71 @@
 use std::time::Duration;
 
-/// Which scrobbling rules to apply when deciding if a listen counts.
+/// When a listen counts: min(fraction of track length, max_listen cap).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ThresholdProfile {
-    /// Ratune local history and Subsonic server scrobble: min(50% of duration, 30 s).
-    Local,
-    /// Last.fm / Libre.fm (Audioscrobbler): min(50% of duration, 4 min).
-    Audioscrobbler,
+pub struct ListenThreshold {
+    /// Whole-number percent of track duration (1–100). Default convention: 50.
+    pub min_percent: u8,
+    /// Upper cap on listen time before counting. Default varies by use case.
+    pub max_listen: Duration,
 }
 
-/// Minimum playback time before a listen is recorded for `profile`.
-///
-/// When track duration is unknown, both profiles fall back to 30 seconds.
-pub fn play_threshold(total: Option<Duration>, profile: ThresholdProfile) -> Duration {
-    let cap = match profile {
-        ThresholdProfile::Local => Duration::from_secs(30),
-        ThresholdProfile::Audioscrobbler => Duration::from_secs(4 * 60),
-    };
-    match total {
-        Some(dur) => {
-            let half = dur / 2;
-            half.min(cap)
+impl ListenThreshold {
+    pub const fn local_default() -> Self {
+        Self {
+            min_percent: 50,
+            max_listen: Duration::from_secs(30),
         }
-        None => Duration::from_secs(30),
+    }
+
+    pub const fn audioscrobbler_default() -> Self {
+        Self {
+            min_percent: 50,
+            max_listen: Duration::from_secs(4 * 60),
+        }
     }
 }
 
-/// Audioscrobbler services ignore tracks that are 30 seconds or shorter.
-pub fn audioscrobbler_eligible(total: Option<Duration>) -> bool {
-    total.is_none_or(|d| d > Duration::from_secs(30))
+impl Default for ListenThreshold {
+    fn default() -> Self {
+        Self::local_default()
+    }
+}
+
+/// Last.fm / Libre.fm eligibility and listen threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AudioscrobblerRules {
+    pub listen: ListenThreshold,
+    /// Tracks must be longer than this to scrobble (Last.fm convention: 30 s).
+    pub min_track_length: Duration,
+}
+
+impl Default for AudioscrobblerRules {
+    fn default() -> Self {
+        Self {
+            listen: ListenThreshold::audioscrobbler_default(),
+            min_track_length: Duration::from_secs(30),
+        }
+    }
+}
+
+/// Minimum playback time before a listen is recorded.
+///
+/// When track duration is unknown, falls back to `rules.max_listen`.
+pub fn play_threshold(total: Option<Duration>, rules: ListenThreshold) -> Duration {
+    let percent = rules.min_percent.clamp(1, 100);
+    let cap = rules.max_listen;
+    match total {
+        Some(dur) => {
+            let secs = dur.as_secs().saturating_mul(u64::from(percent)) / 100;
+            Duration::from_secs(secs).min(cap)
+        }
+        None => cap,
+    }
+}
+
+/// Whether a track is long enough to submit to Audioscrobbler services.
+pub fn audioscrobbler_eligible(total: Option<Duration>, rules: AudioscrobblerRules) -> bool {
+    total.is_none_or(|d| d > rules.min_track_length)
 }
 
 #[cfg(test)]
@@ -39,7 +76,7 @@ mod tests {
     fn local_caps_at_thirty_seconds() {
         let ten_min = Some(Duration::from_secs(600));
         assert_eq!(
-            play_threshold(ten_min, ThresholdProfile::Local),
+            play_threshold(ten_min, ListenThreshold::local_default()),
             Duration::from_secs(30)
         );
     }
@@ -48,7 +85,7 @@ mod tests {
     fn audioscrobbler_caps_at_four_minutes() {
         let ten_min = Some(Duration::from_secs(600));
         assert_eq!(
-            play_threshold(ten_min, ThresholdProfile::Audioscrobbler),
+            play_threshold(ten_min, ListenThreshold::audioscrobbler_default()),
             Duration::from_secs(240)
         );
     }
@@ -57,15 +94,34 @@ mod tests {
     fn half_duration_when_shorter_than_cap() {
         let three_min = Some(Duration::from_secs(180));
         assert_eq!(
-            play_threshold(three_min, ThresholdProfile::Audioscrobbler),
+            play_threshold(three_min, ListenThreshold::audioscrobbler_default()),
             Duration::from_secs(90)
         );
     }
 
     #[test]
     fn audioscrobbler_rejects_short_tracks() {
-        assert!(!audioscrobbler_eligible(Some(Duration::from_secs(30))));
-        assert!(audioscrobbler_eligible(Some(Duration::from_secs(31))));
-        assert!(audioscrobbler_eligible(None));
+        let rules = AudioscrobblerRules::default();
+        assert!(!audioscrobbler_eligible(
+            Some(Duration::from_secs(30)),
+            rules
+        ));
+        assert!(audioscrobbler_eligible(
+            Some(Duration::from_secs(31)),
+            rules
+        ));
+        assert!(audioscrobbler_eligible(None, rules));
+    }
+
+    #[test]
+    fn custom_percent() {
+        let rules = ListenThreshold {
+            min_percent: 75,
+            max_listen: Duration::from_secs(600),
+        };
+        assert_eq!(
+            play_threshold(Some(Duration::from_secs(200)), rules),
+            Duration::from_secs(150)
+        );
     }
 }

--- a/ratune-scrobble/src/track.rs
+++ b/ratune-scrobble/src/track.rs
@@ -1,0 +1,23 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Metadata sent to Audioscrobbler-compatible services.
+#[derive(Debug, Clone)]
+pub struct TrackInfo {
+    /// Subsonic song id — used for server-side scrobbling, not sent to Last.fm.
+    pub song_id: String,
+    pub artist: String,
+    pub title: String,
+    pub album: Option<String>,
+    pub track_number: Option<u32>,
+    /// Track length in whole seconds.
+    pub duration_secs: Option<u32>,
+}
+
+impl TrackInfo {
+    pub fn now_secs() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+}

--- a/ratune/Cargo.toml
+++ b/ratune/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 anyhow = "1"
 crossterm = "0.28"
 ratune-player = { version = "0.1.0", path = "../ratune-player" }
+ratune-scrobble = { version = "0.1.0", path = "../ratune-scrobble" }
 ratune-subsonic = { version = "0.1.2", path = "../ratune-subsonic" }
 ratatui = { version = "0.29", features = ["crossterm"] }
 serde = { version = "1", features = ["derive"] }

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -519,6 +519,12 @@ pub struct App {
     /// Reset to `false` on every `TrackStarted`; set to `true` once the
     /// scrobble threshold (50% or 30 s, whichever is shorter) is crossed.
     pub play_recorded: bool,
+    /// Unix seconds when the current track began playing (Audioscrobbler timestamp).
+    track_started_at: Option<i64>,
+    /// True once the current track has been submitted to Last.fm / Libre.fm.
+    audioscrobbler_scrobbled: bool,
+    /// Authenticated Audioscrobbler client when `[scrobble].enabled` is configured.
+    scrobble_client: Option<ratune_scrobble::AudioscrobblerClient>,
 
     // ── Dynamic accent (Feature 5.1) ──────────────────────────────────────────
     /// Dominant colour extracted from the current track's album art.
@@ -586,6 +592,7 @@ impl App {
             BrowseMode::Files => BrowseMode::Files,
             BrowseMode::Artists => BrowseMode::Artists,
         };
+        let scrobble_client = config.audioscrobbler_client();
         Ok(Self {
             active_tab: Tab::Home,
             browser_focus: BrowserColumn::Artists,
@@ -647,6 +654,9 @@ impl App {
             help_scroll: 0,
             history: crate::history::PlayHistory::default(),
             play_recorded: false,
+            track_started_at: None,
+            audioscrobbler_scrobbled: false,
+            scrobble_client,
             lyrics_visible,
             lyrics_cache: None,
             lyrics_scroll: 0,
@@ -2271,11 +2281,67 @@ impl App {
 
     // ── Player event ingestion ────────────────────────────────────────────────
 
+    fn scrobble_track_started(&mut self, song: &ratune_subsonic::Song) {
+        self.play_recorded = false;
+        self.audioscrobbler_scrobbled = false;
+        self.track_started_at = Some(ratune_scrobble::TrackInfo::now_secs());
+        if let Some(client) = self.scrobble_client.clone() {
+            crate::scrobble::spawn_now_playing(client, crate::scrobble::track_from_song(song));
+        }
+    }
+
+    fn try_record_listen(&mut self, elapsed: Duration, total: Option<Duration>) {
+        let Some(song) = self.playback.current_song.clone() else {
+            return;
+        };
+
+        if !self.play_recorded {
+            let threshold =
+                ratune_scrobble::play_threshold(total, ratune_scrobble::ThresholdProfile::Local);
+            if elapsed >= threshold {
+                let record = PlayRecord {
+                    song_id: song.id.clone(),
+                    album_id: song.album_id.clone().unwrap_or_default(),
+                    artist_id: song.artist_id.clone().unwrap_or_default(),
+                    artist_name: song.artist.clone().unwrap_or_default(),
+                    album_name: song.album.clone().unwrap_or_default(),
+                    track_name: song.title.clone(),
+                    played_at: PlayRecord::now_secs(),
+                    duration_secs: song.duration.map(|d| d as u64).unwrap_or(0),
+                };
+                self.history.record_play(record);
+                if self.config.scrobble_to_server {
+                    crate::scrobble::spawn_subsonic_scrobble(self.subsonic.clone(), song.id.clone());
+                }
+                self.play_recorded = true;
+            }
+        }
+
+        if !self.audioscrobbler_scrobbled
+            && self.scrobble_client.is_some()
+            && ratune_scrobble::audioscrobbler_eligible(total)
+        {
+            let threshold = ratune_scrobble::play_threshold(
+                total,
+                ratune_scrobble::ThresholdProfile::Audioscrobbler,
+            );
+            if elapsed >= threshold {
+                if let Some(client) = self.scrobble_client.clone() {
+                    let track = crate::scrobble::track_from_song(&song);
+                    let ts = self
+                        .track_started_at
+                        .unwrap_or_else(ratune_scrobble::TrackInfo::now_secs);
+                    crate::scrobble::spawn_audioscrobbler_scrobble(client, track, ts);
+                }
+                self.audioscrobbler_scrobbled = true;
+            }
+        }
+    }
+
     pub fn handle_player_event(&mut self, event: PlayerEvent) {
         let progress_only = matches!(&event, PlayerEvent::Progress { .. });
         match event {
             PlayerEvent::TrackStarted => {
-                self.play_recorded = false;
                 self.playback.paused = false;
                 if let Some(song) = self.queue.current().cloned() {
                     // Fetch cover art when the track has one and it differs from cache.
@@ -2341,38 +2407,14 @@ impl App {
                             self.spawn_cache_download(&s_id, &a_id);
                         }
                     }
+                    self.scrobble_track_started(&song);
                     self.playback.current_song = Some(song);
                 }
             }
             PlayerEvent::Progress { elapsed, total } => {
                 self.playback.elapsed = elapsed;
                 self.playback.total = total;
-
-                // Record play once threshold is crossed (50% of duration OR 30 s).
-                if !self.play_recorded {
-                    let threshold = if let Some(dur) = total {
-                        let half = dur.as_secs_f64() * 0.5;
-                        std::time::Duration::from_secs_f64(half.min(30.0))
-                    } else {
-                        std::time::Duration::from_secs(30)
-                    };
-                    if elapsed >= threshold {
-                        if let Some(song) = self.playback.current_song.as_ref() {
-                            let record = crate::history::PlayRecord {
-                                song_id: song.id.clone(),
-                                album_id: song.album_id.clone().unwrap_or_default(),
-                                artist_id: song.artist_id.clone().unwrap_or_default(),
-                                artist_name: song.artist.clone().unwrap_or_default(),
-                                album_name: song.album.clone().unwrap_or_default(),
-                                track_name: song.title.clone(),
-                                played_at: crate::history::PlayRecord::now_secs(),
-                                duration_secs: song.duration.map(|d| d as u64).unwrap_or(0),
-                            };
-                            self.history.record_play(record);
-                        }
-                        self.play_recorded = true;
-                    }
-                }
+                self.try_record_listen(elapsed, total);
             }
             PlayerEvent::AboutToFinish => {
                 // Pre-load the next track for gapless playback.
@@ -2431,6 +2473,7 @@ impl App {
                             song.album.clone().unwrap_or_default(),
                         );
                     }
+                    self.scrobble_track_started(&song);
                     self.playback.current_song = Some(song);
                 }
             }

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -2340,7 +2340,10 @@ impl App {
                 };
                 self.history.record_play(record);
                 if self.config.scrobble_to_server {
-                    crate::scrobble::spawn_subsonic_scrobble(self.subsonic.clone(), song.id.clone());
+                    crate::scrobble::spawn_subsonic_scrobble(
+                        self.subsonic.clone(),
+                        song.id.clone(),
+                    );
                 }
                 self.play_recorded = true;
             }
@@ -2383,11 +2386,7 @@ impl App {
         let entries = std::mem::take(&mut self.scrobble_queue.entries);
         self.persist_scrobble_queue();
         if let Some(client) = self.scrobble_client.clone() {
-            crate::scrobble::spawn_flush_scrobble_queue(
-                client,
-                entries,
-                self.library_tx.clone(),
-            );
+            crate::scrobble::spawn_flush_scrobble_queue(client, entries, self.library_tx.clone());
         }
     }
 
@@ -2425,10 +2424,7 @@ impl App {
                     self.scrobble_queue.push(entry);
                     self.persist_scrobble_queue();
                     let pending = self.scrobble_queue.len();
-                    self.flash_status_secs(
-                        format!("Scrobble queued ({pending} pending): {e}"),
-                        6,
-                    );
+                    self.flash_status_secs(format!("Scrobble queued ({pending} pending): {e}"), 6);
                 } else {
                     self.scrobble_queue.push(entry);
                     self.persist_scrobble_queue();

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -330,6 +330,14 @@ pub enum LibraryUpdate {
         id: String,
         result: Result<DirectoryListing, String>,
     },
+    /// Audioscrobbler scrobble attempt (live or queue retry).
+    ScrobbleResult {
+        entry: crate::scrobble_queue::QueuedScrobble,
+        artist: String,
+        title: String,
+        result: Result<(), String>,
+        from_live: bool,
+    },
 }
 
 #[derive(Clone, Copy)]
@@ -525,6 +533,9 @@ pub struct App {
     audioscrobbler_scrobbled: bool,
     /// Authenticated Audioscrobbler client when `[scrobble].enabled` is configured.
     scrobble_client: Option<ratune_scrobble::AudioscrobblerClient>,
+    /// Failed scrobbles persisted for retry when offline.
+    pub scrobble_queue: crate::scrobble_queue::ScrobbleQueue,
+    scrobble_queue_path: std::path::PathBuf,
 
     // ── Dynamic accent (Feature 5.1) ──────────────────────────────────────────
     /// Dominant colour extracted from the current track's album art.
@@ -593,6 +604,12 @@ impl App {
             BrowseMode::Artists => BrowseMode::Artists,
         };
         let scrobble_client = config.audioscrobbler_client();
+        let scrobble_queue_path = crate::scrobble_queue::scrobble_queue_path();
+        let scrobble_queue = crate::scrobble_queue::ScrobbleQueue::load(&scrobble_queue_path)
+            .unwrap_or_else(|e| {
+                eprintln!("warn: could not load scrobble queue: {e:#}");
+                crate::scrobble_queue::ScrobbleQueue::default()
+            });
         Ok(Self {
             active_tab: Tab::Home,
             browser_focus: BrowserColumn::Artists,
@@ -657,6 +674,8 @@ impl App {
             track_started_at: None,
             audioscrobbler_scrobbled: false,
             scrobble_client,
+            scrobble_queue,
+            scrobble_queue_path,
             lyrics_visible,
             lyrics_cache: None,
             lyrics_scroll: 0,
@@ -2276,6 +2295,13 @@ impl App {
                     }
                 }
             }
+            LibraryUpdate::ScrobbleResult {
+                entry,
+                artist,
+                title,
+                result,
+                from_live,
+            } => self.handle_scrobble_result(entry, artist, title, result, from_live),
         }
     }
 
@@ -2331,9 +2357,76 @@ impl App {
                     let ts = self
                         .track_started_at
                         .unwrap_or_else(ratune_scrobble::TrackInfo::now_secs);
-                    crate::scrobble::spawn_audioscrobbler_scrobble(client, track, ts);
+                    crate::scrobble::spawn_audioscrobbler_scrobble(
+                        client,
+                        track,
+                        ts,
+                        self.library_tx.clone(),
+                        true,
+                    );
                 }
                 self.audioscrobbler_scrobbled = true;
+            }
+        }
+    }
+
+    pub fn spawn_scrobble_queue_flush(&mut self) {
+        if self.scrobble_client.is_none() || self.scrobble_queue.is_empty() {
+            return;
+        }
+        let entries = std::mem::take(&mut self.scrobble_queue.entries);
+        self.persist_scrobble_queue();
+        if let Some(client) = self.scrobble_client.clone() {
+            crate::scrobble::spawn_flush_scrobble_queue(
+                client,
+                entries,
+                self.library_tx.clone(),
+            );
+        }
+    }
+
+    pub fn persist_scrobble_queue(&self) {
+        if let Err(e) = self.scrobble_queue.save(&self.scrobble_queue_path) {
+            eprintln!("warn: could not save scrobble queue: {e:#}");
+        }
+    }
+
+    fn handle_scrobble_result(
+        &mut self,
+        entry: crate::scrobble_queue::QueuedScrobble,
+        artist: String,
+        title: String,
+        result: Result<(), String>,
+        from_live: bool,
+    ) {
+        match result {
+            Ok(()) => {
+                self.scrobble_queue.entries.retain(|e| e != &entry);
+                self.persist_scrobble_queue();
+                let msg = if from_live {
+                    format!("Scrobbled: {artist} — {title}")
+                } else {
+                    format!("Scrobble sent: {artist} — {title}")
+                };
+                self.flash_status_secs(msg, 4);
+                if !self.scrobble_queue.is_empty() {
+                    self.spawn_scrobble_queue_flush();
+                }
+            }
+            Err(e) => {
+                if from_live {
+                    self.scrobble_queue.push(entry);
+                    self.persist_scrobble_queue();
+                    let pending = self.scrobble_queue.len();
+                    self.flash_status_secs(
+                        format!("Scrobble queued ({pending} pending): {e}"),
+                        6,
+                    );
+                } else {
+                    self.scrobble_queue.push(entry);
+                    self.persist_scrobble_queue();
+                    eprintln!("scrobble: queue retry failed: {e}");
+                }
             }
         }
     }

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -536,6 +536,8 @@ pub struct App {
     /// Failed scrobbles persisted for retry when offline.
     pub scrobble_queue: crate::scrobble_queue::ScrobbleQueue,
     scrobble_queue_path: std::path::PathBuf,
+    /// Show a ✓ on the status bar until this instant after a successful scrobble.
+    scrobble_ok_until: Option<Instant>,
 
     // ── Dynamic accent (Feature 5.1) ──────────────────────────────────────────
     /// Dominant colour extracted from the current track's album art.
@@ -676,6 +678,7 @@ impl App {
             scrobble_client,
             scrobble_queue,
             scrobble_queue_path,
+            scrobble_ok_until: None,
             lyrics_visible,
             lyrics_cache: None,
             lyrics_scroll: 0,
@@ -2323,7 +2326,7 @@ impl App {
 
         if !self.play_recorded {
             let threshold =
-                ratune_scrobble::play_threshold(total, ratune_scrobble::ThresholdProfile::Local);
+                ratune_scrobble::play_threshold(total, self.config.scrobble_local_threshold);
             if elapsed >= threshold {
                 let record = PlayRecord {
                     song_id: song.id.clone(),
@@ -2345,11 +2348,14 @@ impl App {
 
         if !self.audioscrobbler_scrobbled
             && self.scrobble_client.is_some()
-            && ratune_scrobble::audioscrobbler_eligible(total)
+            && ratune_scrobble::audioscrobbler_eligible(
+                total,
+                self.config.scrobble_audioscrobbler_rules,
+            )
         {
             let threshold = ratune_scrobble::play_threshold(
                 total,
-                ratune_scrobble::ThresholdProfile::Audioscrobbler,
+                self.config.scrobble_audioscrobbler_rules.listen,
             );
             if elapsed >= threshold {
                 if let Some(client) = self.scrobble_client.clone() {
@@ -2403,6 +2409,7 @@ impl App {
             Ok(()) => {
                 self.scrobble_queue.entries.retain(|e| e != &entry);
                 self.persist_scrobble_queue();
+                self.scrobble_ok_until = Some(Instant::now() + Duration::from_secs(10));
                 let msg = if from_live {
                     format!("Scrobbled: {artist} — {title}")
                 } else {
@@ -4639,6 +4646,18 @@ impl App {
                 self.status_flash = None;
             }
         }
+        if self
+            .scrobble_ok_until
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            self.scrobble_ok_until = None;
+        }
+    }
+
+    /// True briefly after a scrobble succeeds (status bar shows ✓).
+    pub fn scrobble_recently_ok(&self) -> bool {
+        self.scrobble_ok_until
+            .is_some_and(|deadline| Instant::now() < deadline)
     }
 
     // ── Playlist overlay ──────────────────────────────────────────────────────

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -236,6 +236,93 @@ impl Default for LibrarySection {
 
 // ── [scrobble] — Last.fm / Libre.fm + Subsonic play counts ───────────────────
 
+/// Local listen threshold (history + Subsonic). Defaults: 50%, 30 s cap.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ScrobbleLocalThresholdSection {
+    /// Minimum fraction of track length before counting a listen (1–100). Default: 50.
+    #[serde(default = "default_scrobble_min_percent")]
+    pub min_percent: u8,
+    /// Upper cap on listen time (seconds). Default: 30.
+    #[serde(default = "default_local_max_listen_seconds")]
+    pub max_listen_seconds: u32,
+}
+
+impl Default for ScrobbleLocalThresholdSection {
+    fn default() -> Self {
+        Self {
+            min_percent: default_scrobble_min_percent(),
+            max_listen_seconds: default_local_max_listen_seconds(),
+        }
+    }
+}
+
+impl ScrobbleLocalThresholdSection {
+    pub fn resolve(&self) -> ratune_scrobble::ListenThreshold {
+        ratune_scrobble::ListenThreshold {
+            min_percent: self.min_percent.clamp(1, 100),
+            max_listen: std::time::Duration::from_secs(self.max_listen_seconds.max(1) as u64),
+        }
+    }
+}
+
+/// Last.fm / Libre.fm listen rules. Defaults match Last.fm’s documented scrobbling rules.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ScrobbleAudioscrobblerThresholdSection {
+    #[serde(default = "default_scrobble_min_percent")]
+    pub min_percent: u8,
+    #[serde(default = "default_audioscrobbler_max_listen_seconds")]
+    pub max_listen_seconds: u32,
+    /// Tracks this long or shorter are not scrobbled. Default: 30.
+    #[serde(default = "default_audioscrobbler_min_track_seconds")]
+    pub min_track_seconds: u32,
+}
+
+impl Default for ScrobbleAudioscrobblerThresholdSection {
+    fn default() -> Self {
+        Self {
+            min_percent: default_scrobble_min_percent(),
+            max_listen_seconds: default_audioscrobbler_max_listen_seconds(),
+            min_track_seconds: default_audioscrobbler_min_track_seconds(),
+        }
+    }
+}
+
+impl ScrobbleAudioscrobblerThresholdSection {
+    pub fn resolve(&self) -> ratune_scrobble::AudioscrobblerRules {
+        ratune_scrobble::AudioscrobblerRules {
+            listen: ratune_scrobble::ListenThreshold {
+                min_percent: self.min_percent.clamp(1, 100),
+                max_listen: std::time::Duration::from_secs(self.max_listen_seconds.max(1) as u64),
+            },
+            min_track_length: std::time::Duration::from_secs(self.min_track_seconds as u64),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ScrobbleThresholdsSection {
+    #[serde(default)]
+    pub local: ScrobbleLocalThresholdSection,
+    #[serde(default)]
+    pub audioscrobbler: ScrobbleAudioscrobblerThresholdSection,
+}
+
+fn default_scrobble_min_percent() -> u8 {
+    50
+}
+
+fn default_local_max_listen_seconds() -> u32 {
+    30
+}
+
+fn default_audioscrobbler_max_listen_seconds() -> u32 {
+    240
+}
+
+fn default_audioscrobbler_min_track_seconds() -> u32 {
+    30
+}
+
 /// Audioscrobbler and server-side scrobbling settings from config.toml.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ScrobbleSection {
@@ -263,6 +350,9 @@ pub struct ScrobbleSection {
     /// Call the Subsonic `/scrobble` endpoint when a listen is recorded. Default: true.
     #[serde(default = "default_scrobble_to_server")]
     pub scrobble_to_server: bool,
+    /// Optional listen thresholds (defaults follow Last.fm conventions).
+    #[serde(default)]
+    pub thresholds: ScrobbleThresholdsSection,
 }
 
 fn default_scrobble_service() -> String {
@@ -284,6 +374,7 @@ impl Default for ScrobbleSection {
             session_key: String::new(),
             session_key_command: String::new(),
             scrobble_to_server: default_scrobble_to_server(),
+            thresholds: ScrobbleThresholdsSection::default(),
         }
     }
 }
@@ -867,6 +958,10 @@ pub struct Config {
     pub scrobble_session_key: String,
     /// Notify the Subsonic server (Navidrome play counts) when a listen is recorded.
     pub scrobble_to_server: bool,
+    /// Threshold for local history + Subsonic scrobble.
+    pub scrobble_local_threshold: ratune_scrobble::ListenThreshold,
+    /// Threshold for Last.fm / Libre.fm scrobble.
+    pub scrobble_audioscrobbler_rules: ratune_scrobble::AudioscrobblerRules,
 }
 
 impl Config {
@@ -1217,6 +1312,8 @@ impl Config {
             scrobble_api_secret,
             scrobble_session_key,
             scrobble_to_server: scrobble.scrobble_to_server,
+            scrobble_local_threshold: scrobble.thresholds.local.resolve(),
+            scrobble_audioscrobbler_rules: scrobble.thresholds.audioscrobbler.resolve(),
         })
     }
 
@@ -1422,11 +1519,15 @@ max_size_gb = 2   # maximum total cache size in gigabytes
 # enabled = false
 # service = "lastfm"          # or "librefm"
 # api_key = ""
-# api_secret = ""             # or api_secret_command / keyring (lastfm|api_secret)
+# api_secret = ""            # plaintext supported; or api_secret_command / keyring
+# session_key = ""           # from `ratune scrobble-auth`; or session_key_command / keyring
 # api_secret_command = ""
-# session_key = ""            # run `ratune scrobble-auth` once; prefer session_key_command
 # session_key_command = ""
 # scrobble_to_server = true   # Subsonic /scrobble for Navidrome play counts
+#
+# CLI helpers (see README § Scrobbling):
+#   ratune scrobble-api-secret [--save-keyring]
+#   ratune scrobble-auth [--save-keyring]
 "##;
     std::fs::write(path, default_toml)
         .with_context(|| format!("writing default config to {}", path.display()))?;
@@ -1887,11 +1988,48 @@ password_command = "secret-tool lookup service ratune"
             session_key: String::new(),
             session_key_command: String::new(),
             scrobble_to_server: true,
+            thresholds: ScrobbleThresholdsSection::default(),
         };
         assert_eq!(
             resolve_scrobble_api_secret(&sec).expect("command"),
             "shh-secret"
         );
+    }
+
+    #[test]
+    fn parses_scrobble_thresholds() {
+        let text = r#"
+[scrobble.thresholds.local]
+min_percent = 40
+max_listen_seconds = 45
+
+[scrobble.thresholds.audioscrobbler]
+min_percent = 60
+max_listen_seconds = 180
+min_track_seconds = 20
+"#;
+        let fc: FileConfig = toml::from_str(text).expect("toml");
+        assert_eq!(fc.scrobble.thresholds.local.min_percent, 40);
+        assert_eq!(fc.scrobble.thresholds.local.max_listen_seconds, 45);
+        assert_eq!(fc.scrobble.thresholds.audioscrobbler.min_percent, 60);
+        assert_eq!(fc.scrobble.thresholds.audioscrobbler.max_listen_seconds, 180);
+        assert_eq!(fc.scrobble.thresholds.audioscrobbler.min_track_seconds, 20);
+        let local = fc.scrobble.thresholds.local.resolve();
+        assert_eq!(local.min_percent, 40);
+        assert_eq!(local.max_listen, std::time::Duration::from_secs(45));
+        let rules = fc.scrobble.thresholds.audioscrobbler.resolve();
+        assert_eq!(rules.listen.min_percent, 60);
+        assert_eq!(rules.listen.max_listen, std::time::Duration::from_secs(180));
+        assert_eq!(rules.min_track_length, std::time::Duration::from_secs(20));
+    }
+
+    #[test]
+    fn scrobble_threshold_defaults_match_lastfm() {
+        let sec = ScrobbleThresholdsSection::default();
+        let local = sec.local.resolve();
+        assert_eq!(local, ratune_scrobble::ListenThreshold::local_default());
+        let rules = sec.audioscrobbler.resolve();
+        assert_eq!(rules, ratune_scrobble::AudioscrobblerRules::default());
     }
 
     #[test]

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -1234,15 +1234,14 @@ impl Config {
         let scrobble_enabled = scrobble.enabled;
         let scrobble_service = ratune_scrobble::ScrobbleService::parse(&scrobble.service)
             .unwrap_or(ratune_scrobble::ScrobbleService::LastFm);
-        let (scrobble_api_key, scrobble_api_secret, scrobble_session_key) =
-            if scrobble_enabled {
-                resolve_scrobble_credentials(scrobble).unwrap_or_else(|e| {
-                    eprintln!("warning: scrobbling disabled — {e:#}");
-                    (String::new(), String::new(), String::new())
-                })
-            } else {
+        let (scrobble_api_key, scrobble_api_secret, scrobble_session_key) = if scrobble_enabled {
+            resolve_scrobble_credentials(scrobble).unwrap_or_else(|e| {
+                eprintln!("warning: scrobbling disabled — {e:#}");
                 (String::new(), String::new(), String::new())
-            };
+            })
+        } else {
+            (String::new(), String::new(), String::new())
+        };
         let scrobble_enabled = scrobble_enabled
             && !scrobble_api_key.is_empty()
             && !scrobble_api_secret.is_empty()
@@ -1727,7 +1726,8 @@ fn merge_env_overrides(cfg: &mut FileConfig) {
     {
         cfg.scrobble.api_secret = v;
     }
-    if let Ok(v) = std::env::var("LASTFM_SESSION_KEY").or_else(|_| std::env::var("LIBREFM_SESSION_KEY"))
+    if let Ok(v) =
+        std::env::var("LASTFM_SESSION_KEY").or_else(|_| std::env::var("LIBREFM_SESSION_KEY"))
     {
         cfg.scrobble.session_key = v;
     }
@@ -1741,11 +1741,7 @@ fn resolve_scrobble_credentials(sec: &ScrobbleSection) -> Result<(String, String
     }
     let api_secret = resolve_scrobble_api_secret(sec)?;
     let session_key = resolve_scrobble_session_key(sec)?;
-    Ok((
-        api_key.to_string(),
-        api_secret,
-        session_key,
-    ))
+    Ok((api_key.to_string(), api_secret, session_key))
 }
 
 fn scrobble_service_name(service: ratune_scrobble::ScrobbleService) -> &'static str {
@@ -1854,8 +1850,8 @@ pub fn store_scrobble_session_key(
         bail!("refusing to store empty session key");
     }
     let label = scrobble_keyring_label(service, "session");
-    let entry = keyring_core::Entry::new("ratune", &label)
-        .context("keyring entry for scrobble session")?;
+    let entry =
+        keyring_core::Entry::new("ratune", &label).context("keyring entry for scrobble session")?;
     entry
         .set_password(key)
         .context("storing scrobble session key in keyring")?;
@@ -1865,7 +1861,8 @@ pub fn store_scrobble_session_key(
 /// Load `[scrobble]` application credentials for the browser auth flow.
 ///
 /// Does not require a session key or Subsonic password.
-pub fn load_scrobble_app_credentials() -> Result<(ratune_scrobble::ScrobbleService, String, String)> {
+pub fn load_scrobble_app_credentials() -> Result<(ratune_scrobble::ScrobbleService, String, String)>
+{
     let config_path = config_file_path()?;
     if !config_path.exists() {
         bail!(
@@ -1875,8 +1872,8 @@ pub fn load_scrobble_app_credentials() -> Result<(ratune_scrobble::ScrobbleServi
     }
     let text = std::fs::read_to_string(&config_path)
         .with_context(|| format!("reading {}", config_path.display()))?;
-    let mut file_cfg: FileConfig = toml::from_str(&text)
-        .with_context(|| format!("parsing {}", config_path.display()))?;
+    let mut file_cfg: FileConfig =
+        toml::from_str(&text).with_context(|| format!("parsing {}", config_path.display()))?;
     merge_env_overrides(&mut file_cfg);
 
     let sec = &file_cfg.scrobble;
@@ -1907,8 +1904,8 @@ pub fn load_scrobble_api_key() -> Result<(ratune_scrobble::ScrobbleService, Stri
     }
     let text = std::fs::read_to_string(&config_path)
         .with_context(|| format!("reading {}", config_path.display()))?;
-    let mut file_cfg: FileConfig = toml::from_str(&text)
-        .with_context(|| format!("parsing {}", config_path.display()))?;
+    let mut file_cfg: FileConfig =
+        toml::from_str(&text).with_context(|| format!("parsing {}", config_path.display()))?;
     merge_env_overrides(&mut file_cfg);
 
     let sec = &file_cfg.scrobble;
@@ -2012,7 +2009,10 @@ min_track_seconds = 20
         assert_eq!(fc.scrobble.thresholds.local.min_percent, 40);
         assert_eq!(fc.scrobble.thresholds.local.max_listen_seconds, 45);
         assert_eq!(fc.scrobble.thresholds.audioscrobbler.min_percent, 60);
-        assert_eq!(fc.scrobble.thresholds.audioscrobbler.max_listen_seconds, 180);
+        assert_eq!(
+            fc.scrobble.thresholds.audioscrobbler.max_listen_seconds,
+            180
+        );
         assert_eq!(fc.scrobble.thresholds.audioscrobbler.min_track_seconds, 20);
         let local = fc.scrobble.thresholds.local.resolve();
         assert_eq!(local.min_percent, 40);

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -34,6 +34,8 @@ struct FileConfig {
     pub cache: CacheSection,
     #[serde(default)]
     pub library: LibrarySection,
+    #[serde(default)]
+    pub scrobble: ScrobbleSection,
 }
 
 // ── [keybinds] ────────────────────────────────────────────────────────────────
@@ -228,6 +230,56 @@ impl Default for LibrarySection {
             fetch_artist_parallelism: default_library_fetch_artist_parallelism(),
             navidrome_skip_unchanged_scan: false,
             notify_on_forced_index_refresh: default_library_notify_on_forced_refresh(),
+        }
+    }
+}
+
+// ── [scrobble] — Last.fm / Libre.fm + Subsonic play counts ───────────────────
+
+/// Audioscrobbler and server-side scrobbling settings from config.toml.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ScrobbleSection {
+    /// Enable scrobbling to Last.fm or Libre.fm. Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// `lastfm` (default) or `librefm`.
+    #[serde(default = "default_scrobble_service")]
+    pub service: String,
+    /// Application API key from your Last.fm / Libre.fm account.
+    #[serde(default)]
+    pub api_key: String,
+    /// API shared secret (required to sign POST requests).
+    #[serde(default)]
+    pub api_secret: String,
+    /// Session key from `auth.getSession` (see docs). Prefer keyring / command over plaintext.
+    #[serde(default)]
+    pub session_key: String,
+    /// Shell command whose stdout is the session key (trimmed).
+    #[serde(default)]
+    pub session_key_command: String,
+    /// Call the Subsonic `/scrobble` endpoint when a listen is recorded. Default: true.
+    #[serde(default = "default_scrobble_to_server")]
+    pub scrobble_to_server: bool,
+}
+
+fn default_scrobble_service() -> String {
+    "lastfm".into()
+}
+
+fn default_scrobble_to_server() -> bool {
+    true
+}
+
+impl Default for ScrobbleSection {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            service: default_scrobble_service(),
+            api_key: String::new(),
+            api_secret: String::new(),
+            session_key: String::new(),
+            session_key_command: String::new(),
+            scrobble_to_server: default_scrobble_to_server(),
         }
     }
 }
@@ -803,6 +855,14 @@ pub struct Config {
     pub browse_mode: BrowseMode,
     /// When true, folder browsing can be toggled with the keybind and used from the Browse tab.
     pub browse_folder_navigation: bool,
+    /// Scrobble listens to Last.fm or Libre.fm when enabled and credentials are configured.
+    pub scrobble_enabled: bool,
+    pub scrobble_service: ratune_scrobble::ScrobbleService,
+    pub scrobble_api_key: String,
+    pub scrobble_api_secret: String,
+    pub scrobble_session_key: String,
+    /// Notify the Subsonic server (Navidrome play counts) when a listen is recorded.
+    pub scrobble_to_server: bool,
 }
 
 impl Config {
@@ -1071,6 +1131,24 @@ impl Config {
             .and_then(|b| b.folder_navigation)
             .unwrap_or(false);
 
+        let scrobble = &file_cfg.scrobble;
+        let scrobble_enabled = scrobble.enabled;
+        let scrobble_service = ratune_scrobble::ScrobbleService::parse(&scrobble.service)
+            .unwrap_or(ratune_scrobble::ScrobbleService::LastFm);
+        let (scrobble_api_key, scrobble_api_secret, scrobble_session_key) =
+            if scrobble_enabled {
+                resolve_scrobble_credentials(scrobble).unwrap_or_else(|e| {
+                    eprintln!("warning: scrobbling disabled — {e:#}");
+                    (String::new(), String::new(), String::new())
+                })
+            } else {
+                (String::new(), String::new(), String::new())
+            };
+        let scrobble_enabled = scrobble_enabled
+            && !scrobble_api_key.is_empty()
+            && !scrobble_api_secret.is_empty()
+            && !scrobble_session_key.is_empty();
+
         Ok(Config {
             subsonic_url: file_cfg.server.url,
             subsonic_user: file_cfg.server.username,
@@ -1129,7 +1207,26 @@ impl Config {
             home_panels,
             browse_mode,
             browse_folder_navigation,
+            scrobble_enabled,
+            scrobble_service,
+            scrobble_api_key,
+            scrobble_api_secret,
+            scrobble_session_key,
+            scrobble_to_server: scrobble.scrobble_to_server,
         })
+    }
+
+    /// Build an authenticated Audioscrobbler client when scrobbling is enabled.
+    pub fn audioscrobbler_client(&self) -> Option<ratune_scrobble::AudioscrobblerClient> {
+        if !self.scrobble_enabled {
+            return None;
+        }
+        Some(ratune_scrobble::AudioscrobblerClient::new(
+            self.scrobble_service,
+            self.scrobble_api_key.clone(),
+            self.scrobble_api_secret.clone(),
+            self.scrobble_session_key.clone(),
+        ))
     }
 
     /// Tab bar position and now-playing height for [`crate::ui::layout::build_layout`].
@@ -1316,6 +1413,15 @@ location = "right"
 [cache]
 enabled     = true
 max_size_gb = 2   # maximum total cache size in gigabytes
+
+# [scrobble]
+# enabled = false
+# service = "lastfm"          # or "librefm"
+# api_key = ""
+# api_secret = ""
+# session_key = ""            # run `ratune scrobble-auth` once; prefer session_key_command
+# session_key_command = ""
+# scrobble_to_server = true   # Subsonic /scrobble for Navidrome play counts
 "##;
     std::fs::write(path, default_toml)
         .with_context(|| format!("writing default config to {}", path.display()))?;
@@ -1506,6 +1612,84 @@ fn merge_env_overrides(cfg: &mut FileConfig) {
     {
         cfg.server.password = v;
     }
+    if let Ok(v) = std::env::var("LASTFM_API_KEY").or_else(|_| std::env::var("LIBREFM_API_KEY")) {
+        cfg.scrobble.api_key = v;
+    }
+    if let Ok(v) = std::env::var("LASTFM_API_SECRET")
+        .or_else(|_| std::env::var("LASTFM_SHARED_SECRET"))
+        .or_else(|_| std::env::var("LIBREFM_API_SECRET"))
+    {
+        cfg.scrobble.api_secret = v;
+    }
+    if let Ok(v) = std::env::var("LASTFM_SESSION_KEY").or_else(|_| std::env::var("LIBREFM_SESSION_KEY"))
+    {
+        cfg.scrobble.session_key = v;
+    }
+}
+
+/// Resolve Audioscrobbler credentials when `[scrobble].enabled` is true.
+fn resolve_scrobble_credentials(sec: &ScrobbleSection) -> Result<(String, String, String)> {
+    let api_key = sec.api_key.trim();
+    if api_key.is_empty() {
+        bail!("[scrobble].api_key is empty (or set LASTFM_API_KEY / LIBREFM_API_KEY)");
+    }
+    let api_secret = sec.api_secret.trim();
+    if api_secret.is_empty() {
+        bail!("[scrobble].api_secret is empty (or set LASTFM_API_SECRET)");
+    }
+    let session_key = if !sec.session_key.trim().is_empty() {
+        sec.session_key.trim().to_string()
+    } else if !sec.session_key_command.trim().is_empty() {
+        run_password_command(sec.session_key_command.trim())?
+    } else {
+        bail!(
+            "[scrobble].session_key is empty — run `ratune scrobble-auth`, or set session_key, session_key_command, or LASTFM_SESSION_KEY"
+        );
+    };
+    Ok((
+        api_key.to_string(),
+        api_secret.to_string(),
+        session_key,
+    ))
+}
+
+/// Load `[scrobble]` application credentials for the browser auth flow.
+///
+/// Does not require a session key or Subsonic password.
+pub fn load_scrobble_app_credentials() -> Result<(ratune_scrobble::ScrobbleService, String, String)> {
+    let config_path = config_file_path()?;
+    if !config_path.exists() {
+        bail!(
+            "config file not found at {} — create it first (ratune writes a starter on first run)",
+            config_path.display()
+        );
+    }
+    let text = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let mut file_cfg: FileConfig = toml::from_str(&text)
+        .with_context(|| format!("parsing {}", config_path.display()))?;
+    merge_env_overrides(&mut file_cfg);
+
+    let sec = &file_cfg.scrobble;
+    let service = ratune_scrobble::ScrobbleService::parse(&sec.service)
+        .unwrap_or(ratune_scrobble::ScrobbleService::LastFm);
+
+    let api_key = sec.api_key.trim();
+    if api_key.is_empty() {
+        bail!(
+            "[scrobble].api_key is empty in {} (or set LASTFM_API_KEY / LIBREFM_API_KEY)",
+            config_path.display()
+        );
+    }
+    let api_secret = sec.api_secret.trim();
+    if api_secret.is_empty() {
+        bail!(
+            "[scrobble].api_secret is empty in {} (or set LASTFM_API_SECRET)",
+            config_path.display()
+        );
+    }
+
+    Ok((service, api_key.to_string(), api_secret.to_string()))
 }
 
 #[cfg(test)]

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -251,6 +251,9 @@ pub struct ScrobbleSection {
     /// API shared secret (required to sign POST requests).
     #[serde(default)]
     pub api_secret: String,
+    /// Shell command whose stdout is the API shared secret (trimmed).
+    #[serde(default)]
+    pub api_secret_command: String,
     /// Session key from `auth.getSession` (see docs). Prefer keyring / command over plaintext.
     #[serde(default)]
     pub session_key: String,
@@ -277,6 +280,7 @@ impl Default for ScrobbleSection {
             service: default_scrobble_service(),
             api_key: String::new(),
             api_secret: String::new(),
+            api_secret_command: String::new(),
             session_key: String::new(),
             session_key_command: String::new(),
             scrobble_to_server: default_scrobble_to_server(),
@@ -1418,7 +1422,8 @@ max_size_gb = 2   # maximum total cache size in gigabytes
 # enabled = false
 # service = "lastfm"          # or "librefm"
 # api_key = ""
-# api_secret = ""
+# api_secret = ""             # or api_secret_command / keyring (lastfm|api_secret)
+# api_secret_command = ""
 # session_key = ""            # run `ratune scrobble-auth` once; prefer session_key_command
 # session_key_command = ""
 # scrobble_to_server = true   # Subsonic /scrobble for Navidrome play counts
@@ -1633,24 +1638,127 @@ fn resolve_scrobble_credentials(sec: &ScrobbleSection) -> Result<(String, String
     if api_key.is_empty() {
         bail!("[scrobble].api_key is empty (or set LASTFM_API_KEY / LIBREFM_API_KEY)");
     }
-    let api_secret = sec.api_secret.trim();
-    if api_secret.is_empty() {
-        bail!("[scrobble].api_secret is empty (or set LASTFM_API_SECRET)");
-    }
-    let session_key = if !sec.session_key.trim().is_empty() {
-        sec.session_key.trim().to_string()
-    } else if !sec.session_key_command.trim().is_empty() {
-        run_password_command(sec.session_key_command.trim())?
-    } else {
-        bail!(
-            "[scrobble].session_key is empty — run `ratune scrobble-auth`, or set session_key, session_key_command, or LASTFM_SESSION_KEY"
-        );
-    };
+    let api_secret = resolve_scrobble_api_secret(sec)?;
+    let session_key = resolve_scrobble_session_key(sec)?;
     Ok((
         api_key.to_string(),
-        api_secret.to_string(),
+        api_secret,
         session_key,
     ))
+}
+
+fn scrobble_service_name(service: ratune_scrobble::ScrobbleService) -> &'static str {
+    match service {
+        ratune_scrobble::ScrobbleService::LastFm => "lastfm",
+        ratune_scrobble::ScrobbleService::LibreFm => "librefm",
+    }
+}
+
+fn scrobble_keyring_label(service: ratune_scrobble::ScrobbleService, kind: &str) -> String {
+    format!("{}|{kind}", scrobble_service_name(service))
+}
+
+fn resolve_scrobble_service(sec: &ScrobbleSection) -> ratune_scrobble::ScrobbleService {
+    ratune_scrobble::ScrobbleService::parse(&sec.service)
+        .unwrap_or(ratune_scrobble::ScrobbleService::LastFm)
+}
+
+fn resolve_scrobble_api_secret(sec: &ScrobbleSection) -> Result<String> {
+    if !sec.api_secret.trim().is_empty() {
+        return Ok(sec.api_secret.trim().to_string());
+    }
+    if !sec.api_secret_command.trim().is_empty() {
+        return run_password_command(sec.api_secret_command.trim());
+    }
+    resolve_scrobble_api_secret_from_keyring(sec)
+}
+
+fn resolve_scrobble_api_secret_from_keyring(sec: &ScrobbleSection) -> Result<String> {
+    read_scrobble_keyring(
+        sec,
+        "api_secret",
+        "set api_secret / LASTFM_API_SECRET, api_secret_command, or run `ratune scrobble-api-secret --save-keyring`",
+    )
+}
+
+fn resolve_scrobble_session_key(sec: &ScrobbleSection) -> Result<String> {
+    if !sec.session_key.trim().is_empty() {
+        return Ok(sec.session_key.trim().to_string());
+    }
+    if !sec.session_key_command.trim().is_empty() {
+        return run_password_command(sec.session_key_command.trim());
+    }
+    resolve_scrobble_session_from_keyring(sec)
+}
+
+fn resolve_scrobble_session_from_keyring(sec: &ScrobbleSection) -> Result<String> {
+    read_scrobble_keyring(
+        sec,
+        "session",
+        "run `ratune scrobble-auth --save-keyring`, or set session_key / session_key_command / LASTFM_SESSION_KEY",
+    )
+}
+
+fn read_scrobble_keyring(sec: &ScrobbleSection, kind: &str, hint: &str) -> Result<String> {
+    use keyring_core::Error as KeyringError;
+
+    let service = resolve_scrobble_service(sec);
+    let label = scrobble_keyring_label(service, kind);
+    let entry = match keyring_core::Entry::new("ratune", &label) {
+        Ok(e) => e,
+        Err(KeyringError::NoDefaultStore) => {
+            bail!("no {kind} configured — {hint}");
+        }
+        Err(e) => return Err(e).context(format!("keyring entry for scrobble {kind}")),
+    };
+
+    match entry.get_password() {
+        Ok(s) => {
+            let t = s.trim();
+            if t.is_empty() {
+                bail!("keyring entry for scrobble {kind} is empty");
+            }
+            Ok(t.to_string())
+        }
+        Err(KeyringError::NoEntry) => bail!("no {kind} in keyring — {hint}"),
+        Err(e) => Err(e).context(format!("reading scrobble {kind} from keyring")),
+    }
+}
+
+/// Persist an API shared secret in the OS keyring (service `ratune`).
+pub fn store_scrobble_api_secret(
+    service: ratune_scrobble::ScrobbleService,
+    api_secret: &str,
+) -> Result<()> {
+    let secret = api_secret.trim();
+    if secret.is_empty() {
+        bail!("refusing to store empty API secret");
+    }
+    let label = scrobble_keyring_label(service, "api_secret");
+    let entry = keyring_core::Entry::new("ratune", &label)
+        .context("keyring entry for scrobble api_secret")?;
+    entry
+        .set_password(secret)
+        .context("storing scrobble api_secret in keyring")?;
+    Ok(())
+}
+
+/// Persist a scrobble session key in the OS keyring (service `ratune`).
+pub fn store_scrobble_session_key(
+    service: ratune_scrobble::ScrobbleService,
+    session_key: &str,
+) -> Result<()> {
+    let key = session_key.trim();
+    if key.is_empty() {
+        bail!("refusing to store empty session key");
+    }
+    let label = scrobble_keyring_label(service, "session");
+    let entry = keyring_core::Entry::new("ratune", &label)
+        .context("keyring entry for scrobble session")?;
+    entry
+        .set_password(key)
+        .context("storing scrobble session key in keyring")?;
+    Ok(())
 }
 
 /// Load `[scrobble]` application credentials for the browser auth flow.
@@ -1671,9 +1779,39 @@ pub fn load_scrobble_app_credentials() -> Result<(ratune_scrobble::ScrobbleServi
     merge_env_overrides(&mut file_cfg);
 
     let sec = &file_cfg.scrobble;
-    let service = ratune_scrobble::ScrobbleService::parse(&sec.service)
-        .unwrap_or(ratune_scrobble::ScrobbleService::LastFm);
+    let (service, api_key) = {
+        let service = resolve_scrobble_service(sec);
+        let api_key = sec.api_key.trim();
+        if api_key.is_empty() {
+            bail!(
+                "[scrobble].api_key is empty in {} (or set LASTFM_API_KEY / LIBREFM_API_KEY)",
+                config_path.display()
+            );
+        }
+        (service, api_key.to_string())
+    };
+    let api_secret = resolve_scrobble_api_secret(sec)?;
 
+    Ok((service, api_key, api_secret))
+}
+
+/// Load service + application API key (for `scrobble-auth` / store helpers).
+pub fn load_scrobble_api_key() -> Result<(ratune_scrobble::ScrobbleService, String)> {
+    let config_path = config_file_path()?;
+    if !config_path.exists() {
+        bail!(
+            "config file not found at {} — create it first (ratune writes a starter on first run)",
+            config_path.display()
+        );
+    }
+    let text = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let mut file_cfg: FileConfig = toml::from_str(&text)
+        .with_context(|| format!("parsing {}", config_path.display()))?;
+    merge_env_overrides(&mut file_cfg);
+
+    let sec = &file_cfg.scrobble;
+    let service = resolve_scrobble_service(sec);
     let api_key = sec.api_key.trim();
     if api_key.is_empty() {
         bail!(
@@ -1681,15 +1819,7 @@ pub fn load_scrobble_app_credentials() -> Result<(ratune_scrobble::ScrobbleServi
             config_path.display()
         );
     }
-    let api_secret = sec.api_secret.trim();
-    if api_secret.is_empty() {
-        bail!(
-            "[scrobble].api_secret is empty in {} (or set LASTFM_API_SECRET)",
-            config_path.display()
-        );
-    }
-
-    Ok((service, api_key.to_string(), api_secret.to_string()))
+    Ok((service, api_key.to_string()))
 }
 
 #[cfg(test)]
@@ -1742,6 +1872,38 @@ password_command = "secret-tool lookup service ratune"
         assert_eq!(
             resolve_subsonic_secret(&server).expect("command"),
             "from-cmd"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn api_secret_command_shell_output() {
+        let sec = ScrobbleSection {
+            enabled: false,
+            service: "lastfm".into(),
+            api_key: "key".into(),
+            api_secret: String::new(),
+            api_secret_command: "printf '%s' 'shh-secret'".into(),
+            session_key: String::new(),
+            session_key_command: String::new(),
+            scrobble_to_server: true,
+        };
+        assert_eq!(
+            resolve_scrobble_api_secret(&sec).expect("command"),
+            "shh-secret"
+        );
+    }
+
+    #[test]
+    fn parses_scrobble_api_secret_command() {
+        let text = r#"
+[scrobble]
+api_secret_command = "secret-tool lookup service ratune user lastfm|api_secret"
+"#;
+        let fc: FileConfig = toml::from_str(text).expect("toml");
+        assert_eq!(
+            fc.scrobble.api_secret_command,
+            "secret-tool lookup service ratune user lastfm|api_secret"
         );
     }
 

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -12,6 +12,7 @@ mod library_index;
 mod lyrics;
 mod mpris;
 mod persist;
+mod scrobble;
 mod state;
 mod theme;
 mod ui;
@@ -857,6 +858,47 @@ async fn run_loop(
     if let Err(e) = app.history.save(&history_path) {
         eprintln!("warn: could not save history: {e}");
     }
+    Ok(())
+}
+
+/// Obtain a Last.fm / Libre.fm session key via the browser authorization flow.
+pub async fn scrobble_auth() -> Result<()> {
+    use std::io::{self, Write};
+
+    use ratune_scrobble::AuthClient;
+
+    let (service, api_key, api_secret) = config::load_scrobble_app_credentials()?;
+    let client = AuthClient::new(service, api_key, api_secret);
+
+    eprintln!(
+        "Requesting auth token from {}…",
+        client.service().display_name()
+    );
+    let token = client.get_token().await?;
+    let url = client.authorize_url(&token);
+
+    eprintln!();
+    eprintln!("Open this URL in a browser and approve access:");
+    eprintln!("  {url}");
+    eprintln!();
+    eprint!("Press Enter after authorizing… ");
+    io::stdout().flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+
+    eprintln!("Exchanging token for session key…");
+    let session = client.get_session(&token).await?;
+
+    eprintln!();
+    eprintln!("Authorized as: {}", session.username);
+    eprintln!();
+    eprintln!("Add to ~/.config/ratune/config.toml under [scrobble]:");
+    eprintln!("  enabled = true");
+    eprintln!("  session_key = \"{}\"", session.key);
+    eprintln!();
+    eprintln!("Or export for the current shell:");
+    eprintln!("  export LASTFM_SESSION_KEY=\"{}\"", session.key);
+
     Ok(())
 }
 

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -13,6 +13,7 @@ mod lyrics;
 mod mpris;
 mod persist;
 mod scrobble;
+mod scrobble_queue;
 mod state;
 mod theme;
 mod ui;
@@ -109,6 +110,16 @@ pub async fn run() -> Result<()> {
     match history::PlayHistory::load(&history_path) {
         Ok(h) => app.history = h,
         Err(e) => eprintln!("warn: could not load history: {e}"),
+    }
+
+    if app.config.scrobble_enabled {
+        if !app.scrobble_queue.is_empty() {
+            eprintln!(
+                "scrobble: retrying {} queued scrobble(s)…",
+                app.scrobble_queue.len()
+            );
+        }
+        app.spawn_scrobble_queue_flush();
     }
 
     // `refresh_home_data()` only ran when navigating to Home — not on cold start. If we restore
@@ -858,14 +869,17 @@ async fn run_loop(
     if let Err(e) = app.history.save(&history_path) {
         eprintln!("warn: could not save history: {e}");
     }
+    app.persist_scrobble_queue();
     Ok(())
 }
 
 /// Obtain a Last.fm / Libre.fm session key via the browser authorization flow.
-pub async fn scrobble_auth() -> Result<()> {
+pub async fn scrobble_auth(save_keyring: bool) -> Result<()> {
     use std::io::{self, Write};
 
     use ratune_scrobble::AuthClient;
+
+    keyring_init::install_default_keyring_store();
 
     let (service, api_key, api_secret) = config::load_scrobble_app_credentials()?;
     let client = AuthClient::new(service, api_key, api_secret);
@@ -892,12 +906,101 @@ pub async fn scrobble_auth() -> Result<()> {
     eprintln!();
     eprintln!("Authorized as: {}", session.username);
     eprintln!();
-    eprintln!("Add to ~/.config/ratune/config.toml under [scrobble]:");
-    eprintln!("  enabled = true");
-    eprintln!("  session_key = \"{}\"", session.key);
-    eprintln!();
-    eprintln!("Or export for the current shell:");
-    eprintln!("  export LASTFM_SESSION_KEY=\"{}\"", session.key);
+
+    if save_keyring {
+        match config::store_scrobble_session_key(client.service(), &session.key) {
+            Ok(()) => {
+                eprintln!(
+                    "Session key saved to the OS keyring (service \"ratune\", user \"{}\").",
+                    scrobble_keyring_user_label(client.service(), "session")
+                );
+                eprintln!("You can leave session_key empty in config and set enabled = true.");
+            }
+            Err(e) => {
+                eprintln!("warning: could not save session key to keyring: {e:#}");
+                eprintln!("Add it manually to ~/.config/ratune/config.toml:");
+                eprintln!("  session_key = \"{}\"", session.key);
+            }
+        }
+    } else {
+        eprintln!("Add to ~/.config/ratune/config.toml under [scrobble]:");
+        eprintln!("  enabled = true");
+        eprintln!("  session_key = \"{}\"", session.key);
+        eprintln!();
+        eprintln!("Or store in the OS keyring and leave session_key empty:");
+        eprintln!("  ratune scrobble-auth --save-keyring");
+        eprintln!();
+        eprintln!("Or export for the current shell:");
+        eprintln!("  export LASTFM_SESSION_KEY=\"{}\"", session.key);
+    }
+
+    Ok(())
+}
+
+fn scrobble_service_display(service: ratune_scrobble::ScrobbleService) -> &'static str {
+    match service {
+        ratune_scrobble::ScrobbleService::LastFm => "Last.fm",
+        ratune_scrobble::ScrobbleService::LibreFm => "Libre.fm",
+    }
+}
+
+fn scrobble_keyring_user_label(service: ratune_scrobble::ScrobbleService, kind: &str) -> &str {
+    match (service, kind) {
+        (ratune_scrobble::ScrobbleService::LastFm, "api_secret") => "lastfm|api_secret",
+        (ratune_scrobble::ScrobbleService::LibreFm, "api_secret") => "librefm|api_secret",
+        (ratune_scrobble::ScrobbleService::LastFm, "session") => "lastfm|session",
+        (ratune_scrobble::ScrobbleService::LibreFm, "session") => "librefm|session",
+        (_, other) => other,
+    }
+}
+
+/// Prompt for the Last.fm / Libre.fm API shared secret.
+pub fn scrobble_api_secret(save_keyring: bool) -> Result<()> {
+    use inquire::Password;
+
+    keyring_init::install_default_keyring_store();
+
+    let (service, api_key) = config::load_scrobble_api_key()?;
+    eprintln!(
+        "{} API shared secret for application key {api_key}",
+        scrobble_service_display(service)
+    );
+
+    let secret = Password::new("API shared secret:")
+        .without_confirmation()
+        .prompt()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let secret = secret.trim();
+    if secret.is_empty() {
+        anyhow::bail!("empty API secret");
+    }
+
+    if save_keyring {
+        match config::store_scrobble_api_secret(service, secret) {
+            Ok(()) => {
+                eprintln!(
+                    "API secret saved to the OS keyring (service \"ratune\", user \"{}\").",
+                    scrobble_keyring_user_label(service, "api_secret")
+                );
+                eprintln!("You can leave api_secret empty in config and unset LASTFM_API_SECRET.");
+            }
+            Err(e) => {
+                eprintln!("warning: could not save API secret to keyring: {e:#}");
+                eprintln!("Add it manually to ~/.config/ratune/config.toml:");
+                eprintln!("  api_secret = \"{secret}\"");
+            }
+        }
+    } else {
+        eprintln!();
+        eprintln!("Add to ~/.config/ratune/config.toml under [scrobble]:");
+        eprintln!("  api_secret = \"{secret}\"");
+        eprintln!();
+        eprintln!("Or store in the OS keyring and leave api_secret empty:");
+        eprintln!("  ratune scrobble-api-secret --save-keyring");
+        eprintln!();
+        eprintln!("Or export for the current shell:");
+        eprintln!("  export LASTFM_API_SECRET=\"{secret}\"");
+    }
 
     Ok(())
 }

--- a/ratune/src/main.rs
+++ b/ratune/src/main.rs
@@ -12,8 +12,11 @@ fn print_help() {
     println!("{PKG_NAME} {PKG_VERSION}");
     println!();
     println!("Usage:");
-    println!("  {PKG_NAME}              Start the terminal music player");
-    println!("  {PKG_NAME} scrobble-auth  Obtain a Last.fm / Libre.fm session key");
+    println!("  {PKG_NAME}                               Start the terminal music player");
+    println!("  {PKG_NAME} scrobble-api-secret             Prompt for API shared secret");
+    println!("  {PKG_NAME} scrobble-api-secret --save-keyring  …and store it in the OS keyring");
+    println!("  {PKG_NAME} scrobble-auth                     Obtain a Last.fm / Libre.fm session key");
+    println!("  {PKG_NAME} scrobble-auth --save-keyring         …and store it in the OS keyring");
     println!();
     println!("Configuration: ~/.config/ratune/config.toml");
     println!("{PKG_REPOSITORY}");
@@ -21,6 +24,18 @@ fn print_help() {
     println!("Options:");
     println!("  -V, --version  Print version and exit");
     println!("  -h, --help     Print this help and exit");
+}
+
+async fn run_scrobble_subcommand(cmd: &str, save_keyring: bool) -> Result<()> {
+    match cmd {
+        "scrobble-api-secret" => ratune::scrobble_api_secret(save_keyring),
+        "scrobble-auth" => ratune::scrobble_auth(save_keyring).await,
+        other => {
+            eprintln!("{PKG_NAME}: unknown scrobble subcommand '{other}'");
+            eprintln!("Try '{PKG_NAME} --help' for usage.");
+            process::exit(2);
+        }
+    }
 }
 
 #[tokio::main]
@@ -37,13 +52,18 @@ async fn main() -> Result<()> {
                 print_help();
                 return Ok(());
             }
-            "scrobble-auth" => return ratune::scrobble_auth().await,
+            "scrobble-api-secret" | "scrobble-auth" => {
+                return run_scrobble_subcommand(a, false).await;
+            }
             other => {
                 eprintln!("{PKG_NAME}: unknown argument '{other}'");
                 eprintln!("Try '{PKG_NAME} --help' for usage.");
                 process::exit(2);
             }
         },
+        [a, b] if b == "--save-keyring" => {
+            return run_scrobble_subcommand(a, true).await;
+        }
         _ => {
             eprintln!("{PKG_NAME}: too many arguments");
             eprintln!("Try '{PKG_NAME} --help' for usage.");

--- a/ratune/src/main.rs
+++ b/ratune/src/main.rs
@@ -8,6 +8,21 @@ const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PKG_REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
 
+fn print_help() {
+    println!("{PKG_NAME} {PKG_VERSION}");
+    println!();
+    println!("Usage:");
+    println!("  {PKG_NAME}              Start the terminal music player");
+    println!("  {PKG_NAME} scrobble-auth  Obtain a Last.fm / Libre.fm session key");
+    println!();
+    println!("Configuration: ~/.config/ratune/config.toml");
+    println!("{PKG_REPOSITORY}");
+    println!();
+    println!("Options:");
+    println!("  -V, --version  Print version and exit");
+    println!("  -h, --help     Print this help and exit");
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -19,19 +34,10 @@ async fn main() -> Result<()> {
                 return Ok(());
             }
             "-h" | "--help" => {
-                println!("{PKG_NAME} {PKG_VERSION}");
-                println!();
-                println!("Usage: {PKG_NAME}");
-                println!();
-                println!("Terminal music player for Subsonic-compatible servers.");
-                println!("Configuration: ~/.config/ratune/config.toml");
-                println!("{PKG_REPOSITORY}");
-                println!();
-                println!("Options:");
-                println!("  -V, --version  Print version and exit");
-                println!("  -h, --help     Print this help and exit");
+                print_help();
                 return Ok(());
             }
+            "scrobble-auth" => return ratune::scrobble_auth().await,
             other => {
                 eprintln!("{PKG_NAME}: unknown argument '{other}'");
                 eprintln!("Try '{PKG_NAME} --help' for usage.");

--- a/ratune/src/main.rs
+++ b/ratune/src/main.rs
@@ -15,7 +15,9 @@ fn print_help() {
     println!("  {PKG_NAME}                               Start the terminal music player");
     println!("  {PKG_NAME} scrobble-api-secret             Prompt for API shared secret");
     println!("  {PKG_NAME} scrobble-api-secret --save-keyring  …and store it in the OS keyring");
-    println!("  {PKG_NAME} scrobble-auth                     Obtain a Last.fm / Libre.fm session key");
+    println!(
+        "  {PKG_NAME} scrobble-auth                     Obtain a Last.fm / Libre.fm session key"
+    );
     println!("  {PKG_NAME} scrobble-auth --save-keyring         …and store it in the OS keyring");
     println!();
     println!("Configuration: ~/.config/ratune/config.toml");

--- a/ratune/src/scrobble.rs
+++ b/ratune/src/scrobble.rs
@@ -2,6 +2,10 @@ use std::sync::Arc;
 
 use ratune_scrobble::{AudioscrobblerClient, TrackInfo};
 use ratune_subsonic::{Song, SubsonicClient};
+use tokio::sync::mpsc;
+
+use crate::app::LibraryUpdate;
+use crate::scrobble_queue::QueuedScrobble;
 
 pub fn track_from_song(song: &Song) -> TrackInfo {
     TrackInfo {
@@ -30,11 +34,25 @@ pub fn spawn_audioscrobbler_scrobble(
     client: AudioscrobblerClient,
     track: TrackInfo,
     timestamp: i64,
+    tx: mpsc::Sender<LibraryUpdate>,
+    from_live: bool,
 ) {
     tokio::spawn(async move {
-        if let Err(e) = client.scrobble(&track, timestamp).await {
-            eprintln!("scrobble: submit failed: {e:#}");
-        }
+        let artist = track.artist.clone();
+        let title = track.title.clone();
+        let result = client
+            .scrobble(&track, timestamp)
+            .await
+            .map_err(|e| e.to_string());
+        let _ = tx
+            .send(LibraryUpdate::ScrobbleResult {
+                entry: QueuedScrobble::from_track(&track, timestamp),
+                result,
+                artist,
+                title,
+                from_live,
+            })
+            .await;
     });
 }
 
@@ -42,6 +60,37 @@ pub fn spawn_subsonic_scrobble(client: Arc<SubsonicClient>, song_id: String) {
     tokio::spawn(async move {
         if let Err(e) = client.scrobble(&song_id).await {
             eprintln!("scrobble: server scrobble failed: {e:#}");
+        }
+    });
+}
+
+pub fn spawn_flush_scrobble_queue(
+    client: AudioscrobblerClient,
+    entries: Vec<QueuedScrobble>,
+    tx: mpsc::Sender<LibraryUpdate>,
+) {
+    if entries.is_empty() {
+        return;
+    }
+    tokio::spawn(async move {
+        for entry in entries {
+            let artist = entry.artist.clone();
+            let title = entry.title.clone();
+            let timestamp = entry.timestamp;
+            let track = entry.to_track_info();
+            let result = client
+                .scrobble(&track, timestamp)
+                .await
+                .map_err(|e| e.to_string());
+            let _ = tx
+                .send(LibraryUpdate::ScrobbleResult {
+                    entry,
+                    result,
+                    artist,
+                    title,
+                    from_live: false,
+                })
+                .await;
         }
     });
 }

--- a/ratune/src/scrobble.rs
+++ b/ratune/src/scrobble.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use ratune_scrobble::{AudioscrobblerClient, TrackInfo};
+use ratune_subsonic::{Song, SubsonicClient};
+
+pub fn track_from_song(song: &Song) -> TrackInfo {
+    TrackInfo {
+        song_id: song.id.clone(),
+        artist: song
+            .artist
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "Unknown Artist".into()),
+        title: song.title.clone(),
+        album: song.album.clone().filter(|s| !s.is_empty()),
+        track_number: song.track,
+        duration_secs: song.duration,
+    }
+}
+
+pub fn spawn_now_playing(client: AudioscrobblerClient, track: TrackInfo) {
+    tokio::spawn(async move {
+        if let Err(e) = client.update_now_playing(&track).await {
+            eprintln!("scrobble: now playing failed: {e:#}");
+        }
+    });
+}
+
+pub fn spawn_audioscrobbler_scrobble(
+    client: AudioscrobblerClient,
+    track: TrackInfo,
+    timestamp: i64,
+) {
+    tokio::spawn(async move {
+        if let Err(e) = client.scrobble(&track, timestamp).await {
+            eprintln!("scrobble: submit failed: {e:#}");
+        }
+    });
+}
+
+pub fn spawn_subsonic_scrobble(client: Arc<SubsonicClient>, song_id: String) {
+    tokio::spawn(async move {
+        if let Err(e) = client.scrobble(&song_id).await {
+            eprintln!("scrobble: server scrobble failed: {e:#}");
+        }
+    });
+}

--- a/ratune/src/scrobble_queue.rs
+++ b/ratune/src/scrobble_queue.rs
@@ -1,0 +1,140 @@
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use ratune_scrobble::TrackInfo;
+use serde::{Deserialize, Serialize};
+
+/// One scrobble waiting to be submitted after a network/API failure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QueuedScrobble {
+    pub artist: String,
+    pub title: String,
+    pub album: Option<String>,
+    pub track_number: Option<u32>,
+    pub duration_secs: Option<u32>,
+    /// Unix seconds when playback started (Audioscrobbler timestamp).
+    pub timestamp: i64,
+}
+
+impl QueuedScrobble {
+    pub fn from_track(track: &TrackInfo, timestamp: i64) -> Self {
+        Self {
+            artist: track.artist.clone(),
+            title: track.title.clone(),
+            album: track.album.clone(),
+            track_number: track.track_number,
+            duration_secs: track.duration_secs,
+            timestamp,
+        }
+    }
+
+    pub fn to_track_info(&self) -> TrackInfo {
+        TrackInfo {
+            song_id: String::new(),
+            artist: self.artist.clone(),
+            title: self.title.clone(),
+            album: self.album.clone(),
+            track_number: self.track_number,
+            duration_secs: self.duration_secs,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ScrobbleQueue {
+    pub entries: Vec<QueuedScrobble>,
+}
+
+const MAX_ENTRIES: usize = 500;
+/// Last.fm rejects scrobbles older than ~14 days.
+const MAX_AGE_SECS: i64 = 14 * 86_400;
+
+impl ScrobbleQueue {
+    pub fn push(&mut self, entry: QueuedScrobble) {
+        if self.entries.iter().any(|e| e == &entry) {
+            return;
+        }
+        self.entries.push(entry);
+        if self.entries.len() > MAX_ENTRIES {
+            let excess = self.entries.len() - MAX_ENTRIES;
+            self.entries.drain(0..excess);
+        }
+    }
+
+    pub fn drop_stale(&mut self) {
+        let now = now_secs();
+        self.entries
+            .retain(|e| now.saturating_sub(e.timestamp) <= MAX_AGE_SECS);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("reading scrobble queue {}", path.display()))?;
+        let mut queue: Self = serde_json::from_str(&text)
+            .with_context(|| format!("parsing scrobble queue {}", path.display()))?;
+        queue.drop_stale();
+        Ok(queue)
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating scrobble queue dir {}", parent.display()))?;
+        }
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)
+            .with_context(|| format!("writing scrobble queue {}", path.display()))?;
+        Ok(())
+    }
+}
+
+pub fn scrobble_queue_path() -> std::path::PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        std::path::PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("ratune")
+            .join("scrobble-queue.json")
+    } else {
+        std::path::PathBuf::from("scrobble-queue.json")
+    }
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_entries_older_than_fourteen_days() {
+        let mut q = ScrobbleQueue::default();
+        q.entries.push(QueuedScrobble {
+            artist: "A".into(),
+            title: "T".into(),
+            album: None,
+            track_number: None,
+            duration_secs: None,
+            timestamp: now_secs() - MAX_AGE_SECS - 1,
+        });
+        q.drop_stale();
+        assert!(q.is_empty());
+    }
+}

--- a/ratune/src/ui/status_bar.rs
+++ b/ratune/src/ui/status_bar.rs
@@ -39,6 +39,46 @@ fn library_fetch_status_text(app: &App) -> String {
     format!("Fetching full library {sp}  ·  {secs}s")
 }
 
+fn scrobble_service_name(app: &App) -> &'static str {
+    match app.config.scrobble_service {
+        ratune_scrobble::ScrobbleService::LastFm => "Last.fm",
+        ratune_scrobble::ScrobbleService::LibreFm => "Libre.fm",
+    }
+}
+
+fn scrobble_status_width(app: &App) -> usize {
+    if !app.config.scrobble_enabled {
+        return 0;
+    }
+    let mut w = scrobble_service_name(app).len();
+    if app.scrobble_recently_ok() {
+        w += " ✓".len();
+    }
+    if !app.scrobble_queue.is_empty() {
+        w += format!(" ({})", app.scrobble_queue.len()).len();
+    }
+    w
+}
+
+fn push_scrobble_status_spans(app: &App, spans: &mut Vec<Span>, accent: ratatui::style::Color, dimmed: ratatui::style::Color) {
+    if !app.config.scrobble_enabled {
+        return;
+    }
+    spans.push(Span::styled(
+        scrobble_service_name(app).to_string(),
+        Style::default().fg(dimmed),
+    ));
+    if app.scrobble_recently_ok() {
+        spans.push(Span::styled(" ✓", Style::default().fg(accent)));
+    }
+    if !app.scrobble_queue.is_empty() {
+        spans.push(Span::styled(
+            format!(" ({})", app.scrobble_queue.len()),
+            Style::default().fg(dimmed),
+        ));
+    }
+}
+
 // ── Public render ─────────────────────────────────────────────────────────────
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect) {
@@ -88,19 +128,6 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
     } else {
         let hint = "i — help";
         let sep = "  ·  ";
-        let scrobble_label = if app.config.scrobble_enabled {
-            let name = match app.config.scrobble_service {
-                ratune_scrobble::ScrobbleService::LastFm => "Last.fm",
-                ratune_scrobble::ScrobbleService::LibreFm => "Libre.fm",
-            };
-            if app.scrobble_queue.is_empty() {
-                name.to_string()
-            } else {
-                format!("{name} ({})", app.scrobble_queue.len())
-            }
-        } else {
-            String::new()
-        };
         let host = app
             .config
             .subsonic_url
@@ -112,8 +139,9 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
         if app.config.show_volume_indicator {
             right_w += sep.len() + vol_label.len();
         }
-        if !scrobble_label.is_empty() {
-            right_w += sep.len() + scrobble_label.len();
+        let scrobble_w = scrobble_status_width(app);
+        if scrobble_w > 0 {
+            right_w += sep.len() + scrobble_w;
         }
 
         let host_w = 2 + host.len();
@@ -124,11 +152,8 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
             Span::styled(host.to_string(), Style::default().fg(t.dimmed)),
             Span::raw(" ".repeat(gap)),
         ];
-        if !scrobble_label.is_empty() {
-            spans.push(Span::styled(
-                scrobble_label,
-                Style::default().fg(t.dimmed),
-            ));
+        if app.config.scrobble_enabled {
+            push_scrobble_status_spans(app, &mut spans, app.accent(), t.dimmed);
             spans.push(Span::styled(sep, Style::default().fg(t.dimmed)));
         }
         if app.config.show_volume_indicator {

--- a/ratune/src/ui/status_bar.rs
+++ b/ratune/src/ui/status_bar.rs
@@ -86,21 +86,37 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
         let shown = fit_status_bar_text(msg, w);
         Line::from(vec![Span::styled(shown, Style::default().fg(app.accent()))])
     } else {
+        let hint = "i — help";
+        let sep = "  ·  ";
+        let scrobble_label = if app.config.scrobble_enabled {
+            let name = match app.config.scrobble_service {
+                ratune_scrobble::ScrobbleService::LastFm => "Last.fm",
+                ratune_scrobble::ScrobbleService::LibreFm => "Libre.fm",
+            };
+            if app.scrobble_queue.is_empty() {
+                name.to_string()
+            } else {
+                format!("{name} ({})", app.scrobble_queue.len())
+            }
+        } else {
+            String::new()
+        };
         let host = app
             .config
             .subsonic_url
             .trim_start_matches("http://")
             .trim_start_matches("https://");
-
-        let hint = "i — help";
-        let sep = "  ·  ";
         let vol_label = format!("{}%", app.config.default_volume);
-        let right_w = if app.config.show_volume_indicator {
-            vol_label.len() + sep.len() + hint.len()
-        } else {
-            hint.len()
-        };
-        let host_w = 2 + host.len(); // "● " + host
+
+        let mut right_w = hint.len();
+        if app.config.show_volume_indicator {
+            right_w += sep.len() + vol_label.len();
+        }
+        if !scrobble_label.is_empty() {
+            right_w += sep.len() + scrobble_label.len();
+        }
+
+        let host_w = 2 + host.len();
         let gap = (area.width as usize).saturating_sub(host_w + right_w);
 
         let mut spans = vec![
@@ -108,6 +124,13 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
             Span::styled(host.to_string(), Style::default().fg(t.dimmed)),
             Span::raw(" ".repeat(gap)),
         ];
+        if !scrobble_label.is_empty() {
+            spans.push(Span::styled(
+                scrobble_label,
+                Style::default().fg(t.dimmed),
+            ));
+            spans.push(Span::styled(sep, Style::default().fg(t.dimmed)));
+        }
         if app.config.show_volume_indicator {
             spans.push(Span::styled(vol_label, Style::default().fg(app.accent())));
             spans.push(Span::styled(sep, Style::default().fg(t.dimmed)));

--- a/ratune/src/ui/status_bar.rs
+++ b/ratune/src/ui/status_bar.rs
@@ -60,7 +60,12 @@ fn scrobble_status_width(app: &App) -> usize {
     w
 }
 
-fn push_scrobble_status_spans(app: &App, spans: &mut Vec<Span>, accent: ratatui::style::Color, dimmed: ratatui::style::Color) {
+fn push_scrobble_status_spans(
+    app: &App,
+    spans: &mut Vec<Span>,
+    accent: ratatui::style::Color,
+    dimmed: ratatui::style::Color,
+) {
     if !app.config.scrobble_enabled {
         return;
     }


### PR DESCRIPTION
Adds support for scrobbling. Addresses #13.

Includes:
- compatibility with last.fm and libre.fm
- secret storage similar to subsonic password
- scrobble threshold customization
- backlog if connection is lost
- proper README updates