### PR TITLE
feat: subsonic lyrics support and cache + bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Ratune was built to bring together a combination of features often missing from 
 
 - **Playback**: Gapless queue, seek, shuffle/unshuffle, and playlist management.
 - **Album Art**: Display using Kitty graphics and [ratatui-image](https://github.com/ratatui/ratatui-image) (see link for compatible terminals)
-- **Lyrics**: Synced lyrics via LRCLib when available.
+- **Lyrics**: Synced lyrics via LRCLib (default) or your Subsonic server. Optional on-disk cache for offline use (`[lyrics].cache_enabled`, default on).
 - **Visualizer**: FFT spectrum analyzer.
 - **Fuzzy finder**: Optional library index + external picker (fzf/skim) for fast track selection.
 - **Folder navigation**: Optional Browse layout that follows server music folders for servers that provide it.
@@ -451,7 +451,7 @@ Ratune is based on [playterm](https://github.com/awriterandtheword-rgb/playterm-
 - [ratatui](https://github.com/ratatui/ratatui) — TUI
 - [rodio](https://github.com/RustAudio/rodio) — playback
 - [Navidrome](https://www.navidrome.org/) — test target server
-- [LRCLib](https://lrclib.net) — lyrics
+- [LRCLib](https://lrclib.net) — default lyrics source
 - [rmpc](https://github.com/mierak/rmpc) — ideas for navigation and art
 
 ## License

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -2,8 +2,6 @@
 # ratune — sample config (every recognized key + comments)
 # =============================================================================
 #
-# This file is documentation only. The app does NOT read it from the repo.
-#
 # Installed config path (first match):
 #   $XDG_CONFIG_HOME/ratune/config.toml
 #   ~/.config/ratune/config.toml
@@ -327,6 +325,22 @@ position = "right"
 enabled = true
 visible = false
 location = "right"
+
+# -----------------------------------------------------------------------------
+# [lyrics] — lyrics fetch source
+# -----------------------------------------------------------------------------
+#
+# source — "lrclib" (default) | "subsonic"
+#   lrclib   — query LRCLib (public API; requests only when the lyrics pane is open)
+#   subsonic — query your Subsonic server (getLyricsBySongId / getLyrics; no third party)
+# lrclib_url — LRCLib base URL when source = "lrclib". Default: https://lrclib.net
+# cache_enabled — store lyrics under ~/.cache/ratune/lyrics/ for offline use. Default: true
+
+[lyrics]
+source = "lrclib"
+# lrclib_url = "https://lrclib.net"
+# cache_enabled = false
+# source = "subsonic"
 
 # [ui.nptab.visualizer_pane]
 # enabled — If false, visualizer cannot be opened. Default: true.

--- a/ratune-subsonic/src/client.rs
+++ b/ratune-subsonic/src/client.rs
@@ -25,9 +25,10 @@ use tokio::task::JoinSet;
 
 use crate::error::check_status;
 use crate::models::{
-    parse_music_library_root_folder_id, Album, AlbumEnvelope, Artist, ArtistEnvelope, Artists,
-    ArtistsEnvelope, DirectoryChild, IndexesEnvelope, MusicDirectory, MusicDirectoryEnvelope,
-    MusicFolder, MusicFoldersEnvelope, PingEnvelope, Playlist, PlaylistDetail, PlaylistEnvelope,
+    parse_music_library_root_folder_id, structured_lyrics_to_lines, Album, AlbumEnvelope, Artist,
+    ArtistEnvelope, Artists, ArtistsEnvelope, DirectoryChild, IndexesEnvelope, LegacyLyricsEnvelope,
+    LyricLine, MusicDirectory, MusicDirectoryEnvelope, MusicFolder, MusicFoldersEnvelope,
+    LyricsBySongIdEnvelope, PingEnvelope, Playlist, PlaylistDetail, PlaylistEnvelope,
     PlaylistsEnvelope, ScanStatus, ScanStatusEnvelope, SearchEnvelope, SearchResult3, Song,
     SongEnvelope, SubsonicLibrary,
 };
@@ -609,6 +610,54 @@ impl SubsonicClient {
             .json()
             .await?;
         check_status(&env.response.status, env.response.error.as_ref())
+    }
+
+    /// Fetch structured lyrics for a song (`getLyricsBySongId`, OpenSubsonic).
+    ///
+    /// Returns an empty vec when the server has no lyrics for this track.
+    pub async fn get_lyrics_by_song_id(&self, id: &str) -> Result<Vec<LyricLine>> {
+        let mut params = self.auth_params();
+        params.push(("id", id.to_string()));
+        let env: LyricsBySongIdEnvelope = self
+            .http
+            .get(self.endpoint_url("getLyricsBySongId"))
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        let r = &env.response;
+        check_status(&r.status, r.error.as_ref())?;
+        let entries = r
+            .lyrics_list
+            .as_ref()
+            .map(|l| l.structured_lyrics.as_slice())
+            .unwrap_or_default();
+        Ok(structured_lyrics_to_lines(entries))
+    }
+
+    /// Fetch plain lyrics by artist/title (`getLyrics`, classic Subsonic).
+    ///
+    /// Returns the raw `value` string split into lines when present.
+    pub async fn get_lyrics(&self, artist: &str, title: &str) -> Result<Option<String>> {
+        let mut params = self.auth_params();
+        params.push(("artist", artist.to_string()));
+        params.push(("title", title.to_string()));
+        let env: LegacyLyricsEnvelope = self
+            .http
+            .get(self.endpoint_url("getLyrics"))
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        let r = &env.response;
+        check_status(&r.status, r.error.as_ref())?;
+        Ok(r.lyrics
+            .as_ref()
+            .and_then(|l| l.value.as_deref())
+            .filter(|v| !v.trim().is_empty())
+            .map(str::to_string))
     }
 }
 

--- a/ratune-subsonic/src/client.rs
+++ b/ratune-subsonic/src/client.rs
@@ -26,11 +26,11 @@ use tokio::task::JoinSet;
 use crate::error::check_status;
 use crate::models::{
     parse_music_library_root_folder_id, structured_lyrics_to_lines, Album, AlbumEnvelope, Artist,
-    ArtistEnvelope, Artists, ArtistsEnvelope, DirectoryChild, IndexesEnvelope, LegacyLyricsEnvelope,
-    LyricLine, MusicDirectory, MusicDirectoryEnvelope, MusicFolder, MusicFoldersEnvelope,
-    LyricsBySongIdEnvelope, PingEnvelope, Playlist, PlaylistDetail, PlaylistEnvelope,
-    PlaylistsEnvelope, ScanStatus, ScanStatusEnvelope, SearchEnvelope, SearchResult3, Song,
-    SongEnvelope, SubsonicLibrary,
+    ArtistEnvelope, Artists, ArtistsEnvelope, DirectoryChild, IndexesEnvelope,
+    LegacyLyricsEnvelope, LyricLine, LyricsBySongIdEnvelope, MusicDirectory,
+    MusicDirectoryEnvelope, MusicFolder, MusicFoldersEnvelope, PingEnvelope, Playlist,
+    PlaylistDetail, PlaylistEnvelope, PlaylistsEnvelope, ScanStatus, ScanStatusEnvelope,
+    SearchEnvelope, SearchResult3, Song, SongEnvelope, SubsonicLibrary,
 };
 
 // ── Constants ──────────────────────────────────────────────────────────────────

--- a/ratune-subsonic/src/models.rs
+++ b/ratune-subsonic/src/models.rs
@@ -793,4 +793,24 @@ mod tests {
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].text, "Hello");
     }
+
+    #[test]
+    fn deserialize_legacy_get_lyrics_envelope() {
+        let j = r#"{"subsonic-response":{"status":"ok","lyrics":{
+            "artist":"Muse","title":"Hysteria","value":"Line one\nLine two"
+        }}}"#
+            .replace('\n', "");
+        let env: LegacyLyricsEnvelope = serde_json::from_str(&j).unwrap();
+        let value = env.response.lyrics.expect("lyrics").value.expect("value");
+        assert!(value.contains("Line one"));
+    }
+
+    #[test]
+    fn structured_lyrics_unsynced_lines_have_no_timestamps() {
+        let j = r#"[{"synced":false,"line":[{"value":"A"},{"value":"B"}]}]"#;
+        let entries: Vec<StructuredLyricsRaw> = serde_json::from_str(j).unwrap();
+        let lines = structured_lyrics_to_lines(&entries);
+        assert_eq!(lines.len(), 2);
+        assert!(lines.iter().all(|l| l.time.is_none()));
+    }
 }

--- a/ratune-subsonic/src/models.rs
+++ b/ratune-subsonic/src/models.rs
@@ -282,12 +282,128 @@ pub struct ScanStatus {
 /// `time` is `Some(offset)` for synced (LRC-style) lyrics where the line
 /// should be highlighted at the given playback position, or `None` for plain
 /// unsynced text.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LyricLine {
     /// Playback offset at which to highlight this line; `None` = unsynced.
     pub time: Option<Duration>,
     /// The lyric text.
     pub text: String,
+}
+
+/// Convert OpenSubsonic [`StructuredLyricsRaw`] entries into display lines.
+///
+/// Prefers synced `main` lyrics, then any synced track, then the first entry.
+pub(crate) fn structured_lyrics_to_lines(entries: &[StructuredLyricsRaw]) -> Vec<LyricLine> {
+    pick_best_structured_lyrics(entries)
+        .map(structured_lyrics_entry_to_lines)
+        .unwrap_or_default()
+}
+
+fn pick_best_structured_lyrics(entries: &[StructuredLyricsRaw]) -> Option<&StructuredLyricsRaw> {
+    entries
+        .iter()
+        .find(|e| e.synced && e.kind.as_deref().unwrap_or("main") == "main")
+        .or_else(|| entries.iter().find(|e| e.synced))
+        .or_else(|| entries.first())
+}
+
+fn structured_lyrics_entry_to_lines(entry: &StructuredLyricsRaw) -> Vec<LyricLine> {
+    let offset_ms = entry.offset.unwrap_or(0);
+    entry
+        .line
+        .iter()
+        .map(|l| {
+            let time = l.start.map(|start| {
+                let adjusted = (i64::from(start) + offset_ms).max(0) as u64;
+                Duration::from_millis(adjusted)
+            });
+            LyricLine {
+                time,
+                text: l.value.clone(),
+            }
+        })
+        .collect()
+}
+
+fn deserialize_structured_lyrics_list<'de, D>(
+    deserializer: D,
+) -> Result<Vec<StructuredLyricsRaw>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        Single(StructuredLyricsRaw),
+        List(Vec<StructuredLyricsRaw>),
+    }
+    match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::Single(o) => Ok(vec![o]),
+        OneOrMany::List(v) => Ok(v),
+    }
+}
+
+/// One structured lyrics block from `getLyricsBySongId`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StructuredLyricsRaw {
+    #[serde(default)]
+    pub(crate) kind: Option<String>,
+    #[serde(default)]
+    pub(crate) synced: bool,
+    #[serde(default)]
+    pub(crate) offset: Option<i64>,
+    #[serde(default)]
+    pub(crate) line: Vec<StructuredLyricLineRaw>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct StructuredLyricLineRaw {
+    #[serde(default)]
+    pub(crate) start: Option<u32>,
+    pub(crate) value: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct LyricsListRaw {
+    #[serde(
+        default,
+        rename = "structuredLyrics",
+        deserialize_with = "deserialize_structured_lyrics_list"
+    )]
+    pub(crate) structured_lyrics: Vec<StructuredLyricsRaw>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct LyricsBySongIdEnvelope {
+    #[serde(rename = "subsonic-response")]
+    pub response: LyricsBySongIdBody,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct LyricsBySongIdBody {
+    pub status: String,
+    pub error: Option<SubsonicError>,
+    #[serde(rename = "lyricsList")]
+    pub lyrics_list: Option<LyricsListRaw>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct LegacyLyricsEnvelope {
+    #[serde(rename = "subsonic-response")]
+    pub response: LegacyLyricsBody,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct LegacyLyricsBody {
+    pub status: String,
+    pub error: Option<SubsonicError>,
+    pub lyrics: Option<LegacyLyricsRaw>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct LegacyLyricsRaw {
+    pub value: Option<String>,
 }
 
 // ── Private serde envelope types ──────────────────────────────────────────────
@@ -647,5 +763,34 @@ mod tests {
             }],
         };
         let _ = format!("{lib:?}");
+    }
+
+    #[test]
+    fn structured_lyrics_to_lines_prefers_synced_main() {
+        let j = r#"[
+            {"lang":"eng","synced":false,"line":[{"value":"plain"}]},
+            {"kind":"main","lang":"eng","synced":true,"offset":-100,"line":[
+                {"start":0,"value":"It's bugging me"},
+                {"start":2000,"value":"Grating me"}
+            ]}
+        ]"#;
+        let entries: Vec<StructuredLyricsRaw> = serde_json::from_str(j).unwrap();
+        let lines = structured_lyrics_to_lines(&entries);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].text, "It's bugging me");
+        assert_eq!(lines[0].time, Some(Duration::from_millis(0)));
+        assert_eq!(lines[1].time, Some(Duration::from_millis(1900)));
+    }
+
+    #[test]
+    fn deserialize_lyrics_by_song_id_envelope() {
+        let j = r#"{"subsonic-response":{"status":"ok","lyricsList":{"structuredLyrics":{
+            "kind":"main","synced":true,"line":[{"start":0,"value":"Hello"}]
+        }}}}"#;
+        let env: LyricsBySongIdEnvelope = serde_json::from_str(j).unwrap();
+        let list = env.response.lyrics_list.expect("lyricsList");
+        let lines = structured_lyrics_to_lines(&list.structured_lyrics);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].text, "Hello");
     }
 }

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -1799,13 +1799,7 @@ impl App {
     /// No network request is made when lyrics are disabled or the pane is hidden.
     /// Checks the on-disk cache first. Soft-fails silently — on any error an
     /// empty `lines` vec is delivered so the UI shows "No lyrics available".
-    pub fn fetch_lyrics(
-        &mut self,
-        song_id: String,
-        artist: String,
-        title: String,
-        album: String,
-    ) {
+    pub fn fetch_lyrics(&mut self, song_id: String, artist: String, title: String, album: String) {
         if !self.config.lyrics_enabled || !self.lyrics_visible {
             return;
         }

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -447,6 +447,8 @@ pub struct App {
     // ── Offline cache (Feature 5.3) ───────────────────────────────────────────
     /// Track file cache (LRU, persisted to `~/.cache/ratune/`).
     pub cache: crate::cache::TrackCache,
+    /// On-disk lyrics cache (`~/.cache/ratune/lyrics/`).
+    lyrics_disk_cache: crate::lyrics_cache::LyricsDiskCache,
     /// Monotonically increasing counter for background download tasks.
     /// Incremented on every `play_current()` call. Background tasks discard
     /// their result if the gen has advanced since they were spawned.
@@ -592,6 +594,7 @@ impl App {
         let visualizer_visible = config.visualizer_visible;
         let track_cache =
             crate::cache::TrackCache::load(config.cache_enabled, config.cache_max_size_gb);
+        let lyrics_disk_cache = crate::lyrics_cache::LyricsDiskCache::load();
         let index_path = config.resolved_library_index_path();
         let (library_index_tracks, library_index_refreshed_at) =
             match crate::library_index::load(&index_path) {
@@ -654,6 +657,7 @@ impl App {
             library_server_append_fetching: false,
             library_server_append_started: None,
             cache: track_cache,
+            lyrics_disk_cache,
             prefetch_gen: Arc::new(AtomicU64::new(0)),
             help_visible: false,
             home_art_needs_redraw: false,
@@ -1790,18 +1794,69 @@ impl App {
         });
     }
 
-    /// Spawn a task to fetch lyrics for a song from LRCLib.
+    /// Spawn a task to fetch lyrics from the configured source.
     ///
-    /// Soft-fails silently — on any error an empty `lines` vec is delivered so
-    /// the UI shows "No lyrics available" rather than a loading spinner forever.
-    pub fn fetch_lyrics(&mut self, song_id: String, artist: String, title: String, album: String) {
+    /// No network request is made when lyrics are disabled or the pane is hidden.
+    /// Checks the on-disk cache first. Soft-fails silently — on any error an
+    /// empty `lines` vec is delivered so the UI shows "No lyrics available".
+    pub fn fetch_lyrics(
+        &mut self,
+        song_id: String,
+        artist: String,
+        title: String,
+        album: String,
+    ) {
+        if !self.config.lyrics_enabled || !self.lyrics_visible {
+            return;
+        }
+
+        if self
+            .lyrics_cache
+            .as_ref()
+            .map(|(id, _)| id == &song_id)
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        let source_key = self.config.lyrics_source.cache_dir_name();
+        if self.config.lyrics_cache_enabled {
+            if let Some(lines) = self.lyrics_disk_cache.get(source_key, &song_id) {
+                self.lyrics_loading = false;
+                self.lyrics_scroll = 0;
+                self.lyrics_cache = Some((song_id, lines));
+                return;
+            }
+        }
+
         self.lyrics_loading = true;
         self.lyrics_scroll = 0;
+        let source = self.config.lyrics_source;
+        let lrclib_url = self.config.lyrics_lrclib_url.clone();
+        let cache_enabled = self.config.lyrics_cache_enabled;
+        let client = self.subsonic.clone();
         let tx = self.library_tx.clone();
+        let lyrics_dir = self.lyrics_disk_cache.cache_dir_for(source_key);
         tokio::spawn(async move {
-            let lines = crate::lyrics::fetch_lyrics(&artist, &title, &album).await;
+            let lines = crate::lyrics::fetch_lyrics(
+                source,
+                &lrclib_url,
+                &client,
+                &song_id,
+                &artist,
+                &title,
+                &album,
+            )
+            .await;
+            if cache_enabled {
+                crate::lyrics_cache::LyricsDiskCache::put_at(&lyrics_dir, &song_id, &lines);
+            }
             let _ = tx.send(LibraryUpdate::Lyrics { song_id, lines }).await;
         });
+    }
+
+    fn should_fetch_lyrics(&self) -> bool {
+        self.config.lyrics_enabled && self.lyrics_visible
     }
 
     /// Return `true` when lyrics are plain-text (no timestamps) and should scroll
@@ -2462,19 +2517,21 @@ impl App {
                         // Track has no cover art.
                         self.apply_dynamic_accent(None);
                     }
-                    // Fetch lyrics if not already cached for this song.
-                    let cached_for_song = self
-                        .lyrics_cache
-                        .as_ref()
-                        .map(|(id, _)| id == &song.id)
-                        .unwrap_or(false);
-                    if !cached_for_song {
-                        self.fetch_lyrics(
-                            song.id.clone(),
-                            song.artist.clone().unwrap_or_default(),
-                            song.title.clone(),
-                            song.album.clone().unwrap_or_default(),
-                        );
+                    // Fetch lyrics only when the lyrics pane is visible.
+                    if self.should_fetch_lyrics() {
+                        let cached_for_song = self
+                            .lyrics_cache
+                            .as_ref()
+                            .map(|(id, _)| id == &song.id)
+                            .unwrap_or(false);
+                        if !cached_for_song {
+                            self.fetch_lyrics(
+                                song.id.clone(),
+                                song.artist.clone().unwrap_or_default(),
+                                song.title.clone(),
+                                song.album.clone().unwrap_or_default(),
+                            );
+                        }
                     }
                     // Background-cache current track + prefetch next 2.
                     if self.config.cache_enabled {
@@ -2555,19 +2612,21 @@ impl App {
                     } else {
                         self.apply_dynamic_accent(None);
                     }
-                    // Fetch lyrics if not already cached for this song.
-                    let cached_for_song = self
-                        .lyrics_cache
-                        .as_ref()
-                        .map(|(id, _)| id == &song.id)
-                        .unwrap_or(false);
-                    if !cached_for_song {
-                        self.fetch_lyrics(
-                            song.id.clone(),
-                            song.artist.clone().unwrap_or_default(),
-                            song.title.clone(),
-                            song.album.clone().unwrap_or_default(),
-                        );
+                    // Fetch lyrics only when the lyrics pane is visible.
+                    if self.should_fetch_lyrics() {
+                        let cached_for_song = self
+                            .lyrics_cache
+                            .as_ref()
+                            .map(|(id, _)| id == &song.id)
+                            .unwrap_or(false);
+                        if !cached_for_song {
+                            self.fetch_lyrics(
+                                song.id.clone(),
+                                song.artist.clone().unwrap_or_default(),
+                                song.title.clone(),
+                                song.album.clone().unwrap_or_default(),
+                            );
+                        }
                     }
                     self.scrobble_track_started(&song);
                     self.playback.current_song = Some(song);

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -2224,8 +2224,17 @@ api_secret_command = "secret-tool lookup service ratune user lastfm|api_secret"
     #[test]
     fn lyrics_source_parses_lrclib_and_subsonic() {
         assert_eq!(LyricsSource::parse("lrclib"), Some(LyricsSource::LrcLib));
-        assert_eq!(LyricsSource::parse("subsonic"), Some(LyricsSource::Subsonic));
+        assert_eq!(
+            LyricsSource::parse("subsonic"),
+            Some(LyricsSource::Subsonic)
+        );
         assert_eq!(LyricsSource::parse("unknown"), None);
+    }
+
+    #[test]
+    fn lyrics_source_cache_dir_names() {
+        assert_eq!(LyricsSource::LrcLib.cache_dir_name(), "lrclib");
+        assert_eq!(LyricsSource::Subsonic.cache_dir_name(), "subsonic");
     }
 
     #[test]

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -33,6 +33,8 @@ struct FileConfig {
     #[serde(default)]
     pub cache: CacheSection,
     #[serde(default)]
+    pub lyrics: LyricsSection,
+    #[serde(default)]
     pub library: LibrarySection,
     #[serde(default)]
     pub scrobble: ScrobbleSection,
@@ -138,6 +140,72 @@ impl Default for CacheSection {
         Self {
             enabled: default_cache_enabled(),
             max_size_gb: default_cache_max_size_gb(),
+        }
+    }
+}
+
+// ── [lyrics] ──────────────────────────────────────────────────────────────────
+
+/// Lyrics fetch settings from config.toml.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LyricsSection {
+    /// Where to fetch lyrics: `lrclib` (default) or `subsonic`.
+    #[serde(default = "default_lyrics_source")]
+    pub source: String,
+    /// LRCLib server base URL (used when `source = "lrclib"`). Default: https://lrclib.net
+    #[serde(default = "default_lrclib_url")]
+    pub lrclib_url: String,
+    /// Cache fetched lyrics on disk for offline use. Default: true.
+    #[serde(default = "default_lyrics_cache_enabled")]
+    pub cache_enabled: bool,
+}
+
+fn default_lyrics_source() -> String {
+    "lrclib".into()
+}
+
+fn default_lrclib_url() -> String {
+    "https://lrclib.net".into()
+}
+
+fn default_lyrics_cache_enabled() -> bool {
+    true
+}
+
+impl Default for LyricsSection {
+    fn default() -> Self {
+        Self {
+            source: default_lyrics_source(),
+            lrclib_url: default_lrclib_url(),
+            cache_enabled: default_lyrics_cache_enabled(),
+        }
+    }
+}
+
+/// Lyrics provider configured in `[lyrics].source`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LyricsSource {
+    /// Public LRCLib API (default).
+    #[default]
+    LrcLib,
+    /// Subsonic server (`getLyricsBySongId` / `getLyrics`).
+    Subsonic,
+}
+
+impl LyricsSource {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "lrclib" | "lrc-lib" | "lrc" => Some(Self::LrcLib),
+            "subsonic" | "server" => Some(Self::Subsonic),
+            _ => None,
+        }
+    }
+
+    /// Subdirectory name under `~/.cache/ratune/lyrics/`.
+    pub fn cache_dir_name(self) -> &'static str {
+        match self {
+            Self::LrcLib => "lrclib",
+            Self::Subsonic => "subsonic",
         }
     }
 }
@@ -944,6 +1012,12 @@ pub struct Config {
     pub cache_enabled: bool,
     /// Maximum total cache size in gigabytes.
     pub cache_max_size_gb: f64,
+    /// Where to fetch lyrics (`lrclib` or `subsonic`).
+    pub lyrics_source: LyricsSource,
+    /// LRCLib base URL when `lyrics_source` is `LrcLib`.
+    pub lyrics_lrclib_url: String,
+    /// Whether to cache lyrics on disk under `~/.cache/ratune/lyrics/`.
+    pub lyrics_cache_enabled: bool,
     /// Local metadata index for fzf (see `[library]`).
     pub library_index_enabled: bool,
     pub library_index_path: String,
@@ -1315,6 +1389,10 @@ impl Config {
             now_playing_lines_boxed,
             cache_enabled: file_cfg.cache.enabled,
             cache_max_size_gb: file_cfg.cache.max_size_gb,
+            lyrics_source: LyricsSource::parse(&file_cfg.lyrics.source)
+                .unwrap_or(LyricsSource::LrcLib),
+            lyrics_lrclib_url: file_cfg.lyrics.lrclib_url,
+            lyrics_cache_enabled: file_cfg.lyrics.cache_enabled,
             library_index_enabled: file_cfg.library.enabled,
             library_index_path: file_cfg.library.index_path,
             library_index_max_age_secs: file_cfg.library.max_age_secs,
@@ -1542,6 +1620,14 @@ location = "right"
 [cache]
 enabled     = true
 max_size_gb = 2   # maximum total cache size in gigabytes
+
+[lyrics]
+# source — "lrclib" (default) | "subsonic"
+source = "lrclib"
+# lrclib_url — LRCLib base URL when source = "lrclib". Default: https://lrclib.net
+# lrclib_url = "https://lrclib.net"
+# cache_enabled — store lyrics under ~/.cache/ratune/lyrics/ for offline use. Default: true
+# cache_enabled = true
 
 # [scrobble]
 # enabled = false
@@ -2133,5 +2219,32 @@ api_secret_command = "secret-tool lookup service ratune user lastfm|api_secret"
     fn browse_mode_parses_artists() {
         assert_eq!(BrowseMode::parse("artists"), Some(BrowseMode::Artists));
         assert_eq!(BrowseMode::parse("bogus"), None);
+    }
+
+    #[test]
+    fn lyrics_source_parses_lrclib_and_subsonic() {
+        assert_eq!(LyricsSource::parse("lrclib"), Some(LyricsSource::LrcLib));
+        assert_eq!(LyricsSource::parse("subsonic"), Some(LyricsSource::Subsonic));
+        assert_eq!(LyricsSource::parse("unknown"), None);
+    }
+
+    #[test]
+    fn parses_lyrics_section() {
+        let text = r#"
+[lyrics]
+source = "subsonic"
+lrclib_url = "https://example.com"
+cache_enabled = false
+"#;
+        let fc: FileConfig = toml::from_str(text).expect("toml");
+        assert_eq!(fc.lyrics.source, "subsonic");
+        assert_eq!(fc.lyrics.lrclib_url, "https://example.com");
+        assert!(!fc.lyrics.cache_enabled);
+    }
+
+    #[test]
+    fn lyrics_cache_enabled_defaults_true() {
+        let fc: FileConfig = toml::from_str("[lyrics]\nsource = \"lrclib\"\n").expect("toml");
+        assert!(fc.lyrics.cache_enabled);
     }
 }

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -10,6 +10,7 @@ mod keybinds;
 mod keyring_init;
 mod library_index;
 mod lyrics;
+mod lyrics_cache;
 mod mpris;
 mod persist;
 mod scrobble;

--- a/ratune/src/lyrics.rs
+++ b/ratune/src/lyrics.rs
@@ -1,12 +1,13 @@
-//! LRCLib lyrics fetcher.
+//! Lyrics fetcher — LRCLib or Subsonic, selected in `[lyrics].source`.
 //!
-//! Fetches synced or plain lyrics from the public LRCLib API (no auth required).
 //! All errors are soft-failed — callers always receive a `Vec`, possibly empty.
 
 use std::time::Duration;
 
-use ratune_subsonic::LyricLine;
+use ratune_subsonic::{LyricLine, SubsonicClient};
 use serde::Deserialize;
+
+use crate::config::LyricsSource;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,22 +16,37 @@ struct LrcLibResponse {
     plain_lyrics: Option<String>,
 }
 
-/// Fetch lyrics for a track from LRCLib.
-///
-/// Returns synced `LyricLine`s (with `time: Some`) when LRC data is available,
-/// plain lines (with `time: None`) when only plain text exists, or an empty
-/// `Vec` when the track is not found or any error occurs.
-pub async fn fetch_lyrics(artist: &str, title: &str, album: &str) -> Vec<LyricLine> {
-    fetch_inner(artist, title, album).await.unwrap_or_default()
+/// Fetch lyrics using the configured source.
+pub async fn fetch_lyrics(
+    source: LyricsSource,
+    lrclib_url: &str,
+    client: &SubsonicClient,
+    song_id: &str,
+    artist: &str,
+    title: &str,
+    album: &str,
+) -> Vec<LyricLine> {
+    match source {
+        LyricsSource::LrcLib => fetch_lrclib(lrclib_url, artist, title, album)
+            .await
+            .unwrap_or_default(),
+        LyricsSource::Subsonic => fetch_subsonic(client, song_id, artist, title)
+            .await
+            .unwrap_or_default(),
+    }
 }
 
-async fn fetch_inner(
+async fn fetch_lrclib(
+    base_url: &str,
     artist: &str,
     title: &str,
     album: &str,
 ) -> Result<Vec<LyricLine>, Box<dyn std::error::Error + Send + Sync>> {
+    let base = base_url.trim_end_matches('/');
+    let endpoint = format!("{base}/api/get");
+
     let resp = reqwest::Client::new()
-        .get("https://lrclib.net/api/get")
+        .get(&endpoint)
         .query(&[
             ("artist_name", artist),
             ("track_name", title),
@@ -45,35 +61,58 @@ async fn fetch_inner(
 
     let body: LrcLibResponse = resp.json().await?;
 
-    // Prefer synced LRC lyrics.
     if let Some(lrc) = body.synced_lyrics.filter(|s| !s.is_empty()) {
         return Ok(parse_lrc(&lrc));
     }
 
-    // Fall back to plain text.
     if let Some(plain) = body.plain_lyrics.filter(|s| !s.is_empty()) {
-        return Ok(plain
-            .lines()
-            .map(|l| LyricLine {
-                time: None,
-                text: l.to_string(),
-            })
-            .collect());
+        return Ok(parse_lyrics_text(&plain));
     }
 
     Ok(vec![])
 }
 
+async fn fetch_subsonic(
+    client: &SubsonicClient,
+    song_id: &str,
+    artist: &str,
+    title: &str,
+) -> Result<Vec<LyricLine>, Box<dyn std::error::Error + Send + Sync>> {
+    if let Ok(lines) = client.get_lyrics_by_song_id(song_id).await {
+        if !lines.is_empty() {
+            return Ok(lines);
+        }
+    }
+
+    if let Some(text) = client.get_lyrics(artist, title).await? {
+        return Ok(parse_lyrics_text(&text));
+    }
+
+    Ok(vec![])
+}
+
+/// Parse plain or LRC-formatted lyrics text into display lines.
+fn parse_lyrics_text(text: &str) -> Vec<LyricLine> {
+    if text.lines().any(|l| l.trim_start().starts_with('[') && l.contains(']')) {
+        let synced = parse_lrc(text);
+        if !synced.is_empty() {
+            return synced;
+        }
+    }
+    text.lines()
+        .map(|l| LyricLine {
+            time: None,
+            text: l.to_string(),
+        })
+        .collect()
+}
+
 /// Parse LRC-format text into timestamped `LyricLine`s.
-///
-/// Expected line format: `[MM:SS.xx] lyric text`
-/// Lines that don't match are skipped.
 fn parse_lrc(lrc: &str) -> Vec<LyricLine> {
     lrc.lines().filter_map(parse_lrc_line).collect()
 }
 
 fn parse_lrc_line(line: &str) -> Option<LyricLine> {
-    // Expect `[MM:SS.xx] text` — find the enclosing brackets first.
     let line = line.trim();
     if !line.starts_with('[') {
         return None;
@@ -82,7 +121,6 @@ fn parse_lrc_line(line: &str) -> Option<LyricLine> {
     let tag = &line[1..close];
     let text = line[close + 1..].trim().to_string();
 
-    // Parse `MM:SS.xx`
     let colon = tag.find(':')?;
     let dot = tag.find('.')?;
     if dot <= colon {
@@ -91,11 +129,33 @@ fn parse_lrc_line(line: &str) -> Option<LyricLine> {
 
     let mins: u64 = tag[..colon].parse().ok()?;
     let secs: u64 = tag[colon + 1..dot].parse().ok()?;
-    let cs: u64 = tag[dot + 1..].parse().ok()?; // centiseconds
+    let cs: u64 = tag[dot + 1..].parse().ok()?;
 
     let ms = (mins * 60 + secs) * 1000 + cs * 10;
     Some(LyricLine {
         time: Some(Duration::from_millis(ms)),
         text,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_lrc_timestamps() {
+        let lrc = "[00:01.50] Hello\n[00:03.00] World";
+        let lines = parse_lrc(lrc);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].text, "Hello");
+        assert_eq!(lines[0].time, Some(Duration::from_millis(1500)));
+    }
+
+    #[test]
+    fn parse_plain_text_lines() {
+        let text = "Line one\nLine two";
+        let lines = parse_lyrics_text(text);
+        assert_eq!(lines.len(), 2);
+        assert!(lines.iter().all(|l| l.time.is_none()));
+    }
 }

--- a/ratune/src/lyrics.rs
+++ b/ratune/src/lyrics.rs
@@ -36,14 +36,29 @@ pub async fn fetch_lyrics(
     }
 }
 
+/// Build the LRCLib `get` endpoint from a configured base URL.
+fn lrclib_api_url(base_url: &str) -> String {
+    format!("{}/api/get", base_url.trim_end_matches('/'))
+}
+
+/// Convert an LRCLib API JSON body into display lines.
+fn lines_from_lrclib_body(body: &LrcLibResponse) -> Vec<LyricLine> {
+    if let Some(lrc) = body.synced_lyrics.as_deref().filter(|s| !s.is_empty()) {
+        return parse_lrc(lrc);
+    }
+    if let Some(plain) = body.plain_lyrics.as_deref().filter(|s| !s.is_empty()) {
+        return parse_lyrics_text(plain);
+    }
+    vec![]
+}
+
 async fn fetch_lrclib(
     base_url: &str,
     artist: &str,
     title: &str,
     album: &str,
 ) -> Result<Vec<LyricLine>, Box<dyn std::error::Error + Send + Sync>> {
-    let base = base_url.trim_end_matches('/');
-    let endpoint = format!("{base}/api/get");
+    let endpoint = lrclib_api_url(base_url);
 
     let resp = reqwest::Client::new()
         .get(&endpoint)
@@ -60,16 +75,7 @@ async fn fetch_lrclib(
     }
 
     let body: LrcLibResponse = resp.json().await?;
-
-    if let Some(lrc) = body.synced_lyrics.filter(|s| !s.is_empty()) {
-        return Ok(parse_lrc(&lrc));
-    }
-
-    if let Some(plain) = body.plain_lyrics.filter(|s| !s.is_empty()) {
-        return Ok(parse_lyrics_text(&plain));
-    }
-
-    Ok(vec![])
+    Ok(lines_from_lrclib_body(&body))
 }
 
 async fn fetch_subsonic(
@@ -93,7 +99,10 @@ async fn fetch_subsonic(
 
 /// Parse plain or LRC-formatted lyrics text into display lines.
 fn parse_lyrics_text(text: &str) -> Vec<LyricLine> {
-    if text.lines().any(|l| l.trim_start().starts_with('[') && l.contains(']')) {
+    if text
+        .lines()
+        .any(|l| l.trim_start().starts_with('[') && l.contains(']'))
+    {
         let synced = parse_lrc(text);
         if !synced.is_empty() {
             return synced;
@@ -143,6 +152,50 @@ mod tests {
     use super::*;
 
     #[test]
+    fn lrclib_api_url_trims_trailing_slash() {
+        assert_eq!(
+            lrclib_api_url("https://lrclib.net/"),
+            "https://lrclib.net/api/get"
+        );
+        assert_eq!(
+            lrclib_api_url("https://example.com"),
+            "https://example.com/api/get"
+        );
+    }
+
+    #[test]
+    fn lines_from_lrclib_body_prefers_synced_over_plain() {
+        let body = LrcLibResponse {
+            synced_lyrics: Some("[00:01.00] Synced line".into()),
+            plain_lyrics: Some("Plain only\nSecond line".into()),
+        };
+        let lines = lines_from_lrclib_body(&body);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].text, "Synced line");
+        assert_eq!(lines[0].time, Some(Duration::from_millis(1000)));
+    }
+
+    #[test]
+    fn lines_from_lrclib_body_falls_back_to_plain() {
+        let body = LrcLibResponse {
+            synced_lyrics: None,
+            plain_lyrics: Some("Line one\nLine two".into()),
+        };
+        let lines = lines_from_lrclib_body(&body);
+        assert_eq!(lines.len(), 2);
+        assert!(lines.iter().all(|l| l.time.is_none()));
+    }
+
+    #[test]
+    fn lines_from_lrclib_body_empty_when_missing() {
+        let body = LrcLibResponse {
+            synced_lyrics: None,
+            plain_lyrics: None,
+        };
+        assert!(lines_from_lrclib_body(&body).is_empty());
+    }
+
+    #[test]
     fn parse_lrc_timestamps() {
         let lrc = "[00:01.50] Hello\n[00:03.00] World";
         let lines = parse_lrc(lrc);
@@ -157,5 +210,13 @@ mod tests {
         let lines = parse_lyrics_text(text);
         assert_eq!(lines.len(), 2);
         assert!(lines.iter().all(|l| l.time.is_none()));
+    }
+
+    #[test]
+    fn parse_lyrics_text_detects_lrc_in_plain_field() {
+        let text = "[00:02.00] First\n[00:04.00] Second";
+        let lines = parse_lyrics_text(text);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].time, Some(Duration::from_millis(2000)));
     }
 }

--- a/ratune/src/lyrics_cache.rs
+++ b/ratune/src/lyrics_cache.rs
@@ -98,10 +98,7 @@ mod tests {
                 text: "World".into(),
             },
         ];
-        let dir = std::env::temp_dir().join(format!(
-            "ratune-lyrics-test-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("ratune-lyrics-test-{}", std::process::id()));
         let source_dir = dir.join("lrclib");
         let _ = std::fs::create_dir_all(&source_dir);
         LyricsDiskCache::put_at(&source_dir, "song-1", &lines);
@@ -109,5 +106,52 @@ mod tests {
         let loaded = cache.get("lrclib", "song-1").expect("cached lyrics");
         assert_eq!(loaded, lines);
         let _ = std::fs::remove_dir_all(cache.dir);
+    }
+
+    #[test]
+    fn cache_isolated_by_source() {
+        let dir =
+            std::env::temp_dir().join(format!("ratune-lyrics-sources-{}", std::process::id()));
+        let lrclib_dir = dir.join("lrclib");
+        let subsonic_dir = dir.join("subsonic");
+        let lrclib_lines = vec![LyricLine {
+            time: None,
+            text: "from lrclib".into(),
+        }];
+        let subsonic_lines = vec![LyricLine {
+            time: None,
+            text: "from subsonic".into(),
+        }];
+        LyricsDiskCache::put_at(&lrclib_dir, "song-1", &lrclib_lines);
+        LyricsDiskCache::put_at(&subsonic_dir, "song-1", &subsonic_lines);
+        let cache = LyricsDiskCache { dir };
+        assert_eq!(
+            cache.get("lrclib", "song-1").expect("lrclib")[0].text,
+            "from lrclib"
+        );
+        assert_eq!(
+            cache.get("subsonic", "song-1").expect("subsonic")[0].text,
+            "from subsonic"
+        );
+        let _ = std::fs::remove_dir_all(cache.dir);
+    }
+
+    #[test]
+    fn empty_lines_are_cached() {
+        let dir = std::env::temp_dir().join(format!("ratune-lyrics-empty-{}", std::process::id()));
+        let source_dir = dir.join("subsonic");
+        LyricsDiskCache::put_at(&source_dir, "no-lyrics", &[]);
+        let cache = LyricsDiskCache { dir };
+        let loaded = cache.get("subsonic", "no-lyrics").expect("cached empty");
+        assert!(loaded.is_empty());
+        let _ = std::fs::remove_dir_all(cache.dir);
+    }
+
+    #[test]
+    fn missing_cache_entry_returns_none() {
+        let cache = LyricsDiskCache {
+            dir: std::env::temp_dir().join(format!("ratune-lyrics-missing-{}", std::process::id())),
+        };
+        assert!(cache.get("lrclib", "does-not-exist").is_none());
     }
 }

--- a/ratune/src/lyrics_cache.rs
+++ b/ratune/src/lyrics_cache.rs
@@ -1,0 +1,113 @@
+//! On-disk lyrics cache under `~/.cache/ratune/lyrics/`.
+//!
+//! Lyrics are stored as small JSON files keyed by song ID so they remain
+//! available offline alongside cached audio tracks.
+
+use std::path::{Path, PathBuf};
+
+use ratune_subsonic::LyricLine;
+use serde::{Deserialize, Serialize};
+
+use crate::cache::ratune_cache_dir;
+
+#[derive(Serialize, Deserialize)]
+struct CachedLine {
+    time_ms: Option<u64>,
+    text: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct CachedLyrics {
+    lines: Vec<CachedLine>,
+}
+
+/// Disk-backed lyrics store.
+#[derive(Clone)]
+pub struct LyricsDiskCache {
+    dir: PathBuf,
+}
+
+impl LyricsDiskCache {
+    /// Open the lyrics cache directory, creating it when possible.
+    pub fn load() -> Self {
+        let dir = ratune_cache_dir()
+            .map(|base| base.join("lyrics"))
+            .unwrap_or_else(|| PathBuf::from(".ratune-lyrics-cache"));
+        let _ = std::fs::create_dir_all(&dir);
+        Self { dir }
+    }
+
+    fn path_for(&self, source: &str, song_id: &str) -> PathBuf {
+        self.dir.join(source).join(format!("{song_id}.json"))
+    }
+
+    /// Directory where lyrics JSON files are stored for a given source.
+    pub fn cache_dir_for(&self, source: &str) -> PathBuf {
+        let dir = self.dir.join(source);
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    /// Read cached lyrics for `song_id`, if present.
+    pub fn get(&self, source: &str, song_id: &str) -> Option<Vec<LyricLine>> {
+        let path = self.path_for(source, song_id);
+        let json = std::fs::read_to_string(path).ok()?;
+        let cached: CachedLyrics = serde_json::from_str(&json).ok()?;
+        Some(cached.lines.into_iter().map(line_from_cached).collect())
+    }
+
+    /// Write lyrics to a source-specific directory (for async fetch tasks).
+    pub fn put_at(dir: &Path, song_id: &str, lines: &[LyricLine]) {
+        let cached = CachedLyrics {
+            lines: lines.iter().map(line_to_cached).collect(),
+        };
+        if let Ok(json) = serde_json::to_string(&cached) {
+            let _ = std::fs::create_dir_all(dir);
+            let _ = std::fs::write(dir.join(format!("{song_id}.json")), json);
+        }
+    }
+}
+
+fn line_to_cached(line: &LyricLine) -> CachedLine {
+    CachedLine {
+        time_ms: line.time.map(|d| d.as_millis() as u64),
+        text: line.text.clone(),
+    }
+}
+
+fn line_from_cached(line: CachedLine) -> LyricLine {
+    LyricLine {
+        time: line.time_ms.map(std::time::Duration::from_millis),
+        text: line.text,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_cached_lines() {
+        let lines = vec![
+            LyricLine {
+                time: Some(std::time::Duration::from_millis(1500)),
+                text: "Hello".into(),
+            },
+            LyricLine {
+                time: None,
+                text: "World".into(),
+            },
+        ];
+        let dir = std::env::temp_dir().join(format!(
+            "ratune-lyrics-test-{}",
+            std::process::id()
+        ));
+        let source_dir = dir.join("lrclib");
+        let _ = std::fs::create_dir_all(&source_dir);
+        LyricsDiskCache::put_at(&source_dir, "song-1", &lines);
+        let cache = LyricsDiskCache { dir };
+        let loaded = cache.get("lrclib", "song-1").expect("cached lyrics");
+        assert_eq!(loaded, lines);
+        let _ = std::fs::remove_dir_all(cache.dir);
+    }
+}


### PR DESCRIPTION
Users can now set to have lyrics grabbed from subsonic server instead of LRCLib. See #21.

Additionally added a lyrics cache (can be enabled or disabled) and fixed a bug where lyrics were grabbed regardless if lyrics tab was open or not.

Sample usage:
```toml
[lyrics]
# source = "lrclib"
# lrclib_url = "https://lrclib.net"
# cache_enabled = false
source = "subsonic"
```
