### PR TITLE
fix: NP album art optimized via proper caching

### DIFF
--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -16,7 +16,7 @@ use ratune_subsonic::SubsonicClient;
 use serde::{Deserialize, Serialize};
 
 use crate::action::{Action, Direction};
-use crate::color::{extract_accent, lerp_color};
+use crate::color::{extract_accent, extract_accent_from_image, lerp_color};
 use crate::config::{AlbumArtBackend, BrowseMode, Config};
 use crate::history::PlayRecord;
 use crate::keybinds::Keybinds;
@@ -576,6 +576,8 @@ pub struct App {
     pub home_strip_last_cells: HashMap<String, (u16, u16)>,
     /// Decoded home strip covers — avoids JPEG decode on every ratatui frame (Sixel path).
     pub home_strip_decoded: HashMap<String, DynamicImage>,
+    /// Cached resize + zlib for Now Playing Kitty APC (built once per cover + placement).
+    pub np_kitty_prepared: Option<crate::ui::kitty_art::NpKittyPrepared>,
 }
 
 impl App {
@@ -717,6 +719,7 @@ impl App {
             home_strip_art: HashMap::new(),
             home_strip_last_cells: HashMap::new(),
             home_strip_decoded: HashMap::new(),
+            np_kitty_prepared: None,
             #[cfg(target_os = "linux")]
             mpris: None,
         })
@@ -785,10 +788,72 @@ impl App {
             && (self.kitty_apc_graphics_ready() || self.ratatui_art_ready())
     }
 
+    /// Decode the current cover once and cache in `art_cache_decoded`.
+    pub fn ensure_art_cache_decoded(&mut self) -> bool {
+        let Some(fp) = self.art_cache_fingerprint else {
+            return false;
+        };
+        if self
+            .art_cache_decoded
+            .as_ref()
+            .is_some_and(|(cached_fp, _)| *cached_fp == fp)
+        {
+            return true;
+        }
+        let Some((_, bytes)) = self.art_cache.as_ref() else {
+            self.art_cache_decoded = None;
+            return false;
+        };
+        match image::load_from_memory(bytes) {
+            Ok(img) => {
+                self.art_cache_decoded = Some((fp, img));
+                true
+            }
+            Err(_) => {
+                self.art_cache_decoded = None;
+                false
+            }
+        }
+    }
+
+    /// Build or reuse Kitty APC zlib/base64 for the current cover at `placement`.
+    pub fn ensure_np_kitty_prepared(
+        &mut self,
+        placement: Rect,
+        font: (u16, u16),
+    ) -> Option<&crate::ui::kitty_art::NpKittyPrepared> {
+        let fp = self.art_cache_fingerprint?;
+        if !self.ensure_art_cache_decoded() {
+            self.np_kitty_prepared = None;
+            return None;
+        }
+        if self
+            .np_kitty_prepared
+            .as_ref()
+            .is_some_and(|p| p.matches(fp, placement))
+        {
+            return self.np_kitty_prepared.as_ref();
+        }
+        let img = &self.art_cache_decoded.as_ref()?.1;
+        let prepared = crate::ui::kitty_art::NpKittyPrepared::build(img, fp, placement, font)?;
+        self.np_kitty_prepared = Some(prepared);
+        self.np_kitty_prepared.as_ref()
+    }
+
+    /// Accent from cached cover pixels when available, else decode from bytes.
+    fn accent_from_art_cache(&self) -> Option<Color> {
+        if let Some((_, img)) = self.art_cache_decoded.as_ref() {
+            return extract_accent_from_image(img);
+        }
+        let (_, bytes) = self.art_cache.as_ref()?;
+        extract_accent(bytes)
+    }
+
     /// Drop all `ratatui-image` protocol state (tab switch, help overlay, fzf suspend, …).
     pub fn clear_ratatui_art_state(&mut self) {
         self.np_art_state = None;
         self.np_art_prep_key = None;
+        self.np_kitty_prepared = None;
         self.home_strip_art.clear();
         self.home_strip_last_cells.clear();
         self.home_strip_decoded.clear();
@@ -800,6 +865,7 @@ impl App {
     pub fn clear_np_ratatui_art_state(&mut self) {
         self.np_art_state = None;
         self.np_art_prep_key = None;
+        self.np_kitty_prepared = None;
     }
 
     pub fn schedule_home_strip_resize_invalidate(&mut self) {
@@ -2149,12 +2215,16 @@ impl App {
                 }
             }
             LibraryUpdate::CoverArt { cover_id, bytes } => {
-                // Extract dynamic accent before storing (bytes are consumed here).
-                let accent = extract_accent(&bytes);
                 let fp = crate::ui::art_prepare::art_bytes_fingerprint(&bytes);
+                let decoded = image::load_from_memory(&bytes).ok();
+                let accent = decoded
+                    .as_ref()
+                    .and_then(extract_accent_from_image)
+                    .or_else(|| extract_accent(&bytes));
                 self.art_cache = Some((cover_id, bytes));
                 self.art_cache_fingerprint = Some(fp);
-                self.art_cache_decoded = None;
+                self.art_cache_decoded = decoded.map(|img| (fp, img));
+                self.np_kitty_prepared = None;
                 self.apply_dynamic_accent(accent);
                 #[cfg(target_os = "linux")]
                 self.mpris_emit_props();
@@ -2567,9 +2637,9 @@ impl App {
                             // is applied there.  Clear stale dynamic accent for now.
                             self.apply_dynamic_accent(None);
                             self.fetch_cover_art(cid.clone());
-                        } else if let Some((_, ref bytes)) = self.art_cache.clone() {
+                        } else if self.art_cache.is_some() {
                             // Art already cached for this cover_id — extract immediately.
-                            let accent = extract_accent(bytes);
+                            let accent = self.accent_from_art_cache();
                             self.apply_dynamic_accent(accent);
                         }
                     } else {
@@ -2664,8 +2734,8 @@ impl App {
                         if needs_fetch {
                             self.apply_dynamic_accent(None);
                             self.fetch_cover_art(cid.clone());
-                        } else if let Some((_, ref bytes)) = self.art_cache.clone() {
-                            let accent = extract_accent(bytes);
+                        } else if self.art_cache.is_some() {
+                            let accent = self.accent_from_art_cache();
                             self.apply_dynamic_accent(accent);
                         }
                     } else {

--- a/ratune/src/color.rs
+++ b/ratune/src/color.rs
@@ -9,12 +9,16 @@ use ratatui::style::Color;
 /// (V < 0.15) nor near-white (V > 0.85).  Returns `None` when no suitable
 /// colour is found.
 pub fn extract_accent(image_bytes: &[u8]) -> Option<Color> {
+    let img = image::load_from_memory(image_bytes).ok()?;
+    extract_accent_from_image(&img)
+}
+
+/// Like [`extract_accent`] but reuses an already-decoded cover (avoids a second JPEG decode).
+pub fn extract_accent_from_image(img: &image::DynamicImage) -> Option<Color> {
     use palette_extract::{
         get_palette_with_options, MaxColors, PixelEncoding, PixelFilter, Quality,
     };
 
-    // Decode to RGBA8.
-    let img = image::load_from_memory(image_bytes).ok()?;
     let rgba = img.to_rgba8();
     let pixels: &[u8] = rgba.as_raw();
 

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -397,7 +397,7 @@ async fn run_loop(
     // redisplay it instantly with `a=p,i=1` when switching back.
     let mut last_rendered_art: Option<(u64, Rect)> = None;
     let mut art_displayed = false;
-    // Cover id for which `render_image` failed (e.g. undecodable bytes). Without
+    // Cover id for which Kitty transmit failed (e.g. undecodable bytes). Without
     // this latch the loop retries every frame and spams stderr.
     let mut kitty_cover_unrenderable: Option<String> = None;
     let mut last_tab = app.active_tab;
@@ -489,7 +489,7 @@ async fn run_loop(
                 // On every entry to NowPlaying (including initial load) drop any
                 // cached render state so the art is fully re-transmitted this frame.
                 // The fast display_image() path (a=p,i=1) can silently fail if the
-                // terminal evicted the stored image; render_image() is always reliable.
+                // terminal evicted the stored image; full re-transmit is always reliable.
                 if last_tab != app::Tab::NowPlaying {
                     last_rendered_art = None;
                     art_displayed = false;
@@ -510,9 +510,10 @@ async fn run_loop(
                         }
                         continue;
                     };
-                    if let (Some((cover_id, bytes)), Some(fp)) =
-                        (app.art_cache.as_ref(), app.art_cache_fingerprint)
-                    {
+                    if let (Some(fp), Some(cover_id)) = (
+                        app.art_cache_fingerprint,
+                        app.art_cache.as_ref().map(|(id, _)| id.clone()),
+                    ) {
                         let show_art = app.config.nowplaying_show_art;
                         let layout_opts = ui::layout::layout_options_for_app(app);
                         let center = ui::layout::build_layout(terminal_rect, &layout_opts).center;
@@ -568,22 +569,14 @@ async fn run_loop(
                                 .map(|p| p.font_size())
                                 .or(app.cell_px)
                                 .unwrap_or((10, 20));
-                            let placement = app
-                                .art_cache_decoded
-                                .as_ref()
-                                .map(|(_, img)| {
+                            let placement = if app.ensure_art_cache_decoded() {
+                                app.art_cache_decoded.as_ref().map(|(_, img)| {
                                     ui::art_prepare::contain_fit_rect_in_cells(img, inner, font)
                                 })
-                                .unwrap_or_else(|| {
-                                    image::load_from_memory(bytes)
-                                        .ok()
-                                        .map(|img| {
-                                            ui::art_prepare::contain_fit_rect_in_cells(
-                                                &img, inner, font,
-                                            )
-                                        })
-                                        .unwrap_or(inner)
-                                });
+                            } else {
+                                None
+                            }
+                            .unwrap_or(inner);
                             if placement.width == 0 || placement.height == 0 {
                                 if art_displayed {
                                     let _ = ui::kitty_art::clear_image(app.in_tmux);
@@ -599,26 +592,28 @@ async fn run_loop(
                                 if stored_matches && art_displayed {
                                     // Image is already visible — nothing to do.
                                 } else {
-                                    // Album changed, first display, tab return, or terminal
-                                    // was resized — full re-encode and re-transmit.
-                                    match ui::kitty_art::render_image(
-                                        bytes,
-                                        placement,
-                                        app.in_tmux,
-                                        app.tmux_status_offset,
-                                        app.cell_px,
-                                        theme::surface_pad_rgba(app.theme.surface),
-                                    ) {
-                                        Ok(()) => {
-                                            last_rendered_art = Some((fp, placement));
-                                            art_displayed = true;
-                                        }
-                                        Err(e) => {
-                                            eprintln!("kitty render: {e}");
-                                            let _ = ui::kitty_art::clear_image(app.in_tmux);
-                                            kitty_cover_unrenderable = Some(cover_id.clone());
-                                            last_rendered_art = None;
-                                            art_displayed = false;
+                                    let prepared =
+                                        app.ensure_np_kitty_prepared(placement, font).cloned();
+                                    let in_tmux = app.in_tmux;
+                                    let tmux_offset = app.tmux_status_offset;
+                                    if let Some(prepared) = prepared {
+                                        match ui::kitty_art::transmit_np_image(
+                                            &prepared,
+                                            placement,
+                                            in_tmux,
+                                            tmux_offset,
+                                        ) {
+                                            Ok(()) => {
+                                                last_rendered_art = Some((fp, placement));
+                                                art_displayed = true;
+                                            }
+                                            Err(e) => {
+                                                eprintln!("kitty render: {e}");
+                                                let _ = ui::kitty_art::clear_image(app.in_tmux);
+                                                kitty_cover_unrenderable = Some(cover_id.clone());
+                                                last_rendered_art = None;
+                                                art_displayed = false;
+                                            }
                                         }
                                     }
                                 }

--- a/ratune/src/ui/kitty_art.rs
+++ b/ratune/src/ui/kitty_art.rs
@@ -444,82 +444,92 @@ pub fn album_art_placeholder_inner(outer: Rect) -> Rect {
     album_art_block().inner(outer)
 }
 
-/// Render image `bytes` (JPEG/PNG/etc.) into `placement` using the Kitty graphics protocol.
-///
-/// `placement` must be the **cell rectangle** where the image should appear — typically
-/// [`album_art_placeholder_inner`] applied to the same outer `Rect` as the ratatui placeholder.
-/// Coordinates are ratatui’s 0-based buffer positions; CSI cursor uses 1-based rows/cols.
-///
-/// `cell_px` — terminal cell size in pixels (`CSI 16 t` or ratatui-image picker). `None` → 10×20.
-///
-/// `pad` is retained for API compatibility; letterboxing uses the caller's contain-fit `placement`.
-pub fn render_image(
-    bytes: &[u8],
+/// Cached resize + zlib for Now Playing Kitty APC (image id 1).
+#[derive(Debug, Clone)]
+pub struct NpKittyPrepared {
+    pub fingerprint: u64,
+    pub art_cols: u16,
+    pub art_rows: u16,
+    pub img_w: u32,
+    pub img_h: u32,
+    /// Base64 of zlib-compressed RGBA — built once per cover + placement geometry.
+    pub b64: String,
+}
+
+impl NpKittyPrepared {
+    pub fn matches(&self, fingerprint: u64, placement: Rect) -> bool {
+        self.fingerprint == fingerprint
+            && self.art_cols == placement.width
+            && self.art_rows == placement.height
+    }
+
+    pub fn build(
+        img: &image::DynamicImage,
+        fingerprint: u64,
+        placement: Rect,
+        font: (u16, u16),
+    ) -> Option<Self> {
+        use base64::Engine;
+        use flate2::write::ZlibEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        if placement.width == 0 || placement.height == 0 {
+            return None;
+        }
+        let img = crate::ui::art_prepare::prepare_art_image_for_rect_contain_fit(
+            img.clone(),
+            placement,
+            font,
+        );
+        let img_rgba = img.to_rgba8();
+        let (w, h) = img_rgba.dimensions();
+        let raw = img_rgba.into_raw();
+        let mut enc = ZlibEncoder::new(Vec::new(), Compression::fast());
+        enc.write_all(&raw).ok()?;
+        let zlib_body = enc.finish().ok()?;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&zlib_body);
+        Some(Self {
+            fingerprint,
+            art_cols: placement.width,
+            art_rows: placement.height,
+            img_w: w,
+            img_h: h,
+            b64,
+        })
+    }
+}
+
+/// Write a prepared Now Playing image to stdout (no decode/resize/zlib).
+pub fn transmit_np_image(
+    prepared: &NpKittyPrepared,
     placement: Rect,
     in_tmux: bool,
     tmux_status_offset: u16,
-    cell_px: Option<(u16, u16)>,
-    _pad: Rgba<u8>,
 ) -> Result<()> {
-    use base64::Engine;
-    use flate2::write::ZlibEncoder;
-    use flate2::Compression;
-
     let inner_w = placement.width;
     let inner_h = placement.height;
     if inner_w == 0 || inner_h == 0 {
         return Ok(());
     }
 
-    // Cap placeholder rows to ROW_DIACRITICS (tmux Unicode path only).
     let tmux_rows = if in_tmux {
         inner_h.min(ROW_DIACRITICS.len() as u16)
     } else {
         inner_h
     };
-
     let place_rows = if in_tmux { tmux_rows } else { inner_h };
-    let fw = cell_px
-        .map(|(w, _)| w as u32)
-        .filter(|&w| w > 0)
-        .unwrap_or(10);
-    let fh = cell_px
-        .map(|(_, h)| h as u32)
-        .filter(|&h| h > 0)
-        .unwrap_or(20);
+    let w = prepared.img_w;
+    let h = prepared.img_h;
 
-    let img = image::load_from_memory(bytes)?;
-    let font = (
-        fw.min(u16::MAX as u32) as u16,
-        fh.min(u16::MAX as u32) as u16,
-    );
-    let img = crate::ui::art_prepare::prepare_art_image_for_rect_contain_fit(img, placement, font);
-    let img_rgba = img.to_rgba8();
-    let (w, h) = img_rgba.dimensions();
-    let raw = img_rgba.into_raw();
-
-    // Zlib-compress the raw RGBA bytes.
-    let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
-    enc.write_all(&raw)?;
-    let compressed = enc.finish()?;
-
-    // Base64-encode.
-    let b64 = base64::engine::general_purpose::STANDARD.encode(&compressed);
-
-    // Transmit the image in ≤4096-char chunks.
     const CHUNK: usize = 4096;
-    let chunks: Vec<&[u8]> = b64.as_bytes().chunks(CHUNK).collect();
+    let chunks: Vec<&[u8]> = prepared.b64.as_bytes().chunks(CHUNK).collect();
     let n = chunks.len();
 
     let mut out = io::stdout().lock();
 
     if in_tmux {
-        // ── Unicode placeholder path (tmux) ───────────────────────────────────
-        // Delete any existing virtual placement for ID=1 before re-transmitting.
         let _ = write!(out, "{}", apc("a=d,d=i,i=1,q=2", true));
-
-        // Step 1: Transmit image data only (a=t — store, no display).
-        // No placement coordinates here; the virtual placement is explicit below.
         for (i, chunk) in chunks.iter().enumerate() {
             let is_last = i == n - 1;
             let m = if is_last { 0u8 } else { 1u8 };
@@ -537,19 +547,12 @@ pub fn render_image(
                 write!(out, "{}", apc(&format!("m={m};{chunk_str}"), true))?;
             }
         }
-
-        // Step 2: Create virtual placement (U=1 enables Unicode placeholder mode).
         write!(
             out,
             "{}",
             apc(&format!("a=p,U=1,i=1,c={inner_w},r={tmux_rows},q=2"), true)
         )?;
-
-        // Step 3: Write placeholder characters row-by-row at the image position.
-        // These are normal terminal text cells — tmux can overwrite them on window
-        // switch, which is exactly what prevents the bleed.
         for row in 0..tmux_rows {
-            // 1-based CSI; tmux_status_offset maps pane rows when status bar eats row 0.
             write!(
                 out,
                 "\x1b[{};{}H{}",
@@ -559,21 +562,21 @@ pub fn render_image(
             )?;
         }
     } else {
-        // ── Direct placement path (non-tmux) ──────────────────────────────────
         write!(out, "\x1b[{};{}H", placement.y + 1, placement.x + 1)?;
-
         for (i, chunk) in chunks.iter().enumerate() {
             let is_last = i == n - 1;
             let m = if is_last { 0u8 } else { 1u8 };
             let chunk_str = unsafe { std::str::from_utf8_unchecked(chunk) };
             if i == 0 {
-                // First chunk: include all control parameters.
-                // i=1 assigns a persistent image ID so the terminal stores the
-                // image and we can redisplay it with a=p,i=1 without re-transmitting.
                 write!(
                     out,
                     "{}",
-                    apc(&format!("a=T,f=32,i=1,s={w},v={h},c={inner_w},r={place_rows},o=z,m={m},q=2;{chunk_str}"), false)
+                    apc(
+                        &format!(
+                            "a=T,f=32,i=1,s={w},v={h},c={inner_w},r={place_rows},o=z,m={m},q=2;{chunk_str}"
+                        ),
+                        false
+                    )
                 )?;
             } else {
                 write!(out, "{}", apc(&format!("m={m};{chunk_str}"), false))?;
@@ -1016,7 +1019,7 @@ impl StripThumbPrepared {
 /// Render the home tab art strip using Kitty protocol.
 ///
 /// Image IDs [`KITTY_STRIP_ID_BASE`] … + slot (up to [`KITTY_STRIP_MAX_SLOTS`]).
-/// Writes escape sequences directly to stdout (same as `render_image`).
+/// Writes escape sequences directly to stdout (same as [`transmit_np_image`]).
 #[allow(clippy::too_many_arguments)]
 pub fn render_art_strip(
     albums: &[crate::app::RecentAlbum],

--- a/ratune/src/ui/now_playing.rs
+++ b/ratune/src/ui/now_playing.rs
@@ -125,8 +125,9 @@ fn play_label_for(ctx: ControlsClickCtx) -> &'static str {
     }
 }
 
-/// Total display width of the centered controls line.
-pub fn controls_line_width(ctx: ControlsClickCtx) -> u16 {
+/// Total display width of the centered controls line (used by click tests).
+#[cfg(test)]
+fn controls_line_width(ctx: ControlsClickCtx) -> u16 {
     controls_line_plain(ctx).width() as u16
 }
 
@@ -171,10 +172,7 @@ pub fn controls_click_action_for(
 
 #[cfg(test)]
 fn segment_center(segments: &[ControlSegment], slot: ControlSlot) -> u16 {
-    let seg = segments
-        .iter()
-        .find(|s| s.slot == slot)
-        .expect("segment");
+    let seg = segments.iter().find(|s| s.slot == slot).expect("segment");
     seg.start + seg.width / 2
 }
 
@@ -983,7 +981,10 @@ mod controls_click_tests {
         let legacy = area.x + (area.width.saturating_sub(total)) / 2;
         let aligned = line_start(area, ctx);
         assert_eq!(aligned, area.x + (area.width / 2).saturating_sub(total / 2));
-        assert_ne!(legacy, aligned, "regression: must not use (W-L)/2 centering");
+        assert_ne!(
+            legacy, aligned,
+            "regression: must not use (W-L)/2 centering"
+        );
     }
 
     #[test]
@@ -993,7 +994,10 @@ mod controls_click_tests {
             paused: false,
             shuffled: false,
         };
-        assert_eq!(controls_line_width(idle), controls_line_plain(idle).width() as u16);
+        assert_eq!(
+            controls_line_width(idle),
+            controls_line_plain(idle).width() as u16
+        );
         assert!(controls_line_width(playing()) >= controls_line_width(idle));
     }
 

--- a/ratune/src/ui/nowplaying_tab.rs
+++ b/ratune/src/ui/nowplaying_tab.rs
@@ -64,18 +64,15 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
     }
 }
 
-fn np_art_contain_rect(app: &App, inner: Rect) -> Rect {
+fn np_art_contain_rect(app: &mut App, inner: Rect) -> Rect {
     let font = app
         .art_picker
         .as_ref()
         .map(|p| p.font_size())
         .unwrap_or((10, 20));
-    if let Some((_, img)) = app.art_cache_decoded.as_ref() {
-        return crate::ui::art_prepare::contain_fit_rect_in_cells(img, inner, font);
-    }
-    if let Some((_, bytes)) = app.art_cache.as_ref() {
-        if let Ok(img) = image::load_from_memory(bytes) {
-            return crate::ui::art_prepare::contain_fit_rect_in_cells(&img, inner, font);
+    if app.ensure_art_cache_decoded() {
+        if let Some((_, img)) = app.art_cache_decoded.as_ref() {
+            return crate::ui::art_prepare::contain_fit_rect_in_cells(img, inner, font);
         }
     }
     inner
@@ -103,11 +100,23 @@ fn sync_np_ratatui_protocol(app: &mut App, art_rect: Rect) {
         app.np_art_prep_key = None;
         return;
     };
-    let (_, bytes) = app.art_cache.as_ref().unwrap();
     let key = (fp, art_rect.width, art_rect.height);
     if app.np_art_prep_key.as_ref() == Some(&key) && app.np_art_state.is_some() {
         return;
     }
+    // Must match `Picker` / `ImageSource` font (same as Home strip ratatui prep).
+    let fs = app
+        .art_picker
+        .as_ref()
+        .map(|p| p.font_size())
+        .unwrap_or((10, 20));
+    let base_img = if app.ensure_art_cache_decoded() {
+        app.art_cache_decoded.as_ref().unwrap().1.clone()
+    } else {
+        app.np_art_state = None;
+        app.np_art_prep_key = None;
+        return;
+    };
     let Some(picker) = app.art_picker.as_ref() else {
         return;
     };
@@ -115,24 +124,6 @@ fn sync_np_ratatui_protocol(app: &mut App, art_rect: Rect) {
         app.np_art_state = None;
         app.np_art_prep_key = None;
         return;
-    };
-    // Must match `Picker` / `ImageSource` font (same as Home strip ratatui prep).
-    let fs = picker.font_size();
-    let base_img = match app.art_cache_decoded.as_ref() {
-        Some((cached_fp, img)) if *cached_fp == fp => img.clone(),
-        _ => {
-            let img = match image::load_from_memory(bytes) {
-                Ok(i) => i,
-                Err(_) => {
-                    app.np_art_state = None;
-                    app.np_art_prep_key = None;
-                    app.art_cache_decoded = None;
-                    return;
-                }
-            };
-            app.art_cache_decoded = Some((fp, img.clone()));
-            img
-        }
     };
     let img =
         crate::ui::art_prepare::prepare_art_image_for_rect_contain_fit(base_img, art_rect, fs);


### PR DESCRIPTION
Adds proper album art caching in Now Playing tab, preventing constant decoding of art on refresh.

Fixes issues related to CPU spike issues in NP tab.

Similar to changes made in #28. Also see issue #25.



