### PR TITLE
fix: CPU spikes with quitting terminal and home_tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,6 +2656,7 @@ dependencies = [
  "image",
  "inquire",
  "keyring-core",
+ "libc",
  "linux-keyutils-keyring-store",
  "mpris-server",
  "notify-rust",

--- a/ratune/Cargo.toml
+++ b/ratune/Cargo.toml
@@ -41,6 +41,7 @@ notify-rust = "4"
 ratatui-image = { version = "9.0", default-features = false, features = ["image-defaults", "crossterm"] }
 inquire = "0.7"
 keyring-core = "1"
+libc = "0.2"
 
 # Platform credential stores for keyring-core — see https://crates.io/crates/keyring-core
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -572,6 +572,8 @@ pub struct App {
     pub home_strip_art: HashMap<String, ratatui_image::protocol::StatefulProtocol>,
     /// Last thumbnail cell size per album — rebuild strip slot when layout resizes.
     pub home_strip_last_cells: HashMap<String, (u16, u16)>,
+    /// Decoded home strip covers — avoids JPEG decode on every ratatui frame (Sixel path).
+    pub home_strip_decoded: HashMap<String, DynamicImage>,
 }
 
 impl App {
@@ -705,6 +707,7 @@ impl App {
             np_art_prep_key: None,
             home_strip_art: HashMap::new(),
             home_strip_last_cells: HashMap::new(),
+            home_strip_decoded: HashMap::new(),
             #[cfg(target_os = "linux")]
             mpris: None,
         })
@@ -779,6 +782,7 @@ impl App {
         self.np_art_prep_key = None;
         self.home_strip_art.clear();
         self.home_strip_last_cells.clear();
+        self.home_strip_decoded.clear();
         self.home_strip_layout_key = None;
         self.home_strip_resize_settle = None;
     }
@@ -827,6 +831,7 @@ impl App {
         }
         self.home_strip_art.clear();
         self.home_strip_last_cells.clear();
+        self.home_strip_decoded.clear();
         self.home_strip_thumb_prepared.clear();
         if self.kitty_apc_overlay_active() {
             let _ = crate::ui::kitty_art::clear_art_strip(self.in_tmux);
@@ -2115,6 +2120,7 @@ impl App {
                 self.home_strip_thumb_prepared.remove(&album_id);
                 self.home_strip_art.remove(&album_id);
                 self.home_strip_last_cells.remove(&album_id);
+                self.home_strip_decoded.remove(&album_id);
                 self.home_art_cache.insert(album_id, bytes);
                 // A fetch slot opened up — check if more albums need fetching.
                 self.spawn_pending_home_art_fetches();

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -17,6 +17,7 @@ mod scrobble;
 mod scrobble_queue;
 mod state;
 mod theme;
+mod tty;
 mod ui;
 mod visualizer;
 
@@ -35,7 +36,7 @@ use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
 use crossterm::ExecutableCommand;
-use ratatui::backend::CrosstermBackend;
+use ratatui::backend::{Backend, CrosstermBackend};
 use ratatui::layout::Rect;
 use ratatui::Terminal;
 
@@ -139,7 +140,7 @@ pub async fn run() -> Result<()> {
     // Background metadata index refresh when missing or stale (Milestone 2).
     app.spawn_library_index_refresh(false);
 
-    // Spawn a task that sets a flag on SIGTERM or SIGHUP so the main loop
+    // Spawn a task that sets a flag on SIGTERM, SIGHUP, SIGPIPE, or SIGINT so the main loop
     // can shut down cleanly (same path as pressing `q`).
     let signal_quit = Arc::new(AtomicBool::new(false));
     {
@@ -153,10 +154,13 @@ pub async fn run() -> Result<()> {
             // SIGPIPE: stdout/stdin fd closed (e.g. tmux pane killed while piped).
             let mut sigpipe =
                 signal(SignalKind::pipe()).expect("failed to install SIGPIPE handler");
+            let mut sigint =
+                signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
             tokio::select! {
                 _ = sigterm.recv() => {}
                 _ = sighup.recv()  => {}
                 _ = sigpipe.recv() => {}
+                _ = sigint.recv() => {}
             }
             flag.store(true, Ordering::Relaxed);
         });
@@ -237,7 +241,7 @@ pub async fn run() -> Result<()> {
         terminal
             .backend_mut()
             .write_all(b"\x1bPtmux;\x1b\x1b[?1004l\x1b\\")?;
-        terminal.backend_mut().flush()?;
+        std::io::Write::flush(terminal.backend_mut())?;
     } else {
         terminal.backend_mut().execute(DisableFocusChange)?;
     }
@@ -347,6 +351,27 @@ fn drain_ratatui_np_resize_completions(app: &mut App) {
     }
 }
 
+fn terminal_size_or_quit(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+) -> Result<Option<ratatui::layout::Rect>> {
+    loop {
+        match terminal.size() {
+            Ok(sz) if sz.width == 0 || sz.height == 0 => {
+                app.should_quit = true;
+                return Ok(None);
+            }
+            Ok(sz) => return Ok(Some(Rect::new(0, 0, sz.width, sz.height))),
+            Err(e) if tty::io_disconnect(&e) => {
+                app.should_quit = true;
+                return Ok(None);
+            }
+            Err(e) if tty::io_interrupted(&e) => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
 async fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
@@ -374,8 +399,18 @@ async fn run_loop(
     let mut last_art_recovery_fire = Instant::now();
 
     loop {
-        // Check for SIGTERM / SIGHUP from the signal handler task.
+        let frame_t0 = Instant::now();
+        let poll_ms = if app.visualizer_visible || app.accent_transition_active() {
+            33
+        } else {
+            50
+        };
+
+        // Check for SIGTERM / SIGHUP / SIGPIPE / SIGINT from the signal handler task.
         if signal_quit.load(Ordering::Relaxed) {
+            app.should_quit = true;
+        }
+        if tty::terminal_disconnected() {
             app.should_quit = true;
         }
 
@@ -406,7 +441,19 @@ async fn run_loop(
         // Apply completed NP encodes before draw (previous frame) and after draw (same-frame worker).
         drain_ratatui_np_resize_completions(app);
 
-        terminal.draw(|f| ui::render(app, f))?;
+        match terminal.draw(|f| ui::render(app, f)) {
+            Ok(_) => {}
+            Err(e) if tty::io_disconnect(&e) => app.should_quit = true,
+            // EINTR during SIGWINCH: skip this present; next frame redraws cleanly.
+            Err(e) if tty::io_interrupted(&e) => {}
+            Err(e) => return Err(e.into()),
+        }
+        match Backend::flush(terminal.backend_mut()) {
+            Ok(()) => {}
+            Err(e) if tty::io_disconnect(&e) => app.should_quit = true,
+            Err(e) if tty::io_interrupted(&e) => {}
+            Err(e) => return Err(e.into()),
+        }
 
         app.apply_home_strip_resize_settle();
 
@@ -447,12 +494,18 @@ async fn run_loop(
                         let _ = ui::kitty_art::clear_image(app.in_tmux);
                         art_displayed = false;
                     }
-                } else if let (Some((cover_id, bytes)), Some(fp)) =
-                    (app.art_cache.as_ref(), app.art_cache_fingerprint)
-                {
-                    let sz = terminal.size()?;
+                } else {
+                    let Some(terminal_rect) = terminal_size_or_quit(terminal, app)? else {
+                        last_tab = app.active_tab;
+                        if app.should_quit {
+                            break;
+                        }
+                        continue;
+                    };
+                    if let (Some((cover_id, bytes)), Some(fp)) =
+                        (app.art_cache.as_ref(), app.art_cache_fingerprint)
+                    {
                     let show_art = app.config.nowplaying_show_art;
-                    let terminal_rect = Rect::new(0, 0, sz.width, sz.height);
                     let layout_opts = ui::layout::layout_options_for_app(app);
                     let center = ui::layout::build_layout(terminal_rect, &layout_opts).center;
 
@@ -574,6 +627,7 @@ async fn run_loop(
                     last_rendered_art = None;
                     art_displayed = false;
                 }
+                }
             } else if last_tab != app.active_tab {
                 // Switched away from any tab — clear any visible Kitty
                 // placement so it doesn't float above the new tab's content.
@@ -619,29 +673,16 @@ async fn run_loop(
         // Block until the frame interval elapses *or* input is ready.  Previously we
         // slept first and only then polled stdin, which added a full period (50 ms)
         // of latency to every keypress.
-        let poll_ms = if app.visualizer_visible || app.accent_transition_active() {
-            33
-        } else {
-            50
-        };
-        match event::poll(Duration::from_millis(poll_ms)) {
-            Err(e)
-                if e.kind() == std::io::ErrorKind::BrokenPipe
-                    || e.kind() == std::io::ErrorKind::UnexpectedEof =>
-            {
-                app.should_quit = true;
-            }
-            Err(e) => return Err(e.into()),
+        match tty::wait_for_input(poll_ms, &mut app.should_quit) {
+            Err(e) => return Err(e),
             Ok(false) => {}
             Ok(true) => loop {
                 let read_result = event::read();
                 match read_result {
-                    Err(e)
-                        if e.kind() == std::io::ErrorKind::BrokenPipe
-                            || e.kind() == std::io::ErrorKind::UnexpectedEof =>
-                    {
+                    Err(e) if tty::io_disconnect(&e) => {
                         app.should_quit = true;
                     }
+                    Err(e) if tty::io_interrupted(&e) => {}
                     Err(e) => return Err(e.into()),
                     Ok(ev) => match ev {
                         Event::Key(key)
@@ -767,8 +808,10 @@ async fn run_loop(
                                 }
                             }
                         Event::Mouse(mouse) => {
-                            let sz = terminal.size()?;
-                            let area = Rect::new(0, 0, sz.width, sz.height);
+                            let Some(area) = terminal_size_or_quit(terminal, app)? else {
+                                app.should_quit = true;
+                                break;
+                            };
                             match mouse.kind {
                                 MouseEventKind::Down(MouseButton::Left) => {
                                     handle_mouse_click(mouse.column, mouse.row, app, area);
@@ -795,12 +838,10 @@ async fn run_loop(
                             }
                         }
                         Event::Resize(_, _) => {
-                            // Terminal resized — clear any displayed image and reset
-                            // stored state so the art is re-encoded at the new size.
-                            // last_rendered_art rect will no longer match the new
-                            // art_rect, so the full render path is taken on next frame.
+                            // Invalidate cached art geometry; re-encode on the next draw.
+                            // Avoid clear_image here — clearing on every resize tick while
+                            // dragging a window causes visible flicker (especially Kitty APC).
                             if app.kitty_apc_overlay_active() && art_displayed {
-                                let _ = ui::kitty_art::clear_image(app.in_tmux);
                                 art_displayed = false;
                                 last_rendered_art = None;
                             }
@@ -859,17 +900,8 @@ async fn run_loop(
                     break;
                 }
 
-                match event::poll(Duration::ZERO) {
-                    Err(e)
-                        if e.kind() == std::io::ErrorKind::BrokenPipe
-                            || e.kind() == std::io::ErrorKind::UnexpectedEof =>
-                    {
-                        app.should_quit = true;
-                        break;
-                    }
-                    Err(e) => return Err(e.into()),
-                    Ok(false) => break,
-                    Ok(true) => {}
+                if !tty::stdin_has_input() {
+                    break;
                 }
             },
         }
@@ -903,6 +935,14 @@ async fn run_loop(
 
         if app.should_quit {
             break;
+        }
+
+        // When stdin had a burst (resize drag, key repeat), `wait_for_input` may return
+        // immediately; cap the loop at ~20–30 FPS so we don't full-redraw as fast as possible.
+        let frame_budget = Duration::from_millis(poll_ms);
+        let spent = frame_t0.elapsed();
+        if spent < frame_budget {
+            std::thread::sleep(frame_budget - spent);
         }
     }
     // Persist UI state on clean quit.

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -505,128 +505,128 @@ async fn run_loop(
                     if let (Some((cover_id, bytes)), Some(fp)) =
                         (app.art_cache.as_ref(), app.art_cache_fingerprint)
                     {
-                    let show_art = app.config.nowplaying_show_art;
-                    let layout_opts = ui::layout::layout_options_for_app(app);
-                    let center = ui::layout::build_layout(terminal_rect, &layout_opts).center;
+                        let show_art = app.config.nowplaying_show_art;
+                        let layout_opts = ui::layout::layout_options_for_app(app);
+                        let center = ui::layout::build_layout(terminal_rect, &layout_opts).center;
 
-                    let boxed = app
-                        .config
-                        .now_playing_layout
-                        .trim()
-                        .eq_ignore_ascii_case("boxed");
+                        let boxed = app
+                            .config
+                            .now_playing_layout
+                            .trim()
+                            .eq_ignore_ascii_case("boxed");
 
-                    let art_position =
-                        ui::layout::placement_from_str(&app.config.nowplaying_art_position)
-                            .unwrap_or(ui::layout::Placement::Left);
-                    let queue_position =
-                        ui::layout::placement_from_str(&app.config.nowplaying_queue_position)
-                            .unwrap_or(ui::layout::Placement::Right);
-                    let visualizer_position =
-                        ui::layout::placement_from_str(&app.config.visualizer_location)
-                            .unwrap_or(ui::layout::Placement::Right);
-                    let now_playing_position =
-                        ui::layout::placement_from_str(&app.config.now_playing_box_location)
-                            .unwrap_or(ui::layout::Placement::Right);
-                    let lyrics_position =
-                        ui::layout::placement_from_str(&app.config.lyrics_location)
-                            .unwrap_or(queue_position);
+                        let art_position =
+                            ui::layout::placement_from_str(&app.config.nowplaying_art_position)
+                                .unwrap_or(ui::layout::Placement::Left);
+                        let queue_position =
+                            ui::layout::placement_from_str(&app.config.nowplaying_queue_position)
+                                .unwrap_or(ui::layout::Placement::Right);
+                        let visualizer_position =
+                            ui::layout::placement_from_str(&app.config.visualizer_location)
+                                .unwrap_or(ui::layout::Placement::Right);
+                        let now_playing_position =
+                            ui::layout::placement_from_str(&app.config.now_playing_box_location)
+                                .unwrap_or(ui::layout::Placement::Right);
+                        let lyrics_position =
+                            ui::layout::placement_from_str(&app.config.lyrics_location)
+                                .unwrap_or(queue_position);
 
-                    let rects = ui::layout::now_playing_rects(
-                        center,
-                        show_art,
-                        art_position,
-                        queue_position,
-                        app.config.nowplaying_left_width_percent,
-                        app.config.nowplaying_vertical_fill_top_percent,
-                        app.visualizer_visible,
-                        visualizer_position,
-                        app.lyrics_visible,
-                        lyrics_position,
-                        boxed,
-                        now_playing_position,
-                    );
-                    let art_rect_opt = rects.art;
+                        let rects = ui::layout::now_playing_rects(
+                            center,
+                            show_art,
+                            art_position,
+                            queue_position,
+                            app.config.nowplaying_left_width_percent,
+                            app.config.nowplaying_vertical_fill_top_percent,
+                            app.visualizer_visible,
+                            visualizer_position,
+                            app.lyrics_visible,
+                            lyrics_position,
+                            boxed,
+                            now_playing_position,
+                        );
+                        let art_rect_opt = rects.art;
 
-                    if kitty_cover_unrenderable.as_deref() == Some(cover_id.as_str()) {
-                        if art_displayed {
-                            let _ = ui::kitty_art::clear_image(app.in_tmux);
-                            art_displayed = false;
-                        }
-                    } else if let Some(art_rect) = art_rect_opt {
-                        let inner = ui::kitty_art::album_art_placeholder_inner(art_rect);
-                        let font = app
-                            .art_picker
-                            .as_ref()
-                            .map(|p| p.font_size())
-                            .or(app.cell_px)
-                            .unwrap_or((10, 20));
-                        let placement = app
-                            .art_cache_decoded
-                            .as_ref()
-                            .map(|(_, img)| {
-                                ui::art_prepare::contain_fit_rect_in_cells(img, inner, font)
-                            })
-                            .unwrap_or_else(|| {
-                                image::load_from_memory(bytes)
-                                    .ok()
-                                    .map(|img| {
-                                        ui::art_prepare::contain_fit_rect_in_cells(
-                                            &img, inner, font,
-                                        )
-                                    })
-                                    .unwrap_or(inner)
-                            });
-                        if placement.width == 0 || placement.height == 0 {
+                        if kitty_cover_unrenderable.as_deref() == Some(cover_id.as_str()) {
                             if art_displayed {
                                 let _ = ui::kitty_art::clear_image(app.in_tmux);
                                 art_displayed = false;
                             }
-                            last_rendered_art = None;
-                        } else {
-                            let stored_matches = last_rendered_art
+                        } else if let Some(art_rect) = art_rect_opt {
+                            let inner = ui::kitty_art::album_art_placeholder_inner(art_rect);
+                            let font = app
+                                .art_picker
                                 .as_ref()
-                                .map(|(last_fp, r)| *last_fp == fp && r == &placement)
-                                .unwrap_or(false);
-
-                            if stored_matches && art_displayed {
-                                // Image is already visible — nothing to do.
+                                .map(|p| p.font_size())
+                                .or(app.cell_px)
+                                .unwrap_or((10, 20));
+                            let placement = app
+                                .art_cache_decoded
+                                .as_ref()
+                                .map(|(_, img)| {
+                                    ui::art_prepare::contain_fit_rect_in_cells(img, inner, font)
+                                })
+                                .unwrap_or_else(|| {
+                                    image::load_from_memory(bytes)
+                                        .ok()
+                                        .map(|img| {
+                                            ui::art_prepare::contain_fit_rect_in_cells(
+                                                &img, inner, font,
+                                            )
+                                        })
+                                        .unwrap_or(inner)
+                                });
+                            if placement.width == 0 || placement.height == 0 {
+                                if art_displayed {
+                                    let _ = ui::kitty_art::clear_image(app.in_tmux);
+                                    art_displayed = false;
+                                }
+                                last_rendered_art = None;
                             } else {
-                                // Album changed, first display, tab return, or terminal
-                                // was resized — full re-encode and re-transmit.
-                                match ui::kitty_art::render_image(
-                                    bytes,
-                                    placement,
-                                    app.in_tmux,
-                                    app.tmux_status_offset,
-                                    app.cell_px,
-                                    theme::surface_pad_rgba(app.theme.surface),
-                                ) {
-                                    Ok(()) => {
-                                        last_rendered_art = Some((fp, placement));
-                                        art_displayed = true;
-                                    }
-                                    Err(e) => {
-                                        eprintln!("kitty render: {e}");
-                                        let _ = ui::kitty_art::clear_image(app.in_tmux);
-                                        kitty_cover_unrenderable = Some(cover_id.clone());
-                                        last_rendered_art = None;
-                                        art_displayed = false;
+                                let stored_matches = last_rendered_art
+                                    .as_ref()
+                                    .map(|(last_fp, r)| *last_fp == fp && r == &placement)
+                                    .unwrap_or(false);
+
+                                if stored_matches && art_displayed {
+                                    // Image is already visible — nothing to do.
+                                } else {
+                                    // Album changed, first display, tab return, or terminal
+                                    // was resized — full re-encode and re-transmit.
+                                    match ui::kitty_art::render_image(
+                                        bytes,
+                                        placement,
+                                        app.in_tmux,
+                                        app.tmux_status_offset,
+                                        app.cell_px,
+                                        theme::surface_pad_rgba(app.theme.surface),
+                                    ) {
+                                        Ok(()) => {
+                                            last_rendered_art = Some((fp, placement));
+                                            art_displayed = true;
+                                        }
+                                        Err(e) => {
+                                            eprintln!("kitty render: {e}");
+                                            let _ = ui::kitty_art::clear_image(app.in_tmux);
+                                            kitty_cover_unrenderable = Some(cover_id.clone());
+                                            last_rendered_art = None;
+                                            art_displayed = false;
+                                        }
                                     }
                                 }
                             }
+                        } else if art_displayed {
+                            // Art column hidden — clear Kitty overlay.
+                            let _ = ui::kitty_art::clear_image(app.in_tmux);
+                            last_rendered_art = None;
+                            art_displayed = false;
                         }
                     } else if art_displayed {
-                        // Art column hidden — clear Kitty overlay.
+                        // In NowPlaying tab but no art — clear any stale image.
                         let _ = ui::kitty_art::clear_image(app.in_tmux);
                         last_rendered_art = None;
                         art_displayed = false;
                     }
-                } else if art_displayed {
-                    // In NowPlaying tab but no art — clear any stale image.
-                    let _ = ui::kitty_art::clear_image(app.in_tmux);
-                    last_rendered_art = None;
-                    art_displayed = false;
-                }
                 }
             } else if last_tab != app.active_tab {
                 // Switched away from any tab — clear any visible Kitty

--- a/ratune/src/tty.rs
+++ b/ratune/src/tty.rs
@@ -210,3 +210,53 @@ pub fn stdin_has_input() -> bool {
         event::poll(Duration::ZERO).unwrap_or(false)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    fn err(kind: io::ErrorKind) -> io::Error {
+        io::Error::new(kind, "test")
+    }
+
+    #[cfg(unix)]
+    fn err_raw(raw: i32) -> io::Error {
+        io::Error::from_raw_os_error(raw)
+    }
+
+    #[test]
+    fn io_disconnect_pipe_and_eof() {
+        assert!(io_disconnect(&err(io::ErrorKind::BrokenPipe)));
+        assert!(io_disconnect(&err(io::ErrorKind::UnexpectedEof)));
+        assert!(io_disconnect(&err(io::ErrorKind::NotConnected)));
+        assert!(io_disconnect(&err(io::ErrorKind::WriteZero)));
+    }
+
+    #[test]
+    fn io_disconnect_not_interrupted() {
+        assert!(!io_disconnect(&err(io::ErrorKind::Interrupted)));
+        #[cfg(unix)]
+        assert!(!io_disconnect(&err_raw(libc::EINTR)));
+    }
+
+    #[test]
+    fn io_interrupted_eintr() {
+        assert!(io_interrupted(&err(io::ErrorKind::Interrupted)));
+        #[cfg(unix)]
+        assert!(io_interrupted(&err_raw(libc::EINTR)));
+    }
+
+    #[test]
+    fn io_interrupted_not_disconnect() {
+        assert!(!io_interrupted(&err(io::ErrorKind::BrokenPipe)));
+        #[cfg(unix)]
+        assert!(!io_interrupted(&err_raw(libc::EIO)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn io_disconnect_eio() {
+        assert!(io_disconnect(&err_raw(libc::EIO)));
+    }
+}

--- a/ratune/src/tty.rs
+++ b/ratune/src/tty.rs
@@ -1,0 +1,212 @@
+//! Detect when the controlling terminal has closed (PTY hangup).
+//!
+//! `isatty` and stdout write errors are enough on some emulators (e.g. Alacritty).
+//! Kitty and Ghostty often keep the slave PTY open with `isatty` still true while
+//! crossterm spins on `read(0) → EIO`; `poll(POLLHUP)` catches that case.
+
+use std::io;
+use std::io::IsTerminal;
+
+/// I/O errors that mean the terminal session is gone.
+pub fn io_disconnect(err: &io::Error) -> bool {
+    if matches!(
+        err.kind(),
+        io::ErrorKind::BrokenPipe
+            | io::ErrorKind::UnexpectedEof
+            | io::ErrorKind::NotConnected
+            | io::ErrorKind::WriteZero
+    ) {
+        return true;
+    }
+    #[cfg(unix)]
+    if err.raw_os_error() == Some(libc::EIO) {
+        return true;
+    }
+    false
+}
+
+/// Signal interrupted a syscall (e.g. SIGWINCH during `poll` on resize). Retry, don't quit.
+pub fn io_interrupted(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::Interrupted
+        || (cfg!(unix) && err.raw_os_error() == Some(libc::EINTR))
+}
+
+/// True when stdin/stdout no longer represent a live terminal session.
+pub fn terminal_disconnected() -> bool {
+    if !(io::stdin().is_terminal() && io::stdout().is_terminal()) {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        pty_hung_up()
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+#[cfg(unix)]
+fn poll_fd(pfd: &mut libc::pollfd, timeout: i32) -> Result<i32, io::Error> {
+    loop {
+        let ret = unsafe { libc::poll(pfd, 1, timeout) };
+        if ret < 0 {
+            let e = io::Error::last_os_error();
+            if io_interrupted(&e) {
+                continue;
+            }
+            return Err(e);
+        }
+        return Ok(ret);
+    }
+}
+
+#[cfg(unix)]
+fn fionread(fd: std::os::unix::io::RawFd) -> Result<i32, io::Error> {
+    loop {
+        let mut queued = 0i32;
+        let rc = unsafe { libc::ioctl(fd, libc::FIONREAD, &mut queued as *mut _) };
+        if rc < 0 {
+            let e = io::Error::last_os_error();
+            if io_interrupted(&e) {
+                continue;
+            }
+            return Err(e);
+        }
+        return Ok(queued);
+    }
+}
+
+#[cfg(unix)]
+fn pty_hung_up() -> bool {
+    use std::os::unix::io::AsRawFd;
+
+    pty_fd_hung_up(io::stdin().as_raw_fd()) || pty_fd_hung_up(io::stdout().as_raw_fd())
+}
+
+#[cfg(unix)]
+fn pty_fd_hung_up(fd: std::os::unix::io::RawFd) -> bool {
+    if fd < 0 {
+        return true;
+    }
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN | libc::POLLOUT | libc::POLLHUP | libc::POLLERR,
+        revents: 0,
+    };
+    match poll_fd(&mut pfd, 0) {
+        Ok(_) => {}
+        Err(e) => return io_disconnect(&e),
+    }
+    if pfd.revents & (libc::POLLHUP | libc::POLLERR) != 0 {
+        return true;
+    }
+    // Linux PTY master close often sets POLLIN with a pending zero-byte read (EOF).
+    if pfd.revents & libc::POLLIN != 0 && pty_fd_eof_pending(fd) {
+        return true;
+    }
+    false
+}
+
+#[cfg(unix)]
+fn pty_fd_eof_pending(fd: std::os::unix::io::RawFd) -> bool {
+    match fionread(fd) {
+        Ok(0) => true,
+        Ok(_) => false,
+        Err(e) => io_disconnect(&e),
+    }
+}
+
+/// Block until `poll_ms` elapses or stdin has input. Uses `poll(2)` on Unix so we
+/// detect PTY hangup before crossterm's reader (which can spin on `EIO` in Kitty/Ghostty).
+pub fn wait_for_input(poll_ms: u64, should_quit: &mut bool) -> anyhow::Result<bool> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+
+        if terminal_disconnected() {
+            *should_quit = true;
+            return Ok(false);
+        }
+
+        let fd = io::stdin().as_raw_fd();
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+            revents: 0,
+        };
+        let timeout = poll_ms.min(i32::MAX as u64) as i32;
+        match poll_fd(&mut pfd, timeout) {
+            Ok(_) => {}
+            Err(e) if io_disconnect(&e) => {
+                *should_quit = true;
+                return Ok(false);
+            }
+            Err(e) => return Err(e.into()),
+        }
+        if pfd.revents & (libc::POLLHUP | libc::POLLERR) != 0 {
+            *should_quit = true;
+            return Ok(false);
+        }
+        if pfd.revents & libc::POLLIN != 0 {
+            if pty_fd_eof_pending(fd) {
+                *should_quit = true;
+                return Ok(false);
+            }
+            return Ok(true);
+        }
+        Ok(false)
+    }
+    #[cfg(not(unix))]
+    {
+        use crossterm::event;
+        use std::time::Duration;
+
+        if terminal_disconnected() {
+            *should_quit = true;
+            return Ok(false);
+        }
+        match event::poll(Duration::from_millis(poll_ms)) {
+            Err(e) if io_disconnect(&e) => {
+                *should_quit = true;
+                Ok(false)
+            }
+            Err(e) if io_interrupted(&e) => Ok(false),
+            Err(e) => Err(e.into()),
+            Ok(ready) => Ok(ready),
+        }
+    }
+}
+
+/// Non-blocking check for more stdin data (burst keypresses).
+pub fn stdin_has_input() -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+
+        if terminal_disconnected() {
+            return false;
+        }
+        let fd = io::stdin().as_raw_fd();
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ret = match poll_fd(&mut pfd, 0) {
+            Ok(n) => n,
+            Err(_) => return false,
+        };
+        if ret <= 0 {
+            return false;
+        }
+        pfd.revents & libc::POLLIN != 0 && !pty_fd_eof_pending(fd)
+    }
+    #[cfg(not(unix))]
+    {
+        use crossterm::event;
+        use std::time::Duration;
+
+        event::poll(Duration::ZERO).unwrap_or(false)
+    }
+}

--- a/ratune/src/ui/home_tab.rs
+++ b/ratune/src/ui/home_tab.rs
@@ -384,21 +384,35 @@ fn render_art_strip_ratatui(f: &mut Frame, albums_inner: Rect, app: &mut App, _i
 
         let thumb_rect = art_strip_slot_thumb_rect(&layout, albums_inner, i);
 
-        if let Some(bytes) = app.home_art_cache.get(&album_id) {
+        if app.home_art_cache.contains_key(&album_id) {
             let slot = (thumb_cols, thumb_rows);
             if app.home_strip_last_cells.get(&album_id).copied() != Some(slot) {
                 app.home_strip_art.remove(&album_id);
             }
-            let Ok(img) = image::load_from_memory(bytes) else {
+
+            if !app.home_strip_decoded.contains_key(&album_id) {
+                let Some(bytes) = app.home_art_cache.get(&album_id) else {
+                    continue;
+                };
+                let Ok(img) = image::load_from_memory(bytes) else {
+                    continue;
+                };
+                app.home_strip_decoded.insert(album_id.clone(), img);
+            }
+            let Some(img) = app.home_strip_decoded.get(&album_id) else {
                 continue;
             };
-            let art_rect = crate::ui::art_prepare::contain_fit_rect_in_cells(&img, thumb_rect, fs);
+            let art_rect =
+                crate::ui::art_prepare::contain_fit_rect_in_cells(img, thumb_rect, fs);
+
             if !app.home_strip_art.contains_key(&album_id) {
                 if is_sixel && sixel_builds_this_frame >= MAX_SIXEL_STRIP_BUILDS_PER_FRAME {
                     continue;
                 }
                 let prepared = crate::ui::art_prepare::prepare_art_image_for_rect_contain_fit(
-                    img, art_rect, fs,
+                    img.clone(),
+                    art_rect,
+                    fs,
                 );
                 let proto = picker.new_resize_protocol(prepared);
                 app.home_strip_art.insert(album_id.clone(), proto);
@@ -416,6 +430,7 @@ fn render_art_strip_ratatui(f: &mut Frame, albums_inner: Rect, app: &mut App, _i
 
     app.home_strip_art.retain(|k, _| keep.contains(k));
     app.home_strip_last_cells.retain(|k, _| keep.contains(k));
+    app.home_strip_decoded.retain(|k, _| keep.contains(k));
 }
 
 // ── Art strip label rows (Kitty path) ─────────────────────────────────────────

--- a/ratune/src/ui/home_tab.rs
+++ b/ratune/src/ui/home_tab.rs
@@ -402,8 +402,7 @@ fn render_art_strip_ratatui(f: &mut Frame, albums_inner: Rect, app: &mut App, _i
             let Some(img) = app.home_strip_decoded.get(&album_id) else {
                 continue;
             };
-            let art_rect =
-                crate::ui::art_prepare::contain_fit_rect_in_cells(img, thumb_rect, fs);
+            let art_rect = crate::ui::art_prepare::contain_fit_rect_in_cells(img, thumb_rect, fs);
 
             if !app.home_strip_art.contains_key(&album_id) {
                 if is_sixel && sixel_builds_this_frame >= MAX_SIXEL_STRIP_BUILDS_PER_FRAME {


### PR DESCRIPTION
Two main fixes here:

1. Issue #27 -- Ratune was not catching SIGINT and if was drawing on terminal quit, would do this indefinitely. Added additional checks to ensure Ratune is still in a live terminal before drawing. Added a few tests around this.

2. Issue #25 -- There was an issue where we weren't properly caching the images on home_tab. This led to constant reloading of images over and over and over at a fairly fast rate.