### PR TITLE
fix: clicking in browse and homepage

### DIFF
--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -261,10 +261,14 @@ panels = ["recent_albums", "recent_tracks", "rediscover"]
 # mode — Default layout on startup when folder_navigation is true: "artists" or
 #   "files". When folder_navigation is false, the Browse tab always starts as
 #   artists. "genre" is still a stub.
+# mouse_wheel_scroll_lines — Rows to move per mouse wheel tick in Browse lists
+#   (artists, albums, tracks, and folder browse). Default: 1. Keyboard j/k always
+#   moves one row.
 
 [ui.browsetab]
 folder_navigation = false
 mode = "artists"
+# mouse_wheel_scroll_lines = 10
 
 # -----------------------------------------------------------------------------
 # [ui.nptab] — Now Playing tab overrides

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -3542,7 +3542,7 @@ impl App {
     fn handle_navigate(&mut self, dir: Direction) {
         match self.active_tab {
             Tab::Home => self.handle_navigate_home(dir),
-            Tab::Browser => self.handle_navigate_browser(dir),
+            Tab::Browser => self.handle_navigate_browser(dir, 1),
             Tab::NowPlaying => self.handle_navigate_queue(dir),
         }
     }
@@ -3676,9 +3676,9 @@ impl App {
         };
     }
 
-    fn handle_navigate_browser(&mut self, dir: Direction) {
+    fn handle_navigate_browser(&mut self, dir: Direction, line_steps: usize) {
         if self.browse_files() {
-            self.handle_navigate_browser_files(dir);
+            self.handle_navigate_browser_files(dir, line_steps);
             return;
         }
         match self.browser_focus {
@@ -3706,8 +3706,8 @@ impl App {
                         .unwrap_or(0);
                     let page = self.browser_list_viewport_rows.max(1);
                     let new_pos = match dir {
-                        Direction::Up => cur_pos.saturating_sub(1),
-                        Direction::Down => (cur_pos + 1).min(indices.len() - 1),
+                        Direction::Up => cur_pos.saturating_sub(line_steps),
+                        Direction::Down => (cur_pos + line_steps).min(indices.len() - 1),
                         Direction::Top => 0,
                         Direction::Bottom => indices.len() - 1,
                         Direction::PageUp => cur_pos.saturating_sub(page),
@@ -3759,8 +3759,8 @@ impl App {
                             .unwrap_or(0);
                         let page = self.browser_list_viewport_rows.max(1);
                         let new_pos = match dir {
-                            Direction::Up => cur_pos.saturating_sub(1),
-                            Direction::Down => (cur_pos + 1).min(indices.len() - 1),
+                            Direction::Up => cur_pos.saturating_sub(line_steps),
+                            Direction::Down => (cur_pos + line_steps).min(indices.len() - 1),
                             Direction::Top => 0,
                             Direction::Bottom => indices.len() - 1,
                             Direction::PageUp => cur_pos.saturating_sub(page),
@@ -3810,8 +3810,8 @@ impl App {
                         .unwrap_or(0);
                     let page = self.browser_list_viewport_rows.max(1);
                     let new_pos = match dir {
-                        Direction::Up => cur_pos.saturating_sub(1),
-                        Direction::Down => (cur_pos + 1).min(indices.len() - 1),
+                        Direction::Up => cur_pos.saturating_sub(line_steps),
+                        Direction::Down => (cur_pos + line_steps).min(indices.len() - 1),
                         Direction::Top => 0,
                         Direction::Bottom => indices.len() - 1,
                         Direction::PageUp => cur_pos.saturating_sub(page),
@@ -3823,7 +3823,7 @@ impl App {
         }
     }
 
-    fn handle_navigate_browser_files(&mut self, dir: Direction) {
+    fn handle_navigate_browser_files(&mut self, dir: Direction, line_steps: usize) {
         let page = self.browser_list_viewport_rows.max(1);
         match self.browser_focus {
             BrowserColumn::Artists | BrowserColumn::Albums => {
@@ -3865,8 +3865,8 @@ impl App {
                 }
                 let cur = self.folders.selected_dir.unwrap_or(0).min(len - 1);
                 let new_pos = match dir {
-                    Direction::Up => cur.saturating_sub(1),
-                    Direction::Down => (cur + 1).min(len - 1),
+                    Direction::Up => cur.saturating_sub(line_steps),
+                    Direction::Down => (cur + line_steps).min(len - 1),
                     Direction::Top => 0,
                     Direction::Bottom => len - 1,
                     Direction::PageUp => cur.saturating_sub(page),
@@ -3890,8 +3890,8 @@ impl App {
                     }
                     let cur_pos = self.folders.preview_selected_row.min(rows.len() - 1);
                     let new_pos = match dir {
-                        Direction::Up => cur_pos.saturating_sub(1),
-                        Direction::Down => (cur_pos + 1).min(rows.len() - 1),
+                        Direction::Up => cur_pos.saturating_sub(line_steps),
+                        Direction::Down => (cur_pos + line_steps).min(rows.len() - 1),
                         Direction::Top => 0,
                         Direction::Bottom => rows.len() - 1,
                         Direction::PageUp => cur_pos.saturating_sub(page),
@@ -4532,6 +4532,11 @@ impl App {
     }
 
     // ── Mouse-click helpers (called from main.rs event handler) ──────────────
+
+    pub fn navigate_browser_wheel(&mut self, dir: Direction) {
+        let steps = self.config.browse_mouse_wheel_scroll_lines.max(1);
+        self.handle_navigate_browser(dir, steps);
+    }
 
     pub fn click_browser_artist(&mut self, orig_idx: usize) {
         if let LoadingState::Loaded(artists) = &self.library.artists {

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -553,6 +553,9 @@ pub struct UiBrowseTabSection {
     /// applies when [`folder_navigation`](Self::folder_navigation) is true).
     #[serde(default)]
     pub mode: Option<String>,
+    /// Browse tab: list rows to move per mouse wheel tick (default: 1).
+    #[serde(default)]
+    pub mouse_wheel_scroll_lines: Option<usize>,
 }
 
 /// Optional nested `[ui.nptab]` (Now Playing tab) table.
@@ -950,6 +953,8 @@ pub struct Config {
     pub browse_mode: BrowseMode,
     /// When true, folder browsing can be toggled with the keybind and used from the Browse tab.
     pub browse_folder_navigation: bool,
+    /// Browse tab: list rows to move per mouse wheel tick.
+    pub browse_mouse_wheel_scroll_lines: usize,
     /// Scrobble listens to Last.fm or Libre.fm when enabled and credentials are configured.
     pub scrobble_enabled: bool,
     pub scrobble_service: ratune_scrobble::ScrobbleService,
@@ -1229,6 +1234,12 @@ impl Config {
             .as_ref()
             .and_then(|b| b.folder_navigation)
             .unwrap_or(false);
+        let browse_mouse_wheel_scroll_lines = ui
+            .browsetab
+            .as_ref()
+            .and_then(|b| b.mouse_wheel_scroll_lines)
+            .unwrap_or(1)
+            .max(1);
 
         let scrobble = &file_cfg.scrobble;
         let scrobble_enabled = scrobble.enabled;
@@ -1305,6 +1316,7 @@ impl Config {
             home_panels,
             browse_mode,
             browse_folder_navigation,
+            browse_mouse_wheel_scroll_lines,
             scrobble_enabled,
             scrobble_service,
             scrobble_api_key,

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -743,12 +743,34 @@ async fn run_loop(
                                     }
                                 }
                             }
-                        Event::Mouse(mouse)
-                            if mouse.kind == MouseEventKind::Down(MouseButton::Left) => {
-                                let sz = terminal.size()?;
-                                let area = ratatui::layout::Rect::new(0, 0, sz.width, sz.height);
-                                handle_mouse_click(mouse.column, mouse.row, app, area);
+                        Event::Mouse(mouse) => {
+                            let sz = terminal.size()?;
+                            let area = Rect::new(0, 0, sz.width, sz.height);
+                            match mouse.kind {
+                                MouseEventKind::Down(MouseButton::Left) => {
+                                    handle_mouse_click(mouse.column, mouse.row, app, area);
+                                }
+                                MouseEventKind::ScrollUp => {
+                                    handle_mouse_wheel(
+                                        mouse.column,
+                                        mouse.row,
+                                        Direction::Up,
+                                        app,
+                                        area,
+                                    );
+                                }
+                                MouseEventKind::ScrollDown => {
+                                    handle_mouse_wheel(
+                                        mouse.column,
+                                        mouse.row,
+                                        Direction::Down,
+                                        app,
+                                        area,
+                                    );
+                                }
+                                _ => {}
                             }
+                        }
                         Event::Resize(_, _) => {
                             // Terminal resized — clear any displayed image and reset
                             // stored state so the art is re-encoded at the new size.
@@ -1038,53 +1060,28 @@ fn handle_home_click(x: u16, y: u16, app: &mut App, center: ratatui::layout::Rec
 }
 
 fn home_click_panel(x: u16, y: u16, area: Rect, panel: HomePanel, app: &mut App) {
-    use crate::ui::kitty_art::{art_strip_layout, art_strip_thumb_hit, KITTY_STRIP_MAX_SLOTS};
-
     match panel {
         HomePanel::RecentAlbums => {
-            let inner = Rect {
-                x: area.x + 1,
-                y: area.y + 1,
-                width: area.width.saturating_sub(2),
-                height: area.height.saturating_sub(2),
+            let inner = crate::ui::home_tab::home_panel_inner(area);
+            let album_count = app.home.recent_albums.len();
+            let Some(album_index) = crate::ui::home_tab::home_recent_album_index_at(
+                x,
+                y,
+                inner,
+                app.config.home_recent_albums_show_art,
+                app.home.album_scroll_offset,
+                album_count,
+            ) else {
+                return;
             };
-            if y < inner.y
-                || y >= inner.y + inner.height
-                || x < inner.x
-                || x >= inner.x + inner.width
+            if app.home.active_section == app::HomeSection::RecentAlbums
+                && app.home.album_selected_index == album_index
             {
-                return;
-            }
-            app.home.active_section = app::HomeSection::RecentAlbums;
-            app.home.selected_index = 0;
-
-            let layout = art_strip_layout(inner.width, inner.height);
-            let rel_x = x.saturating_sub(inner.x);
-            let rel_y = y.saturating_sub(inner.y);
-            let Some((row_in_grid, col_in_grid)) = art_strip_thumb_hit(&layout, rel_x, rel_y)
-            else {
-                return;
-            };
-            let slot = (row_in_grid as usize) * layout.per_row + (col_in_grid as usize);
-            let max_slots = layout.total_visible.min(KITTY_STRIP_MAX_SLOTS);
-            if slot >= max_slots {
-                return;
-            }
-            let album_index = app.home.album_scroll_offset + slot;
-            if album_index < app.home.recent_albums.len() {
-                if app.home.album_selected_index == album_index {
-                    if app.kitty_apc_overlay_active() {
-                        let _ = crate::ui::kitty_art::clear_image(app.in_tmux);
-                        let _ = crate::ui::kitty_art::clear_art_strip(app.in_tmux);
-                    }
-                    if app.ratatui_art_ready() && !app.ratatui_uses_kitty_apc() {
-                        app.clear_ratatui_art_state();
-                    }
-                    app.active_tab = app::Tab::Browser;
-                    app.clear_browser_search();
-                } else {
-                    app.home.album_selected_index = album_index;
-                }
+                app.dispatch(Action::Select);
+            } else {
+                app.home.active_section = app::HomeSection::RecentAlbums;
+                app.home.selected_index = 0;
+                app.home.album_selected_index = album_index;
             }
         }
         HomePanel::RecentTracks => {
@@ -1509,6 +1506,91 @@ fn map_help_key(code: KeyCode, modifiers: KeyModifiers, kb: &Keybinds) -> Action
     Action::None
 }
 
+// ── Browser column hit-test (shared by click + wheel) ─────────────────────────
+
+struct BrowserColumnHit {
+    focus: BrowserColumn,
+    col_idx: usize,
+    col_area: Rect,
+}
+
+fn browser_column_hit(
+    x: u16,
+    y: u16,
+    center: Rect,
+    browse_mode: BrowseMode,
+) -> Option<BrowserColumnHit> {
+    use ratatui::layout::{Constraint, Layout};
+
+    if y < center.y || y >= center.y + center.height {
+        return None;
+    }
+
+    let files_mode = browse_mode == BrowseMode::Files;
+    let browser_cols = if files_mode {
+        Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)]).split(center)
+    } else {
+        Layout::horizontal([
+            Constraint::Percentage(30),
+            Constraint::Percentage(35),
+            Constraint::Percentage(35),
+        ])
+        .split(center)
+    };
+
+    let col_idx = if files_mode {
+        if x < browser_cols[1].x {
+            0usize
+        } else {
+            1
+        }
+    } else if x < browser_cols[1].x {
+        0usize
+    } else if x < browser_cols[2].x {
+        1
+    } else {
+        2
+    };
+
+    let col_area = browser_cols[col_idx];
+    if y <= col_area.y || y >= col_area.y + col_area.height - 1 {
+        return None;
+    }
+
+    let focus = if files_mode {
+        match col_idx {
+            0 => BrowserColumn::Artists,
+            _ => BrowserColumn::Tracks,
+        }
+    } else {
+        match col_idx {
+            0 => BrowserColumn::Artists,
+            1 => BrowserColumn::Albums,
+            _ => BrowserColumn::Tracks,
+        }
+    };
+
+    Some(BrowserColumnHit {
+        focus,
+        col_idx,
+        col_area,
+    })
+}
+
+fn handle_mouse_wheel(x: u16, y: u16, dir: Direction, app: &mut App, terminal_size: Rect) {
+    if app.active_tab != Tab::Browser {
+        return;
+    }
+
+    let areas = ui::layout::build_layout(terminal_size, &ui::layout::layout_options_for_app(app));
+    let Some(hit) = browser_column_hit(x, y, areas.center, app.browser_browse_mode) else {
+        return;
+    };
+
+    app.browser_focus = hit.focus;
+    app.navigate_browser_wheel(dir);
+}
+
 // ── Mouse click handler ───────────────────────────────────────────────────────
 //
 // CALL PATH DIAGNOSIS (tab-bar freeze, 2026-03-28)
@@ -1538,7 +1620,6 @@ fn map_help_key(code: KeyCode, modifiers: KeyModifiers, kb: &Keybinds) -> Action
 //      the album scroll / selection changes.
 
 fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::layout::Rect) {
-    use ratatui::layout::{Constraint, Layout};
     use state::LoadingState;
 
     // Always use build_layout: the renderer uses it for all three tabs.
@@ -1628,55 +1709,13 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
             handle_home_click(x, y, app, center);
         }
         Tab::Browser => {
-            let files_mode = app.browser_browse_mode == BrowseMode::Files;
-            let browser_cols = if files_mode {
-                Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)])
-                    .split(center)
-            } else {
-                Layout::horizontal([
-                    Constraint::Percentage(30),
-                    Constraint::Percentage(35),
-                    Constraint::Percentage(35),
-                ])
-                .split(center)
-            };
-
-            let col_idx = if files_mode {
-                if x < browser_cols[1].x {
-                    0usize
-                } else {
-                    1
-                }
-            } else if x < browser_cols[1].x {
-                0usize
-            } else if x < browser_cols[2].x {
-                1
-            } else {
-                2
-            };
-
-            let col_area = browser_cols[col_idx];
-            // Ignore clicks on the border rows.
-            if y <= col_area.y || y >= col_area.y + col_area.height - 1 {
+            let Some(hit) = browser_column_hit(x, y, center, app.browser_browse_mode) else {
                 return;
-            }
-
-            let visible_row = (y - col_area.y - 1) as usize;
-            let visible_height = col_area.height.saturating_sub(2) as usize;
-
-            // Switch focus to the clicked column.
-            app.browser_focus = if files_mode {
-                match col_idx {
-                    0 => BrowserColumn::Artists,
-                    _ => BrowserColumn::Tracks,
-                }
-            } else {
-                match col_idx {
-                    0 => BrowserColumn::Artists,
-                    1 => BrowserColumn::Albums,
-                    _ => BrowserColumn::Tracks,
-                }
             };
+            let visible_row = (y - hit.col_area.y - 1) as usize;
+            app.browser_focus = hit.focus;
+            let col_idx = hit.col_idx;
+            let files_mode = app.browser_browse_mode == BrowseMode::Files;
 
             if files_mode {
                 match col_idx {
@@ -1697,7 +1736,6 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
 
             match col_idx {
                 0 => {
-                    // Artists: compute ratatui's auto-scroll offset and map click.
                     let orig_idx: Option<usize> = {
                         if let LoadingState::Loaded(artists) = &app.library.artists {
                             let visible: Vec<usize> = if let Some(q) =
@@ -1712,15 +1750,7 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                             } else {
                                 (0..artists.len()).collect()
                             };
-                            let sel_pos = app
-                                .library
-                                .selected_artist
-                                .and_then(|s| visible.iter().position(|&i| i == s))
-                                .unwrap_or(0);
-                            // ratatui scrolls to keep selection visible from below:
-                            // scroll = max(0, sel_pos - (visible_height - 1))
-                            let scroll = sel_pos.saturating_sub(visible_height.saturating_sub(1));
-                            let clicked = scroll + visible_row;
+                            let clicked = app.library.artists_scroll + visible_row;
                             visible.get(clicked).copied()
                         } else {
                             None
@@ -1751,13 +1781,7 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                             } else {
                                 (0..albums.len()).collect()
                             };
-                            let sel_pos = app
-                                .library
-                                .selected_album
-                                .and_then(|s| visible.iter().position(|&i| i == s))
-                                .unwrap_or(0);
-                            let scroll = sel_pos.saturating_sub(visible_height.saturating_sub(1));
-                            let clicked = scroll + visible_row;
+                            let clicked = app.library.albums_scroll + visible_row;
                             visible.get(clicked).copied()
                         } else {
                             None
@@ -1787,13 +1811,7 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                             } else {
                                 (0..songs.len()).collect()
                             };
-                            let sel_pos = app
-                                .library
-                                .selected_track
-                                .and_then(|s| visible.iter().position(|&i| i == s))
-                                .unwrap_or(0);
-                            let scroll = sel_pos.saturating_sub(visible_height.saturating_sub(1));
-                            let clicked = scroll + visible_row;
+                            let clicked = app.library.tracks_scroll + visible_row;
                             visible.get(clicked).copied()
                         } else {
                             None

--- a/ratune/src/ui/home_tab.rs
+++ b/ratune/src/ui/home_tab.rs
@@ -12,7 +12,9 @@ use ratatui_image::StatefulImage;
 use crate::app::{App, HomeSection, HomeState, RecentAlbum};
 use crate::config::{Config, HomePanel};
 use crate::theme::Theme;
-use crate::ui::kitty_art::{art_strip_layout, KITTY_STRIP_MAX_SLOTS, STRIP_GAP_COLS};
+use crate::ui::kitty_art::{
+    art_strip_layout, art_strip_thumb_hit, KITTY_STRIP_MAX_SLOTS, STRIP_GAP_COLS,
+};
 
 // ── Relative time formatting ──────────────────────────────────────────────────
 
@@ -137,6 +139,53 @@ pub fn compute_home_layout(area: Rect, cfg: &Config) -> Option<HomeLayout> {
         bottom_right_panel,
         bottom_h,
     })
+}
+
+/// Inner content rect of a home panel block (inside the border).
+pub fn home_panel_inner(area: Rect) -> Rect {
+    Rect {
+        x: area.x + 1,
+        y: area.y + 1,
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    }
+}
+
+/// Map a click inside the Recently Played panel to an album index, if any.
+pub fn home_recent_album_index_at(
+    x: u16,
+    y: u16,
+    inner: Rect,
+    show_art: bool,
+    scroll_offset: usize,
+    album_count: usize,
+) -> Option<usize> {
+    if album_count == 0
+        || y < inner.y
+        || y >= inner.y + inner.height
+        || x < inner.x
+        || x >= inner.x + inner.width
+    {
+        return None;
+    }
+
+    if !show_art {
+        let row = (y - inner.y) as usize;
+        let idx = scroll_offset + row;
+        return (idx < album_count).then_some(idx);
+    }
+
+    let layout = art_strip_layout(inner.width, inner.height);
+    let rel_x = x.saturating_sub(inner.x);
+    let rel_y = y.saturating_sub(inner.y);
+    let (row_in_grid, col_in_grid) = art_strip_thumb_hit(&layout, rel_x, rel_y)?;
+    let slot = (row_in_grid as usize) * layout.per_row + (col_in_grid as usize);
+    let max_slots = layout.total_visible.min(KITTY_STRIP_MAX_SLOTS);
+    if slot >= max_slots {
+        return None;
+    }
+    let idx = scroll_offset + slot;
+    (idx < album_count).then_some(idx)
 }
 
 // ── Top-level render ──────────────────────────────────────────────────────────


### PR DESCRIPTION
See #14.

This fixes clicking behavior when scrolling in browse tab. Behind-the-scenes was not tracking items list in same way it was shown visually, causing clicking issues.

In testing, also found some clicking issues on homepage, included those as well.

And lastly, added ability to scroll with mouse wheel through browsing options and config (`mouse_wheel_scroll_lines`) to set scroll jump amount.