### PR TITLE
Fix: linux keyring handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev pkg-config
+          sudo apt-get install -y libasound2-dev libdbus-1-dev pkg-config
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev pkg-config
+          sudo apt-get install -y libasound2-dev libdbus-1-dev pkg-config
 
       # Default name would be `$bin-$target` (e.g. ratune-x86_64-unknown-linux-gnu). `$tag` adds the
       # release version so archives are unambiguous when cached or mirrored (AUR, etc.).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +353,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +475,16 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "color_quant"
@@ -548,6 +596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +686,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,12 +736,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -992,6 +1109,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1228,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1402,6 +1547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1735,15 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1877,6 +2041,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +2096,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2462,6 +2651,7 @@ dependencies = [
  "apple-native-keyring-store",
  "base64",
  "crossterm 0.28.1",
+ "dbus-secret-service-keyring-store",
  "flate2",
  "image",
  "inquire",
@@ -2914,6 +3104,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3642,6 +3843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,6 +3951,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -4697,6 +4910,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/README.md
+++ b/README.md
@@ -155,19 +155,26 @@ On first start, ratune creates a short default file at `~/.config/ratune/config.
 
 Set Subsonic **url** and **username**, then choose how to supply the secret (most secure first):
 
-1. **OS keyring (default)** — leave `password = ""` or remove field entirely. (**NOTE**: This option currently uses keyutils on Linux, to be reconsidered)
+1. **OS keyring (default)** — leave `password = ""` or remove field entirely. On Linux choose the backend with `password_keyring` (see below).
 2. **`password_command`** — run a shell command; stdout is the secret (e.g. `secret-tool`, `pass`, KeePassXC CLI).
 3. **Plaintext** — `password = "..."` in the file, or env vars (convenient for scripts; avoid in shared configs).
 
 #### Keyring
 
-Leave `password` empty. Ratune uses [`keyring-core`](https://crates.io/crates/keyring-core) with a platform store: [**kernel keyutils**](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/) on Linux (no Secret Service or gnome-keyring), **Keychain** on macOS, **Credential Manager** on Windows. On first run you are prompted once ([inquire](https://crates.io/crates/inquire)); the secret is stored under service **`ratune`** and user **`{url}|{username}`** — not in `config.toml`. Linux keys live in the kernel keyring ([persistence](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/#persistence)); a reboot may require entering the secret again. If the store is unavailable (e.g. container), you get a one-time session prompt — use **`password_command`** or **`SUBSONIC_PASS`** instead.
+Leave `password` empty. Ratune uses [`keyring-core`](https://crates.io/crates/keyring-core) with a platform store: on Linux you pick `keyutils` (kernel keyring, default) or `secret-service` (gnome-keyring / KWallet); Keychain*on macOS; Credential Manager on Windows. On first run you are prompted once ([inquire](https://crates.io/crates/inquire)); the secret is stored under service `ratune` and user `{url}|{username}` — not in `config.toml`.
+
+- **`password_keyring = "keyutils"`** (default) — [kernel keyutils](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/). Lightweight and fine for a server password you can re-enter after reboot; keys may not survive reboot ([persistence](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/#persistence)).
+- **`password_keyring = "secret-service"`** — [Secret Service](https://specifications.freedesktop.org/secret-service/) via libsecret (same wallet as `secret-tool`, browser password managers, etc.). Better when you want the password to persist across reboots like other desktop secrets.
+
+If the chosen store is unavailable (e.g. headless container) you get a one-time session prompt, use **`password_command`** or **`SUBSONIC_PASS`** instead.
 
 ```toml
 [server]
 url = "https://your-navidrome.example.com"
 username = "you"
 password = "" # or remove entirely
+# password_keyring = "keyutils"       # default on Linux
+# password_keyring = "secret-service" # gnome-keyring / KWallet
 ```
 
 #### External secret store (`password_command`)
@@ -271,17 +278,16 @@ To not store secrets in the file (synced dotfiles, shared machines, etc.), leave
 | `api_secret` | config → `api_secret_command` → OS keyring (`lastfm\|api_secret`) |
 | `session_key` | config → `session_key_command` → OS keyring (`lastfm\|session`) |
 
-Keyring entries use service **`ratune`**. Env vars (`LASTFM_API_SECRET`, `LASTFM_SESSION_KEY`, …) override the file, same as Subsonic.
-
-**IMPORTANT NOTE**: `--save-keyring` currently uses keyutils in Linux (to be changed soon). This is not recommended, consider using the command options in config instead.
+Keyring entries use service `ratune`. On Linux, scrobble secrets always use Secret Service (gnome-keyring / KWallet). Env vars (`LASTFM_API_SECRET`, `LASTFM_SESSION_KEY`, …) override the file, same as Subsonic.
 
 ```sh
-# save directly to keyutils
 ratune scrobble-api-secret --save-keyring
 ratune scrobble-auth --save-keyring
 ```
 
 Without `--save-keyring`, each command prints the value to paste into config instead.
+
+If you previously saved scrobble secrets with an older build (kernel keyutils), re-run the commands above once and they will land in your desktop wallet instead.
 
 #### plaintext
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ These apply whenever you run Ratune, including [GitHub Releases](https://github.
 
 - **Server**: A Subsonic-compatible music server (Navidrome is a good default).
 - **Linux audio**: ALSA userspace library at runtime — e.g. Debian/Ubuntu `libasound2`, Fedora `alsa-lib`, Arch `alsa-lib`. (You do **not** need `-dev` / `*-devel` packages just to run a prebuilt binary.)
+- **Linux D-Bus**: `libdbus-1` at runtime — e.g. Debian/Ubuntu `libdbus-1-3`, Fedora `dbus-libs`, Arch `dbus`. Required by the Linux binary (scrobble keyring, etc.); usually already installed on desktop Linux.
 - **macOS audio**: Uses Core Audio via the system toolchain; no separate audio library install for typical use.
 - **Optional**: `fzf` or `sk` on `PATH` if you use the library fuzzy picker (see `[library]` in the sample config).
 
@@ -60,7 +61,7 @@ Prebuilt archives on [Releases](https://github.com/acmagn/ratune/releases): **Li
 Everything under **Runtime**, plus:
 
 - **Rust**: Stable toolchain (`rustup` default stable is fine).
-- **Linux build deps**: ALSA headers and `pkg-config` — e.g. Debian/Ubuntu `libasound2-dev` + `pkg-config`, Fedora `alsa-lib-devel`, Arch `alsa-lib` (provides what `alsa-sys` needs via pkg-config).
+- **Linux build deps**: ALSA and D-Bus headers plus `pkg-config` — e.g. Debian/Ubuntu `libasound2-dev` + `libdbus-1-dev` + `pkg-config`, Fedora `alsa-lib-devel` + `dbus-devel`, Arch `alsa-lib` + `dbus`.
 
 ---
 
@@ -97,7 +98,7 @@ yay -S ratune-bin
 cargo install ratune
 ```
 
-This **builds** from the published crate. You need a **Rust toolchain**; on **Linux**, install ALSA **development** packages first (same as [Build from source](#build-from-source)).
+This **builds** from the published crate. You need a **Rust toolchain**; on **Linux**, install ALSA and D-Bus **development** packages first (same as [Build from source](#build-from-source)).
 
 ### macOS (Homebrew)
 
@@ -110,17 +111,17 @@ brew install ratune
 
 Use this when you want the latest git checkout, you’re on an OS/arch without a prebuilt, or you’re developing Ratune.
 
-**Linux:** install ALSA headers and `pkg-config` *before* the first build:
+**Linux:** install ALSA and D-Bus headers and `pkg-config` *before* the first build:
 
 ```bash
 # Debian / Ubuntu
-sudo apt install libasound2-dev pkg-config
+sudo apt install libasound2-dev libdbus-1-dev pkg-config
 
 # Fedora / RHEL
-sudo dnf install alsa-lib-devel pkg-config
+sudo dnf install alsa-lib-devel dbus-devel pkg-config
 
 # Arch
-sudo pacman -S alsa-lib
+sudo pacman -S alsa-lib dbus
 ```
 
 **Clone and build:**
@@ -161,7 +162,7 @@ Set Subsonic **url** and **username**, then choose how to supply the secret (mos
 
 #### Keyring
 
-Leave `password` empty. Ratune uses [`keyring-core`](https://crates.io/crates/keyring-core) with a platform store: on Linux you pick `keyutils` (kernel keyring, default) or `secret-service` (gnome-keyring / KWallet); Keychain*on macOS; Credential Manager on Windows. On first run you are prompted once ([inquire](https://crates.io/crates/inquire)); the secret is stored under service `ratune` and user `{url}|{username}` — not in `config.toml`.
+Leave `password` empty. Ratune uses [`keyring-core`](https://crates.io/crates/keyring-core) with a platform store: on Linux you pick **`keyutils`** (kernel keyring, default) or **`secret-service`** (gnome-keyring / KWallet); **Keychain** on macOS; **Credential Manager** on Windows. On first run you are prompted once ([inquire](https://crates.io/crates/inquire)); the secret is stored under service **`ratune`** and user **`{url}|{username}`** — not in `config.toml`.
 
 - **`password_keyring = "keyutils"`** (default) — [kernel keyutils](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/). Lightweight and fine for a server password you can re-enter after reboot; keys may not survive reboot ([persistence](https://docs.rs/linux-keyutils-keyring-store/latest/linux_keyutils_keyring_store/#persistence)).
 - **`password_keyring = "secret-service"`** — [Secret Service](https://specifications.freedesktop.org/secret-service/) via libsecret (same wallet as `secret-tool`, browser password managers, etc.). Better when you want the password to persist across reboots like other desktop secrets.

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -467,8 +467,8 @@ max_size_gb = 2.0
 # cause the service to ignore scrobbles.
 #
 # Examples:
-#   api_secret_command = "secret-tool lookup service ratune user lastfm|api_secret"
-#   session_key_command = "secret-tool lookup service ratune user lastfm|session"
+#   api_secret_command = "secret-tool lookup service ratune username 'lastfm|api_secret'"
+#   session_key_command = "secret-tool lookup service ratune username 'lastfm|session'"
 #
 # Environment overrides (applied after the file):
 #   LASTFM_API_KEY / LIBREFM_API_KEY

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -51,9 +51,11 @@
 # username  — Subsonic username.
 #
 # Secret (pick one):
-#   password = "" (default) — OS keyring via keyring-core (Linux: kernel keyutils; macOS:
-#             Keychain; Windows: Credential Manager). First run prompts once; stored as service
+#   password = "" (default) — OS keyring via keyring-core. First run prompts once; stored as service
 #             "ratune", user "{url}|{username}". Needs url + username set.
+#             On Linux, choose the backend with password_keyring:
+#               "keyutils" (default) — kernel keyutils; lightweight, may not survive reboot
+#               "secret-service"     — gnome-keyring / KWallet (same as secret-tool)
 #   password_command — Shell command; stdout (trimmed) is the secret. Good for secret-tool,
 #             pass, KeePassXC CLI, etc. Example:
 #             password_command = "secret-tool lookup --label=ratune service subsonic user you"
@@ -66,6 +68,7 @@
 url = ""
 username = ""
 password = ""
+# password_keyring = "keyutils"       # Linux only: "keyutils" (default) or "secret-service"
 # password_command = "secret-tool lookup service subsonic user you"
 
 # -----------------------------------------------------------------------------
@@ -436,7 +439,8 @@ max_size_gb = 2.0
 # Resolution order (first match wins):
 #   api_secret  — api_secret → api_secret_command → OS keyring (lastfm|api_secret)
 #   session_key — session_key → session_key_command → OS keyring (lastfm|session)
-# Keyring service name is always "ratune".
+# Keyring service name is always "ratune". On Linux, scrobble keyring uses Secret Service
+# (gnome-keyring / KWallet), not kernel keyutils.
 #
 # Quick start (all in config):
 #   api_key = "…"

--- a/ratune/Cargo.toml
+++ b/ratune/Cargo.toml
@@ -44,6 +44,7 @@ keyring-core = "1"
 
 # Platform credential stores for keyring-core — see https://crates.io/crates/keyring-core
 [target.'cfg(target_os = "linux")'.dependencies]
+dbus-secret-service-keyring-store = { version = "1", features = ["crypto-rust"] }
 linux-keyutils-keyring-store = "1"
 mpris-server = "0.9"
 

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -825,6 +825,10 @@ struct ServerSection {
     /// Example: `secret-tool lookup --label=ratune service subsonic`.
     #[serde(default)]
     password_command: String,
+    /// Linux only: keyring backend when `password` and `password_command` are empty.
+    /// `keyutils` (default) or `secret-service` (gnome-keyring / KWallet). Ignored on macOS/Windows.
+    #[serde(default = "default_password_keyring")]
+    password_keyring: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -854,6 +858,10 @@ fn default_volume() -> u8 {
 
 fn default_mpris() -> bool {
     true
+}
+
+fn default_password_keyring() -> String {
+    "keyutils".into()
 }
 
 // ── Runtime config ────────────────────────────────────────────────────────────
@@ -1640,36 +1648,40 @@ fn resolve_subsonic_secret_from_keyring(server: &ServerSection) -> Result<String
     }
 
     let label = subsonic_keyring_user(url, user);
-    let entry = match keyring_core::Entry::new("ratune", &label) {
+    let backend = crate::keyring_init::parse_password_keyring(&server.password_keyring)
+        .with_context(|| format!("invalid [server].password_keyring {:?}", server.password_keyring))?;
+    let entry = match crate::keyring_init::keyring_entry("ratune", &label, backend) {
         Ok(e) => e,
         Err(KeyringError::NoDefaultStore) => {
             eprintln!(
-                "warning: keyring default store is not configured on this platform or startup failed."
+                "warning: {} keyring is not available on this platform or startup failed.",
+                backend.label()
             );
             return inquire_subsonic_password_session();
         }
-        Err(e) => return Err(e).context("keyring entry (service ratune)"),
+        Err(e) => return Err(e).context(format!("keyring entry (service ratune, {})", backend.label())),
     };
 
     match entry.get_password() {
         Ok(s) => {
             let t = s.trim();
             if t.is_empty() {
-                prompt_and_store_subsonic_secret(&entry)
+                prompt_and_store_subsonic_secret(&entry, backend)
             } else {
                 Ok(t.to_string())
             }
         }
-        Err(KeyringError::NoEntry) => prompt_and_store_subsonic_secret(&entry),
+        Err(KeyringError::NoEntry) => prompt_and_store_subsonic_secret(&entry, backend),
         Err(e) if keyring_storage_unavailable(&e) => {
             eprintln!(
-                "warning: keyring store is not available ({e}).\n\
+                "warning: {} keyring is not available ({e}).\n\
                  Using a one-time password prompt; the secret is not saved and applies only to this run.\n\
-                 To persist without typing each time: set [server].password_command, [server].password, or SUBSONIC_PASS."
+                 To persist without typing each time: set [server].password_command, [server].password, or SUBSONIC_PASS.",
+                backend.label()
             );
             inquire_subsonic_password_session()
         }
-        Err(e) => Err(e).context("reading Subsonic secret from keyring"),
+        Err(e) => Err(e).context(format!("reading Subsonic secret from {} keyring", backend.label())),
     }
 }
 
@@ -1703,13 +1715,17 @@ fn inquire_plain_secret(prefix: Option<&str>) -> Result<String> {
     Ok(pw.to_string())
 }
 
-fn prompt_and_store_subsonic_secret(entry: &keyring_core::Entry) -> Result<String> {
-    let pw = inquire_plain_secret(Some(
+fn prompt_and_store_subsonic_secret(
+    entry: &keyring_core::Entry,
+    backend: crate::keyring_init::KeyringBackend,
+) -> Result<String> {
+    let pw = inquire_plain_secret(Some(&format!(
         "No plaintext password in config — storing your Subsonic secret in the platform keyring \
-         (service \"ratune\", user \"url|username\").\n\
-         On Linux this uses kernel keyutils; on macOS/Windows use the system credential UI to remove the entry if needed.\n\
+         (service \"ratune\", user \"url|username\", backend: {}).\n\
+         On macOS/Windows use the system credential UI to remove the entry if needed.\n\
          API overview: https://www.navidrome.org/docs/developers/subsonic-api/",
-    ))?;
+        backend.label()
+    )))?;
 
     match entry.set_password(&pw) {
         Ok(()) => Ok(pw),
@@ -1822,12 +1838,18 @@ fn read_scrobble_keyring(sec: &ScrobbleSection, kind: &str, hint: &str) -> Resul
 
     let service = resolve_scrobble_service(sec);
     let label = scrobble_keyring_label(service, kind);
-    let entry = match keyring_core::Entry::new("ratune", &label) {
+    let backend = crate::keyring_init::KeyringBackend::scrobble();
+    let entry = match crate::keyring_init::keyring_entry("ratune", &label, backend) {
         Ok(e) => e,
         Err(KeyringError::NoDefaultStore) => {
             bail!("no {kind} configured — {hint}");
         }
-        Err(e) => return Err(e).context(format!("keyring entry for scrobble {kind}")),
+        Err(e) => {
+            return Err(e).context(format!(
+                "keyring entry for scrobble {kind} ({})",
+                backend.label()
+            ));
+        }
     };
 
     match entry.get_password() {
@@ -1853,8 +1875,9 @@ pub fn store_scrobble_api_secret(
         bail!("refusing to store empty API secret");
     }
     let label = scrobble_keyring_label(service, "api_secret");
-    let entry = keyring_core::Entry::new("ratune", &label)
-        .context("keyring entry for scrobble api_secret")?;
+    let backend = crate::keyring_init::KeyringBackend::scrobble();
+    let entry = crate::keyring_init::keyring_entry("ratune", &label, backend)
+        .context(format!("keyring entry for scrobble api_secret ({})", backend.label()))?;
     entry
         .set_password(secret)
         .context("storing scrobble api_secret in keyring")?;
@@ -1871,8 +1894,9 @@ pub fn store_scrobble_session_key(
         bail!("refusing to store empty session key");
     }
     let label = scrobble_keyring_label(service, "session");
-    let entry =
-        keyring_core::Entry::new("ratune", &label).context("keyring entry for scrobble session")?;
+    let backend = crate::keyring_init::KeyringBackend::scrobble();
+    let entry = crate::keyring_init::keyring_entry("ratune", &label, backend)
+        .context(format!("keyring entry for scrobble session ({})", backend.label()))?;
     entry
         .set_password(key)
         .context("storing scrobble session key in keyring")?;
@@ -1980,6 +2004,26 @@ password_command = "secret-tool lookup service ratune"
     }
 
     #[test]
+    fn parses_password_keyring() {
+        let text = r#"
+[server]
+password_keyring = "secret-service"
+"#;
+        let fc: FileConfig = toml::from_str(text).expect("toml");
+        assert_eq!(fc.server.password_keyring, "secret-service");
+        assert_eq!(
+            crate::keyring_init::parse_password_keyring(&fc.server.password_keyring).expect("parse"),
+            crate::keyring_init::KeyringBackend::SecretService
+        );
+    }
+
+    #[test]
+    fn password_keyring_defaults_to_keyutils() {
+        let fc: FileConfig = toml::from_str("[server]\nurl = \"x\"\n").expect("toml");
+        assert_eq!(fc.server.password_keyring, "keyutils");
+    }
+
+    #[test]
     #[cfg(unix)]
     fn password_command_shell_output() {
         let server = ServerSection {
@@ -1987,6 +2031,7 @@ password_command = "secret-tool lookup service ratune"
             username: String::new(),
             password: String::new(),
             password_command: "printf '%s' 'from-cmd'".into(),
+            password_keyring: default_password_keyring(),
         };
         assert_eq!(
             resolve_subsonic_secret(&server).expect("command"),

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -1649,7 +1649,12 @@ fn resolve_subsonic_secret_from_keyring(server: &ServerSection) -> Result<String
 
     let label = subsonic_keyring_user(url, user);
     let backend = crate::keyring_init::parse_password_keyring(&server.password_keyring)
-        .with_context(|| format!("invalid [server].password_keyring {:?}", server.password_keyring))?;
+        .with_context(|| {
+            format!(
+                "invalid [server].password_keyring {:?}",
+                server.password_keyring
+            )
+        })?;
     let entry = match crate::keyring_init::keyring_entry("ratune", &label, backend) {
         Ok(e) => e,
         Err(KeyringError::NoDefaultStore) => {
@@ -1659,7 +1664,12 @@ fn resolve_subsonic_secret_from_keyring(server: &ServerSection) -> Result<String
             );
             return inquire_subsonic_password_session();
         }
-        Err(e) => return Err(e).context(format!("keyring entry (service ratune, {})", backend.label())),
+        Err(e) => {
+            return Err(e).context(format!(
+                "keyring entry (service ratune, {})",
+                backend.label()
+            ))
+        }
     };
 
     match entry.get_password() {
@@ -1681,7 +1691,10 @@ fn resolve_subsonic_secret_from_keyring(server: &ServerSection) -> Result<String
             );
             inquire_subsonic_password_session()
         }
-        Err(e) => Err(e).context(format!("reading Subsonic secret from {} keyring", backend.label())),
+        Err(e) => Err(e).context(format!(
+            "reading Subsonic secret from {} keyring",
+            backend.label()
+        )),
     }
 }
 
@@ -1876,8 +1889,10 @@ pub fn store_scrobble_api_secret(
     }
     let label = scrobble_keyring_label(service, "api_secret");
     let backend = crate::keyring_init::KeyringBackend::scrobble();
-    let entry = crate::keyring_init::keyring_entry("ratune", &label, backend)
-        .context(format!("keyring entry for scrobble api_secret ({})", backend.label()))?;
+    let entry = crate::keyring_init::keyring_entry("ratune", &label, backend).context(format!(
+        "keyring entry for scrobble api_secret ({})",
+        backend.label()
+    ))?;
     entry
         .set_password(secret)
         .context("storing scrobble api_secret in keyring")?;
@@ -1895,8 +1910,10 @@ pub fn store_scrobble_session_key(
     }
     let label = scrobble_keyring_label(service, "session");
     let backend = crate::keyring_init::KeyringBackend::scrobble();
-    let entry = crate::keyring_init::keyring_entry("ratune", &label, backend)
-        .context(format!("keyring entry for scrobble session ({})", backend.label()))?;
+    let entry = crate::keyring_init::keyring_entry("ratune", &label, backend).context(format!(
+        "keyring entry for scrobble session ({})",
+        backend.label()
+    ))?;
     entry
         .set_password(key)
         .context("storing scrobble session key in keyring")?;
@@ -2012,7 +2029,8 @@ password_keyring = "secret-service"
         let fc: FileConfig = toml::from_str(text).expect("toml");
         assert_eq!(fc.server.password_keyring, "secret-service");
         assert_eq!(
-            crate::keyring_init::parse_password_keyring(&fc.server.password_keyring).expect("parse"),
+            crate::keyring_init::parse_password_keyring(&fc.server.password_keyring)
+                .expect("parse"),
             crate::keyring_init::KeyringBackend::SecretService
         );
     }

--- a/ratune/src/keyring_init.rs
+++ b/ratune/src/keyring_init.rs
@@ -72,7 +72,11 @@ fn linux_secret_service_store() -> Option<Arc<dbus_secret_service_keyring_store:
 }
 
 /// Create a keyring entry using the given backend.
-pub fn keyring_entry(service: &str, user: &str, backend: KeyringBackend) -> Result<Entry, KeyringError> {
+pub fn keyring_entry(
+    service: &str,
+    user: &str,
+    backend: KeyringBackend,
+) -> Result<Entry, KeyringError> {
     #[cfg(target_os = "linux")]
     {
         let store: Arc<dyn CredentialStoreApi> = match backend {

--- a/ratune/src/keyring_init.rs
+++ b/ratune/src/keyring_init.rs
@@ -1,21 +1,115 @@
-//! Install the platform credential store for [`keyring_core`] before any [`keyring_core::Entry`]
-//! is created. See the [keyring ecosystem docs](https://github.com/open-source-cooperative/keyring-rs/wiki/Keyring).
+//! Install platform credential stores for [`keyring_core`] and build entries for a chosen backend.
+//! See the [keyring ecosystem docs](https://github.com/open-source-cooperative/keyring-rs/wiki/Keyring).
 
-/// Select and register the OS-native store ([`keyring_core::set_default_store`]).
-/// On failure, logs a warning and leaves no default store (credential helpers in `config` fall
-/// back to a session-only password prompt).
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{bail, Result};
+use keyring_core::api::CredentialStoreApi;
+use keyring_core::{Entry, Error as KeyringError};
+
+/// Linux keyring backend. macOS and Windows always use the native system store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyringBackend {
+    /// Linux kernel keyutils (session-ish; may not survive reboot).
+    Keyutils,
+    /// Linux Secret Service (gnome-keyring, KWallet, etc.).
+    SecretService,
+}
+
+impl KeyringBackend {
+    /// Backend for scrobble API secrets and session keys.
+    pub fn scrobble() -> Self {
+        #[cfg(target_os = "linux")]
+        {
+            Self::SecretService
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Self::Keyutils
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Keyutils => "kernel keyutils",
+            Self::SecretService => "Secret Service (gnome-keyring, KWallet, …)",
+        }
+    }
+}
+
+/// Parse `[server].password_keyring` (`keyutils` or `secret-service`).
+pub fn parse_password_keyring(raw: &str) -> Result<KeyringBackend> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "keyutils" | "kernel" => Ok(KeyringBackend::Keyutils),
+        "secret-service" | "secret_service" | "libsecret" | "gnome-keyring" | "gnome_keyring" => {
+            Ok(KeyringBackend::SecretService)
+        }
+        other => bail!(
+            "unknown [server].password_keyring value {other:?} — use \"keyutils\" or \"secret-service\""
+        ),
+    }
+}
+
+#[cfg(target_os = "linux")]
+static KEYUTILS_STORE: OnceLock<Option<Arc<linux_keyutils_keyring_store::Store>>> = OnceLock::new();
+
+#[cfg(target_os = "linux")]
+static SECRET_SERVICE_STORE: OnceLock<Option<Arc<dbus_secret_service_keyring_store::Store>>> =
+    OnceLock::new();
+
+#[cfg(target_os = "linux")]
+fn linux_keyutils_store() -> Option<Arc<linux_keyutils_keyring_store::Store>> {
+    KEYUTILS_STORE
+        .get_or_init(|| linux_keyutils_keyring_store::Store::new().ok())
+        .clone()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_secret_service_store() -> Option<Arc<dbus_secret_service_keyring_store::Store>> {
+    SECRET_SERVICE_STORE
+        .get_or_init(|| dbus_secret_service_keyring_store::Store::new().ok())
+        .clone()
+}
+
+/// Create a keyring entry using the given backend.
+pub fn keyring_entry(service: &str, user: &str, backend: KeyringBackend) -> Result<Entry, KeyringError> {
+    #[cfg(target_os = "linux")]
+    {
+        let store: Arc<dyn CredentialStoreApi> = match backend {
+            KeyringBackend::Keyutils => linux_keyutils_store()
+                .map(|s| s as Arc<dyn CredentialStoreApi>)
+                .ok_or(KeyringError::NoDefaultStore)?,
+            KeyringBackend::SecretService => linux_secret_service_store()
+                .map(|s| s as Arc<dyn CredentialStoreApi>)
+                .ok_or(KeyringError::NoDefaultStore)?,
+        };
+        store.build(service, user, None)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = backend;
+        Entry::new(service, user)
+    }
+}
+
+/// Select and register the default credential store ([`keyring_core::set_default_store`]).
+/// On Linux this is keyutils for backward compatibility with `[server].password_keyring = "keyutils"`.
 pub fn install_default_keyring_store() {
     #[cfg(target_os = "linux")]
     {
-        match linux_keyutils_keyring_store::Store::new() {
-            Ok(store) => keyring_core::set_default_store(store),
-            Err(e) => {
+        match linux_keyutils_store() {
+            Some(store) => keyring_core::set_default_store(store),
+            None => {
                 eprintln!(
-                    "warning: could not open Linux kernel keyutils store: {e}\n\
-                     Keyring storage disabled for this run — use password_command, a session password, [server].password, or SUBSONIC_PASS."
+                    "warning: could not open Linux kernel keyutils store.\n\
+                     Keyutils keyring disabled — set [server].password_keyring = \"secret-service\", \
+                     use password_command, a session password, [server].password, or SUBSONIC_PASS."
                 );
             }
         }
+        // Touch the Secret Service store so scrobble helpers fail fast if unavailable.
+        let _ = linux_secret_service_store();
     }
 
     #[cfg(target_os = "macos")]
@@ -29,7 +123,6 @@ pub fn install_default_keyring_store() {
                 );
             }
         }
-        return;
     }
 
     #[cfg(target_os = "windows")]
@@ -43,7 +136,6 @@ pub fn install_default_keyring_store() {
                 );
             }
         }
-        return;
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -955,8 +955,9 @@ pub async fn scrobble_auth(save_keyring: bool) -> Result<()> {
         match config::store_scrobble_session_key(client.service(), &session.key) {
             Ok(()) => {
                 eprintln!(
-                    "Session key saved to the OS keyring (service \"ratune\", user \"{}\").",
-                    scrobble_keyring_user_label(client.service(), "session")
+                    "Session key saved to the OS keyring (service \"ratune\", user \"{}\", {}).",
+                    scrobble_keyring_user_label(client.service(), "session"),
+                    keyring_init::KeyringBackend::scrobble().label()
                 );
                 eprintln!("You can leave session_key empty in config and set enabled = true.");
             }
@@ -1023,8 +1024,9 @@ pub fn scrobble_api_secret(save_keyring: bool) -> Result<()> {
         match config::store_scrobble_api_secret(service, secret) {
             Ok(()) => {
                 eprintln!(
-                    "API secret saved to the OS keyring (service \"ratune\", user \"{}\").",
-                    scrobble_keyring_user_label(service, "api_secret")
+                    "API secret saved to the OS keyring (service \"ratune\", user \"{}\", {}).",
+                    scrobble_keyring_user_label(service, "api_secret"),
+                    keyring_init::KeyringBackend::scrobble().label()
                 );
                 eprintln!("You can leave api_secret empty in config and unset LASTFM_API_SECRET.");
             }


### PR DESCRIPTION
Updates Ratune's keyring handling and makes things more clear in the config and readme. Addresses #17
Changes:
- scrobble keyring commands now use secret-service instead of keyutils on linux
- added config option to use secret-service instead of keyutils for subsonic password
- some refactoring, readme and config updates with examples.