### PR TITLE
feat: offline mode w/ cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Ratune was built to bring together a combination of features often missing from 
 - **Playback**: Gapless queue, seek, shuffle/unshuffle, and playlist management.
 - **Album Art**: Display using Kitty graphics and [ratatui-image](https://github.com/ratatui/ratatui-image) (see link for compatible terminals)
 - **Lyrics**: Synced lyrics via LRCLib (default) or your Subsonic server. Optional on-disk cache for offline use
+- **Offline mode**: Starts without a server when needed; plays cached tracks, browse from library index, and detects reconnect automatically
 - **Visualizer**: FFT spectrum analyzer.
 - **Fuzzy finder**: Optional library index + external picker (fzf/skim) for fast track selection.
 - **Folder navigation**: Optional Browse layout that follows server music folders for servers that provide it.

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -128,7 +128,7 @@ queue_loop = true
 #                       # If you set library_refresh to Ctrl+r while album replace is also Ctrl+r,
 #                       # the app treats refresh as unset so Ctrl+g default wins.
 # library_index_append_queue = "Ctrl+a"  # append full indexed library to queue (y/n); "" disables
-# connection_check    = "Ctrl+Shift+c" # ping server and update online/offline mode; "" disables
+# connection_check    = "Shift+c"   # ping server and update online/offline mode; "" disables
 # toggle_help         = "i"
 # toggle_dynamic_theme = "t"          # cycles dynamic accent (ignored when theme preset is terminal)
 # toggle_lyrics       = "Shift+l"

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -68,6 +68,7 @@ username = ""
 password = ""
 # password_keyring = "keyutils"       # Linux only: "keyutils" (default) or "secret-service"
 # password_command = "secret-tool lookup service subsonic user you"
+# connection_check_interval_secs = 45  # background ping for online/offline; 0 = startup only
 
 # -----------------------------------------------------------------------------
 # [player]
@@ -127,6 +128,7 @@ queue_loop = true
 #                       # If you set library_refresh to Ctrl+r while album replace is also Ctrl+r,
 #                       # the app treats refresh as unset so Ctrl+g default wins.
 # library_index_append_queue = "Ctrl+a"  # append full indexed library to queue (y/n); "" disables
+# connection_check    = "Ctrl+Shift+c" # ping server and update online/offline mode; "" disables
 # toggle_help         = "i"
 # toggle_dynamic_theme = "t"          # cycles dynamic accent (ignored when theme preset is terminal)
 # toggle_lyrics       = "Shift+l"
@@ -436,12 +438,14 @@ notify_on_forced_index_refresh = true
 # max_size_gb — Total on-disk budget for cached audio. Default: 2.0.
 # cache_starred — When true, prefetch favorite tracks while online (Subsonic getStarred2 /
 #   star API). Shares the same max_size_gb LRU pool as normal playback caching. Default: false.
+# cache_starred_albums — When true, prefetch all tracks from a favorited album. Default: false.
 # cache_starred_parallelism — Concurrent favorite-track downloads. Default: 2.
 
 [cache]
 enabled = true
 max_size_gb = 2.0
 cache_starred = false
+cache_starred_albums = false
 cache_starred_parallelism = 2
 
 # -----------------------------------------------------------------------------

--- a/ratune-subsonic/src/client.rs
+++ b/ratune-subsonic/src/client.rs
@@ -207,6 +207,27 @@ impl SubsonicClient {
         check_status(&env.response.status, env.response.error.as_ref())
     }
 
+    /// Lightweight reachability probe for online/offline mode switching.
+    ///
+    /// Uses a one-off HTTP client (no connection pool) with short timeouts so a
+    /// stale pooled socket does not hang for tens of seconds after the network drops.
+    /// Any HTTP response from the server counts as reachable (auth errors included).
+    pub async fn is_network_reachable(&self) -> bool {
+        let Ok(http) = ClientBuilder::new()
+            .connect_timeout(Duration::from_secs(4))
+            .timeout(Duration::from_secs(8))
+            .pool_max_idle_per_host(0)
+            .build()
+        else {
+            return false;
+        };
+        http.get(self.endpoint_url("ping"))
+            .query(&self.auth_params())
+            .send()
+            .await
+            .is_ok()
+    }
+
     /// Top-level music folders (`getMusicFolders`).
     pub async fn get_music_folders(&self) -> Result<Vec<MusicFolder>> {
         let env: MusicFoldersEnvelope = self

--- a/ratune/src/action.rs
+++ b/ratune/src/action.rs
@@ -161,6 +161,8 @@ pub enum Action {
     ConfirmLibraryServerAppendQueue,
     /// Dismiss a global confirmation prompt (e.g. library refresh).
     CancelGlobalConfirm,
+    /// Check server connectivity now (optional keybind; periodic check uses `[server].connection_check_interval_secs`).
+    CheckConnection,
     Quit,
     None,
 }

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -1820,8 +1820,7 @@ impl App {
             return;
         }
         let tracks = if self.cache.enabled {
-            self.cache
-                .filter_cached_tracks(&self.library_index_tracks)
+            self.cache.filter_cached_tracks(&self.library_index_tracks)
         } else {
             self.library_index_tracks.clone()
         };
@@ -1842,7 +1841,9 @@ impl App {
         }
     }
 
-    fn ensure_offline_browse(&mut self) -> Option<std::sync::Arc<crate::library_index::BrowseSnapshot>> {
+    fn ensure_offline_browse(
+        &mut self,
+    ) -> Option<std::sync::Arc<crate::library_index::BrowseSnapshot>> {
         if self.offline_browse.is_none() && !self.library_index_tracks.is_empty() {
             self.prepare_offline_browse();
         }
@@ -1854,7 +1855,8 @@ impl App {
         if !self.remote_available() {
             let tx = self.library_tx.clone();
             let Some(snapshot) = self.ensure_offline_browse() else {
-                self.library.artists = LoadingState::Error(self.offline_browse_empty_message().into());
+                self.library.artists =
+                    LoadingState::Error(self.offline_browse_empty_message().into());
                 return;
             };
             let artists = snapshot.artists.clone();
@@ -3731,7 +3733,9 @@ impl App {
     }
 
     fn spawn_prefetch_album_cache(&self, album_id: &str) {
-        if !self.config.cache_enabled || !self.config.cache_starred_albums || !self.remote_available()
+        if !self.config.cache_enabled
+            || !self.config.cache_starred_albums
+            || !self.remote_available()
         {
             return;
         }
@@ -3755,9 +3759,7 @@ impl App {
                     .song
                     .into_iter()
                     .map(|s| {
-                        let aid = s
-                            .album_id
-                            .unwrap_or_else(|| album_id.clone());
+                        let aid = s.album_id.unwrap_or_else(|| album_id.clone());
                         (s.id, aid)
                     })
                     .collect::<Vec<_>>(),
@@ -5117,8 +5119,7 @@ impl App {
             return;
         }
         let mut songs: Vec<_> = if !self.server_reachable && self.config.cache_enabled {
-            self.cache
-                .filter_cached_tracks(&self.library_index_tracks)
+            self.cache.filter_cached_tracks(&self.library_index_tracks)
         } else {
             self.library_index_tracks.clone()
         };

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -351,6 +351,11 @@ pub enum LibraryUpdate {
     PrefetchStarredCache(Vec<(String, String)>),
     /// Starred library from `getStarred2` for the favorites overlay.
     StarredFetched(Result<ratune_subsonic::Starred2, String>),
+    /// Background connectivity probe (`ping`); may repeat current state when `forced`.
+    ConnectivityChanged {
+        reachable: bool,
+        forced: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -411,6 +416,8 @@ pub struct App {
     pub subsonic: Arc<SubsonicClient>,
     /// Set at startup when the Subsonic `ping` fails for a non-auth reason (e.g. no network).
     pub server_reachable: bool,
+    /// Rate-limit connectivity probes triggered by failed network work.
+    last_connectivity_probe: Option<Instant>,
     /// Receives library data from background tokio tasks.
     pub library_rx: mpsc::Receiver<LibraryUpdate>,
     library_tx: mpsc::Sender<LibraryUpdate>,
@@ -470,6 +477,8 @@ pub struct App {
     library_index_by_id: HashMap<String, ratune_subsonic::Song>,
     /// Unix seconds when the index was last fully refreshed, if known.
     pub library_index_refreshed_at: Option<u64>,
+    /// Browse hierarchy built from [`library_index_tracks`] for offline artist/album/track columns.
+    offline_browse: Option<std::sync::Arc<crate::library_index::BrowseSnapshot>>,
     /// True while a background full-library fetch is running.
     pub library_index_refreshing: bool,
     /// When the current refresh started; drives status-bar animation until complete.
@@ -678,6 +687,7 @@ impl App {
             playback: PlaybackState::default(),
             subsonic: Arc::new(subsonic),
             server_reachable: true,
+            last_connectivity_probe: None,
             library_rx,
             library_tx,
             player_tx,
@@ -707,6 +717,7 @@ impl App {
             library_index_tracks,
             library_index_by_id,
             library_index_refreshed_at,
+            offline_browse: None,
             library_index_refreshing: false,
             library_index_refresh_started: None,
             library_server_append_fetching: false,
@@ -1235,8 +1246,7 @@ impl App {
                     Ok(bytes) => {
                         let _ = tx.send(LibraryUpdate::HomeArt { album_id, bytes }).await;
                     }
-                    Err(e) => {
-                        eprintln!("home art fetch({album_id}): {e}");
+                    Err(_e) => {
                         let _ = tx
                             .send(LibraryUpdate::HomeArtFetchFailed { album_id })
                             .await;
@@ -1721,9 +1731,148 @@ impl App {
         self.folder_enter(id, name);
     }
 
+    /// Background Subsonic reachability probe for online ↔ offline transitions mid-session.
+    pub fn spawn_connectivity_check(&self, forced: bool) {
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        let was_reachable = self.server_reachable;
+        tokio::spawn(async move {
+            let reachable = client.is_network_reachable().await;
+            if forced || reachable != was_reachable {
+                let _ = tx
+                    .send(LibraryUpdate::ConnectivityChanged { reachable, forced })
+                    .await;
+            }
+        });
+    }
+
+    fn maybe_probe_connectivity(&mut self) {
+        if !self.server_reachable {
+            return;
+        }
+        const MIN_INTERVAL: Duration = Duration::from_secs(10);
+        if self
+            .last_connectivity_probe
+            .is_some_and(|t| t.elapsed() < MIN_INTERVAL)
+        {
+            return;
+        }
+        self.last_connectivity_probe = Some(Instant::now());
+        self.spawn_connectivity_check(false);
+    }
+
+    fn apply_connectivity_changed(&mut self, reachable: bool, forced: bool) {
+        if self.server_reachable == reachable {
+            if forced {
+                self.flash_status_secs(
+                    if reachable {
+                        "Server reachable"
+                    } else {
+                        "Server unreachable — offline mode"
+                    },
+                    4,
+                );
+            }
+            return;
+        }
+        self.server_reachable = reachable;
+        if reachable {
+            self.flash_status_secs("Server reachable — back online", 5);
+            self.on_went_online();
+        } else {
+            self.flash_status_secs("Server unreachable — offline mode", 8);
+            self.on_went_offline();
+        }
+    }
+
+    fn on_went_offline(&mut self) {
+        self.home_art_loading.clear();
+        self.prepare_offline_browse();
+        if self.browser_browse_mode != BrowseMode::Files {
+            self.fetch_artists();
+        }
+    }
+
+    fn on_went_online(&mut self) {
+        self.offline_browse = None;
+        if self.browser_browse_mode == BrowseMode::Files {
+            if matches!(
+                self.folders.roots,
+                LoadingState::NotLoaded | LoadingState::Error(_)
+            ) {
+                self.fetch_music_folders();
+            }
+        } else {
+            self.fetch_artists();
+        }
+        self.spawn_library_index_refresh(false);
+        self.fetch_starred();
+        if self.config.scrobble_enabled {
+            self.spawn_scrobble_queue_flush();
+        }
+    }
+
+    /// Build (or rebuild) the in-memory browse tree from the on-disk library index.
+    /// When offline and caching is enabled, only tracks with audio on disk are included.
+    pub fn prepare_offline_browse(&mut self) {
+        if self.library_index_tracks.is_empty() {
+            self.offline_browse = None;
+            return;
+        }
+        let tracks = if self.cache.enabled {
+            self.cache
+                .filter_cached_tracks(&self.library_index_tracks)
+        } else {
+            self.library_index_tracks.clone()
+        };
+        if tracks.is_empty() {
+            self.offline_browse = None;
+            return;
+        }
+        self.offline_browse = Some(std::sync::Arc::new(
+            crate::library_index::build_browse_snapshot(&tracks),
+        ));
+    }
+
+    fn offline_browse_empty_message(&self) -> &'static str {
+        if self.cache.enabled && !self.library_index_tracks.is_empty() {
+            "No cached tracks — play online to download audio"
+        } else {
+            "No library index — connect once while [library] enabled"
+        }
+    }
+
+    fn ensure_offline_browse(&mut self) -> Option<std::sync::Arc<crate::library_index::BrowseSnapshot>> {
+        if self.offline_browse.is_none() && !self.library_index_tracks.is_empty() {
+            self.prepare_offline_browse();
+        }
+        self.offline_browse.clone()
+    }
+
     /// Spawn a task to fetch the artist list.
-    pub fn fetch_artists(&self) {
+    pub fn fetch_artists(&mut self) {
         if !self.remote_available() {
+            let tx = self.library_tx.clone();
+            let Some(snapshot) = self.ensure_offline_browse() else {
+                self.library.artists = LoadingState::Error(self.offline_browse_empty_message().into());
+                return;
+            };
+            let artists = snapshot.artists.clone();
+            let cached_n = self
+                .cache
+                .filter_cached_tracks(&self.library_index_tracks)
+                .len();
+            let flash = if self.cache.enabled {
+                Some(format!("Browse: {cached_n} cached track(s)"))
+            } else {
+                None
+            };
+            tokio::spawn(async move {
+                let _ = tx.send(LibraryUpdate::Artists(Ok(artists))).await;
+            });
+            if let Some(msg) = flash {
+                self.flash_status_secs(msg, 5);
+            }
             return;
         }
         let client = self.subsonic.clone();
@@ -1913,8 +2062,21 @@ impl App {
     }
 
     /// Spawn a task to fetch albums for the given artist.
-    pub fn fetch_albums(&self, artist_id: String) {
+    pub fn fetch_albums(&mut self, artist_id: String) {
         if !self.remote_available() {
+            let tx = self.library_tx.clone();
+            let albums = self
+                .ensure_offline_browse()
+                .and_then(|s| s.albums_by_artist.get(&artist_id).cloned())
+                .unwrap_or_default();
+            tokio::spawn(async move {
+                let _ = tx
+                    .send(LibraryUpdate::Albums {
+                        artist_id,
+                        result: Ok(albums),
+                    })
+                    .await;
+            });
             return;
         }
         let client = self.subsonic.clone();
@@ -1930,8 +2092,21 @@ impl App {
     }
 
     /// Spawn a task to fetch the track list for the given album.
-    pub fn fetch_tracks(&self, album_id: String) {
+    pub fn fetch_tracks(&mut self, album_id: String) {
         if !self.remote_available() {
+            let tx = self.library_tx.clone();
+            let songs = self
+                .ensure_offline_browse()
+                .and_then(|s| s.tracks_by_album.get(&album_id).cloned())
+                .unwrap_or_default();
+            tokio::spawn(async move {
+                let _ = tx
+                    .send(LibraryUpdate::Tracks {
+                        album_id,
+                        result: Ok(songs),
+                    })
+                    .await;
+            });
             return;
         }
         let client = self.subsonic.clone();
@@ -1958,7 +2133,7 @@ impl App {
                 Ok(bytes) => {
                     let _ = tx.send(LibraryUpdate::CoverArt { cover_id, bytes }).await;
                 }
-                Err(e) => eprintln!("fetch_cover_art({cover_id}): {e}"),
+                Err(_e) => {}
             }
         });
     }
@@ -2143,29 +2318,30 @@ impl App {
     pub fn apply_library_update(&mut self, update: LibraryUpdate) {
         match update {
             LibraryUpdate::Artists(result) => {
+                let mut prefetch_albums: Option<String> = None;
                 self.library.artists = match result {
                     Ok(artists) => {
                         if !artists.is_empty() {
-                            // Default to 0 on fresh start; restore keeps whatever was saved.
                             if self.library.selected_artist.is_none() {
                                 self.library.selected_artist = Some(0);
                             }
-                            // Clamp restored index to actual list size.
                             let idx = self.library.selected_artist.unwrap().min(artists.len() - 1);
                             self.library.selected_artist = Some(idx);
-                            // Fetch albums for the selected (or restored) artist.
                             let artist_id = artists[idx].id.clone();
                             if !self.library.albums.contains_key(&artist_id) {
                                 self.library
                                     .albums
                                     .insert(artist_id.clone(), LoadingState::Loading);
-                                self.fetch_albums(artist_id);
+                                prefetch_albums = Some(artist_id);
                             }
                         }
                         LoadingState::Loaded(artists)
                     }
                     Err(e) => LoadingState::Error(e),
                 };
+                if let Some(artist_id) = prefetch_albums {
+                    self.fetch_albums(artist_id);
+                }
                 self.merge_server_starred();
             }
             LibraryUpdate::Albums { artist_id, result } => {
@@ -2182,44 +2358,43 @@ impl App {
                     })
                     .unwrap_or(false);
 
-                self.library.albums.insert(
-                    artist_id,
-                    match result {
-                        Ok(albums) if !albums.is_empty() => {
-                            if is_selected_artist {
-                                // Use restored selection (default 0), clamped to list size.
-                                if self.library.selected_album.is_none() {
-                                    self.library.selected_album = Some(0);
-                                }
-                                let idx =
-                                    self.library.selected_album.unwrap().min(albums.len() - 1);
-                                self.library.selected_album = Some(idx);
-                                let album_id = albums[idx].id.clone();
-                                if !self.library.tracks.contains_key(&album_id) {
-                                    self.library
-                                        .tracks
-                                        .insert(album_id.clone(), LoadingState::Loading);
-                                    self.fetch_tracks(album_id);
-                                }
-                            } else {
-                                // Background prefetch: fetch tracks for first album.
-                                if self.library.selected_album.is_none() {
-                                    self.library.selected_album = Some(0);
-                                }
-                                let first_id = albums[0].id.clone();
-                                if !self.library.tracks.contains_key(&first_id) {
-                                    self.library
-                                        .tracks
-                                        .insert(first_id.clone(), LoadingState::Loading);
-                                    self.fetch_tracks(first_id);
-                                }
+                let mut prefetch_tracks: Option<String> = None;
+                let state = match result {
+                    Ok(albums) if !albums.is_empty() => {
+                        if is_selected_artist {
+                            if self.library.selected_album.is_none() {
+                                self.library.selected_album = Some(0);
                             }
-                            LoadingState::Loaded(albums)
+                            let idx = self.library.selected_album.unwrap().min(albums.len() - 1);
+                            self.library.selected_album = Some(idx);
+                            let album_id = albums[idx].id.clone();
+                            if !self.library.tracks.contains_key(&album_id) {
+                                self.library
+                                    .tracks
+                                    .insert(album_id.clone(), LoadingState::Loading);
+                                prefetch_tracks = Some(album_id);
+                            }
+                        } else {
+                            if self.library.selected_album.is_none() {
+                                self.library.selected_album = Some(0);
+                            }
+                            let first_id = albums[0].id.clone();
+                            if !self.library.tracks.contains_key(&first_id) {
+                                self.library
+                                    .tracks
+                                    .insert(first_id.clone(), LoadingState::Loading);
+                                prefetch_tracks = Some(first_id);
+                            }
                         }
-                        Ok(albums) => LoadingState::Loaded(albums),
-                        Err(e) => LoadingState::Error(e),
-                    },
-                );
+                        LoadingState::Loaded(albums)
+                    }
+                    Ok(albums) => LoadingState::Loaded(albums),
+                    Err(e) => LoadingState::Error(e),
+                };
+                self.library.albums.insert(artist_id, state);
+                if let Some(album_id) = prefetch_tracks {
+                    self.fetch_tracks(album_id);
+                }
                 self.merge_server_starred();
             }
             LibraryUpdate::Tracks { album_id, result } => {
@@ -2331,6 +2506,7 @@ impl App {
             LibraryUpdate::HomeArtFetchFailed { album_id } => {
                 self.home_art_loading.remove(&album_id);
                 self.spawn_pending_home_art_fetches();
+                self.maybe_probe_connectivity();
             }
             LibraryUpdate::Playlists(playlists) => {
                 self.playlist_overlay.playlists = crate::state::LoadingState::Loaded(playlists);
@@ -2493,6 +2669,9 @@ impl App {
                         self.library_index_tracks = tracks;
                         self.library_index_by_id =
                             crate::library_index::index_by_id(&self.library_index_tracks);
+                        if !self.server_reachable {
+                            self.prepare_offline_browse();
+                        }
                         self.merge_server_starred();
                         let msg = if forced {
                             "Library index refresh complete"
@@ -2587,6 +2766,12 @@ impl App {
                                 self.spawn_cache_download(&id, &album_id);
                             }
                         }
+                    } else if !was_starred
+                        && kind == FavoriteKind::Album
+                        && self.config.cache_enabled
+                        && self.config.cache_starred_albums
+                    {
+                        self.spawn_prefetch_album_cache(&id);
                     }
                     self.fetch_starred();
                 }
@@ -2619,6 +2804,9 @@ impl App {
                         }
                     }
                 }
+            }
+            LibraryUpdate::ConnectivityChanged { reachable, forced } => {
+                self.apply_connectivity_changed(reachable, forced);
             }
         }
     }
@@ -3501,29 +3689,83 @@ impl App {
     }
 
     fn maybe_prefetch_starred_cache(&self) {
-        if !self.config.cache_enabled || !self.config.cache_starred || !self.remote_available() {
+        if !self.config.cache_enabled || !self.remote_available() {
+            return;
+        }
+        if !self.config.cache_starred && !self.config.cache_starred_albums {
             return;
         }
         let Some(ref starred) = self.server_starred else {
             return;
         };
-        let pairs: Vec<(String, String)> = starred
-            .songs()
-            .iter()
-            .filter_map(|s| {
-                let album_id = s.album_id.as_deref()?;
-                if album_id.is_empty() {
-                    None
-                } else {
-                    Some((s.id.clone(), album_id.to_string()))
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        if self.config.cache_starred {
+            for song in starred.songs() {
+                if let Some(album_id) = song.album_id.as_ref().filter(|a| !a.is_empty()) {
+                    pairs.push((song.id.clone(), album_id.clone()));
                 }
-            })
-            .collect();
+            }
+        }
+        if self.config.cache_starred_albums {
+            for album in &starred.album {
+                pairs.extend(self.cache_pairs_for_album(&album.id));
+            }
+        }
+        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+        pairs.dedup_by(|a, b| a.0 == b.0);
         if pairs.is_empty() {
             return;
         }
         let tx = self.library_tx.clone();
         tokio::spawn(async move {
+            let _ = tx.send(LibraryUpdate::PrefetchStarredCache(pairs)).await;
+        });
+    }
+
+    fn cache_pairs_for_album(&self, album_id: &str) -> Vec<(String, String)> {
+        self.library_index_tracks
+            .iter()
+            .filter(|s| s.album_id.as_deref() == Some(album_id))
+            .map(|s| (s.id.clone(), album_id.to_string()))
+            .collect()
+    }
+
+    fn spawn_prefetch_album_cache(&self, album_id: &str) {
+        if !self.config.cache_enabled || !self.config.cache_starred_albums || !self.remote_available()
+        {
+            return;
+        }
+        let from_index = self.cache_pairs_for_album(album_id);
+        if !from_index.is_empty() {
+            let uncached: Vec<_> = from_index
+                .into_iter()
+                .filter(|(sid, _)| !self.cache.get_const(sid))
+                .collect();
+            if !uncached.is_empty() {
+                self.spawn_prefetch_starred_downloads(uncached);
+            }
+            return;
+        }
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        let album_id = album_id.to_string();
+        tokio::spawn(async move {
+            let pairs = match client.get_album(&album_id).await {
+                Ok(album) => album
+                    .song
+                    .into_iter()
+                    .map(|s| {
+                        let aid = s
+                            .album_id
+                            .unwrap_or_else(|| album_id.clone());
+                        (s.id, aid)
+                    })
+                    .collect::<Vec<_>>(),
+                Err(_) => return,
+            };
+            if pairs.is_empty() {
+                return;
+            }
             let _ = tx.send(LibraryUpdate::PrefetchStarredCache(pairs)).await;
         });
     }
@@ -3630,6 +3872,10 @@ impl App {
                     self.pending_global_confirm = Some(GlobalConfirm::LibraryIndexRefresh);
                     self.flash_status_secs("Full library index refresh? (y/n)", 12);
                 }
+            }
+            Action::CheckConnection => {
+                self.flash_status_secs("Checking server…", 10);
+                self.spawn_connectivity_check(true);
             }
             Action::ConfirmLibraryIndexRefresh => {
                 if self.pending_global_confirm == Some(GlobalConfirm::LibraryIndexRefresh) {
@@ -4870,9 +5116,19 @@ impl App {
             self.flash_status("Library index empty");
             return;
         }
-        let n = self.library_index_tracks.len();
+        let mut songs: Vec<_> = if !self.server_reachable && self.config.cache_enabled {
+            self.cache
+                .filter_cached_tracks(&self.library_index_tracks)
+        } else {
+            self.library_index_tracks.clone()
+        };
+        if songs.is_empty() {
+            self.flash_status_secs("No cached tracks to queue", 5);
+            return;
+        }
+        let n = songs.len();
         let was_empty = self.queue.songs.is_empty();
-        for song in self.library_index_tracks.iter().cloned() {
+        for song in songs.drain(..) {
             self.queue.push(song);
         }
         if was_empty && !self.queue.songs.is_empty() {

--- a/ratune/src/cache.rs
+++ b/ratune/src/cache.rs
@@ -149,6 +149,21 @@ impl TrackCache {
             .unwrap_or(false)
     }
 
+    /// Tracks from `tracks` that have audio on disk (for offline browse / fzf).
+    pub fn filter_cached_tracks(
+        &self,
+        tracks: &[ratune_subsonic::Song],
+    ) -> Vec<ratune_subsonic::Song> {
+        if !self.enabled {
+            return tracks.to_vec();
+        }
+        tracks
+            .iter()
+            .filter(|s| self.get_const(&s.id))
+            .cloned()
+            .collect()
+    }
+
     /// Return the cached file path for `song_id` if the file exists on disk.
     ///
     /// Removes stale index entries whose files have been deleted externally.
@@ -268,5 +283,52 @@ impl TrackCache {
         if let Ok(json) = serde_json::to_string_pretty(&self.entries) {
             let _ = std::fs::write(&self.index_path, json);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratune_subsonic::Song;
+
+    fn song(id: &str) -> Song {
+        Song {
+            id: id.into(),
+            title: id.into(),
+            album: None,
+            artist: None,
+            album_id: None,
+            artist_id: None,
+            track: None,
+            disc_number: None,
+            year: None,
+            genre: None,
+            cover_art: None,
+            duration: None,
+            bit_rate: None,
+            content_type: None,
+            suffix: None,
+            size: None,
+            path: None,
+            starred: None,
+        }
+    }
+
+    #[test]
+    fn filter_cached_tracks_keeps_only_on_disk() {
+        let dir = std::env::temp_dir().join(format!("ratune-cache-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("XDG_CACHE_HOME", dir.to_str().unwrap());
+
+        let mut cache = TrackCache::load(true, 1.0);
+        cache.put("cached", "al1", b"audio").unwrap();
+        let tracks = vec![song("cached"), song("missing")];
+        let filtered = cache.filter_cached_tracks(&tracks);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "cached");
+
+        std::env::remove_var("XDG_CACHE_HOME");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -87,7 +87,7 @@ pub struct KeybindsSection {
     pub library_fzf: Option<String>,
     /// Force library index refresh. Default: Ctrl+g
     pub library_refresh: Option<String>,
-    /// Ping the Subsonic server and update online/offline mode (`""` disables). Default: disabled.
+    /// Ping the Subsonic server and update online/offline mode (`""` disables). Default: `Shift+c`.
     pub connection_check: Option<String>,
     /// Append all indexed tracks to the queue (y/n confirm). Default: Ctrl+a (`""` disables)
     pub library_index_append_queue: Option<String>,

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -87,6 +87,8 @@ pub struct KeybindsSection {
     pub library_fzf: Option<String>,
     /// Force library index refresh. Default: Ctrl+g
     pub library_refresh: Option<String>,
+    /// Ping the Subsonic server and update online/offline mode (`""` disables). Default: disabled.
+    pub connection_check: Option<String>,
     /// Append all indexed tracks to the queue (y/n confirm). Default: Ctrl+a (`""` disables)
     pub library_index_append_queue: Option<String>,
     /// Toggle this help popup. Default: i
@@ -135,6 +137,9 @@ pub struct CacheSection {
     /// Prefetch favorite tracks into the offline cache (Subsonic getStarred2). Default: false.
     #[serde(default = "default_cache_starred")]
     pub cache_starred: bool,
+    /// When true, prefetch all tracks from a favorited album into the cache. Default: false.
+    #[serde(default = "default_cache_starred_albums")]
+    pub cache_starred_albums: bool,
     /// Concurrent downloads when prefetching favorite tracks. Default: 2.
     #[serde(default = "default_cache_starred_parallelism")]
     pub cache_starred_parallelism: usize,
@@ -149,6 +154,9 @@ fn default_cache_max_size_gb() -> f64 {
 fn default_cache_starred() -> bool {
     false
 }
+fn default_cache_starred_albums() -> bool {
+    false
+}
 fn default_cache_starred_parallelism() -> usize {
     2
 }
@@ -159,6 +167,7 @@ impl Default for CacheSection {
             enabled: default_cache_enabled(),
             max_size_gb: default_cache_max_size_gb(),
             cache_starred: default_cache_starred(),
+            cache_starred_albums: default_cache_starred_albums(),
             cache_starred_parallelism: default_cache_starred_parallelism(),
         }
     }
@@ -917,6 +926,14 @@ struct ServerSection {
     /// `keyutils` (default) or `secret-service` (gnome-keyring / KWallet). Ignored on macOS/Windows.
     #[serde(default = "default_password_keyring")]
     password_keyring: String,
+    /// Background Subsonic `ping` interval in seconds to detect online/offline transitions.
+    /// `0` disables periodic checks (startup ping still runs). Default: 45.
+    #[serde(default = "default_connection_check_interval_secs")]
+    connection_check_interval_secs: u64,
+}
+
+fn default_connection_check_interval_secs() -> u64 {
+    45
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -967,6 +984,8 @@ pub struct Config {
     pub subsonic_url: String,
     pub subsonic_user: String,
     pub subsonic_pass: String,
+    /// Periodic Subsonic `ping` interval (seconds). `0` = startup ping only.
+    pub connection_check_interval_secs: u64,
     pub default_volume: u8,
     pub max_bit_rate: u32,
     /// Linux: register MPRIS on the session bus (media keys, `playerctl`).
@@ -1044,6 +1063,8 @@ pub struct Config {
     pub cache_max_size_gb: f64,
     /// Prefetch favorite tracks into the offline cache.
     pub cache_starred: bool,
+    /// Prefetch all tracks from favorited albums into the offline cache.
+    pub cache_starred_albums: bool,
     /// Concurrent downloads when prefetching favorite tracks.
     pub cache_starred_parallelism: usize,
     /// Where to fetch lyrics (`lrclib` or `subsonic`).
@@ -1383,6 +1404,7 @@ impl Config {
         Ok(Config {
             subsonic_url: file_cfg.server.url,
             subsonic_user: file_cfg.server.username,
+            connection_check_interval_secs: file_cfg.server.connection_check_interval_secs,
             subsonic_pass,
             default_volume: file_cfg.player.default_volume,
             max_bit_rate: file_cfg.player.max_bit_rate,
@@ -1425,6 +1447,7 @@ impl Config {
             cache_enabled: file_cfg.cache.enabled,
             cache_max_size_gb: file_cfg.cache.max_size_gb,
             cache_starred: file_cfg.cache.cache_starred,
+            cache_starred_albums: file_cfg.cache.cache_starred_albums,
             cache_starred_parallelism: file_cfg.cache.cache_starred_parallelism.max(1),
             lyrics_source: LyricsSource::parse(&file_cfg.lyrics.source)
                 .unwrap_or(LyricsSource::LrcLib),
@@ -2175,6 +2198,7 @@ password_keyring = "secret-service"
             password: String::new(),
             password_command: "printf '%s' 'from-cmd'".into(),
             password_keyring: default_password_keyring(),
+            connection_check_interval_secs: default_connection_check_interval_secs(),
         };
         assert_eq!(
             resolve_subsonic_secret(&server).expect("command"),

--- a/ratune/src/keybinds.rs
+++ b/ratune/src/keybinds.rs
@@ -266,7 +266,13 @@ impl Keybinds {
                 modifiers: KeyModifiers::CONTROL,
             }),
         );
-        let connection_check = resolve_opt(sec.connection_check.as_deref(), None);
+        let connection_check = resolve_opt(
+            sec.connection_check.as_deref(),
+            Some(KeySpec {
+                code: KeyCode::Char('c'),
+                modifiers: KeyModifiers::SHIFT,
+            }),
+        );
         let library_index_append_queue = resolve_opt(
             sec.library_index_append_queue.as_deref(),
             Some(KeySpec {

--- a/ratune/src/keybinds.rs
+++ b/ratune/src/keybinds.rs
@@ -166,6 +166,8 @@ pub struct Keybinds {
     pub library_fzf: Option<KeySpec>,
     /// Force library index refresh (`None` = disabled).
     pub library_refresh: Option<KeySpec>,
+    /// Ping Subsonic and refresh online/offline mode (`None` = disabled).
+    pub connection_check: Option<KeySpec>,
     /// Append entire metadata index to queue after y/n (`None` = disabled).
     pub library_index_append_queue: Option<KeySpec>,
     pub toggle_help: KeySpec,
@@ -264,6 +266,7 @@ impl Keybinds {
                 modifiers: KeyModifiers::CONTROL,
             }),
         );
+        let connection_check = resolve_opt(sec.connection_check.as_deref(), None);
         let library_index_append_queue = resolve_opt(
             sec.library_index_append_queue.as_deref(),
             Some(KeySpec {
@@ -349,6 +352,7 @@ impl Keybinds {
             quit: resolve(sec.quit.as_deref(), KeySpec::new(KeyCode::Char('q'))),
             library_fzf,
             library_refresh,
+            connection_check,
             library_index_append_queue,
             toggle_help: resolve(sec.toggle_help.as_deref(), KeySpec::new(KeyCode::Char('i'))),
             toggle_dynamic_theme: resolve(

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -45,7 +45,7 @@ use action::{Action, Direction};
 use app::{App, BrowserColumn, Tab};
 use config::{AlbumArtBackend, BrowseMode, Config, HomePanel};
 use keybinds::Keybinds;
-use state::{FavoritesFocus, GlobalConfirm, PlaylistFocus, PlaylistInputMode};
+use state::{FavoritesFocus, GlobalConfirm, LoadingState, PlaylistFocus, PlaylistInputMode};
 
 /// Entry point shared by the `ratune` binary and integration tests.
 pub async fn run() -> Result<()> {
@@ -148,6 +148,15 @@ pub async fn run() -> Result<()> {
         // Background metadata index refresh when missing or stale (Milestone 2).
         app.spawn_library_index_refresh(false);
         app.fetch_starred();
+    } else {
+        app.prepare_offline_browse();
+        if app.browser_browse_mode != BrowseMode::Files {
+            app.fetch_artists();
+        } else {
+            app.folders.roots = LoadingState::Error(
+                "Folder browse requires server — switch to artists (config or toggle)".into(),
+            );
+        }
     }
 
     // Spawn a task that sets a flag on SIGTERM, SIGHUP, SIGPIPE, or SIGINT so the main loop
@@ -300,8 +309,18 @@ fn run_library_fzf_picker(
         return Ok(());
     }
 
+    let tracks = if !app.server_reachable && app.config.cache_enabled {
+        app.cache.filter_cached_tracks(&app.library_index_tracks)
+    } else {
+        app.library_index_tracks.clone()
+    };
+    if tracks.is_empty() {
+        app.flash_status("No cached tracks — play online to download audio");
+        return Ok(());
+    }
+
     fzf_picker::suspend_tui(terminal, app.in_tmux)?;
-    let input = library_index::fzf_input_lines(&app.library_index_tracks);
+    let input = library_index::fzf_input_lines(&tracks);
     let mut fzf_args = app.config.fzf_args.clone();
     if !fzf_args.iter().any(|a| a.starts_with("--header")) {
         fzf_args.insert(0, format!("--header={}", library_index::fzf_header_line()));
@@ -407,6 +426,12 @@ async fn run_loop(
     // 2-second fallback: nudge Kitty art re-transmit when it is missing.
     // Checked once per loop iteration (see below).
     let mut last_art_recovery_fire = Instant::now();
+    let connectivity_interval = if app.config.connection_check_interval_secs > 0 {
+        Duration::from_secs(app.config.connection_check_interval_secs)
+    } else {
+        Duration::MAX
+    };
+    let mut last_connectivity_check = Instant::now();
 
     loop {
         let frame_t0 = Instant::now();
@@ -447,6 +472,13 @@ async fn run_loop(
 
         // Expire status flash messages.
         app.tick_status_flash();
+
+        if connectivity_interval != Duration::MAX
+            && last_connectivity_check.elapsed() >= connectivity_interval
+        {
+            last_connectivity_check = Instant::now();
+            app.spawn_connectivity_check(false);
+        }
 
         // Apply completed NP encodes before draw (previous frame) and after draw (same-frame worker).
         drain_ratatui_np_resize_completions(app);
@@ -1596,6 +1628,11 @@ fn map_key(
     if let Some(spec) = &kb.library_refresh {
         if spec.matches(code, modifiers) {
             return Action::LibraryIndexRefresh;
+        }
+    }
+    if let Some(spec) = &kb.connection_check {
+        if spec.matches(code, modifiers) {
+            return Action::CheckConnection;
         }
     }
     if let Some(spec) = &kb.library_index_append_queue {

--- a/ratune/src/library_index.rs
+++ b/ratune/src/library_index.rs
@@ -180,9 +180,206 @@ pub fn index_by_id(tracks: &[Song]) -> std::collections::HashMap<String, Song> {
     tracks.iter().cloned().map(|s| (s.id.clone(), s)).collect()
 }
 
+/// Artist/album/track hierarchy derived from a flat library index — used to drive the
+/// Browse tab while offline (no live Subsonic calls).
+#[derive(Debug, Clone)]
+pub struct BrowseSnapshot {
+    pub artists: Vec<ratune_subsonic::Artist>,
+    pub albums_by_artist: std::collections::HashMap<String, Vec<ratune_subsonic::Album>>,
+    pub tracks_by_album: std::collections::HashMap<String, Vec<Song>>,
+}
+
+fn offline_artist_id(song: &Song) -> String {
+    song.artist_id
+        .clone()
+        .or_else(|| {
+            song.artist
+                .as_ref()
+                .map(|name| format!("__offline_artist__{name}"))
+        })
+        .unwrap_or_else(|| "__offline_unknown_artist__".to_string())
+}
+
+fn offline_album_id(song: &Song, artist_id: &str) -> String {
+    song.album_id
+        .clone()
+        .or_else(|| {
+            song.album
+                .as_ref()
+                .map(|name| format!("__offline_album__{artist_id}__{name}"))
+        })
+        .unwrap_or_else(|| format!("__offline_unknown_album__{artist_id}"))
+}
+
+fn album_sort_key(a: &ratune_subsonic::Album) -> (u32, String) {
+    (a.year.unwrap_or(0), a.name.to_lowercase())
+}
+
+fn sort_songs(songs: &mut [Song]) {
+    songs.sort_by_key(|s| (s.disc_number.unwrap_or(1), s.track.unwrap_or(0)));
+}
+
+/// Derive browse columns from the on-disk library index (same data as the fzf picker).
+pub fn build_browse_snapshot(tracks: &[Song]) -> BrowseSnapshot {
+    use ratune_subsonic::{Album, Artist};
+    use std::collections::HashMap;
+
+    struct AlbumAcc {
+        name: String,
+        artist_name: String,
+        songs: Vec<Song>,
+    }
+
+    struct ArtistAcc {
+        name: String,
+        albums: HashMap<String, AlbumAcc>,
+    }
+
+    let mut by_artist: HashMap<String, ArtistAcc> = HashMap::new();
+
+    for song in tracks {
+        let artist_id = offline_artist_id(song);
+        let artist_name = song
+            .artist
+            .clone()
+            .unwrap_or_else(|| "Unknown Artist".to_string());
+        let album_id = offline_album_id(song, &artist_id);
+        let album_name = song
+            .album
+            .clone()
+            .unwrap_or_else(|| "Unknown Album".to_string());
+
+        let artist = by_artist
+            .entry(artist_id.clone())
+            .or_insert_with(|| ArtistAcc {
+                name: artist_name.clone(),
+                albums: HashMap::new(),
+            });
+        if artist.name == "Unknown Artist" && artist_name != "Unknown Artist" {
+            artist.name = artist_name.clone();
+        }
+
+        let album = artist.albums.entry(album_id.clone()).or_insert_with(|| AlbumAcc {
+            name: album_name.clone(),
+            artist_name: artist_name.clone(),
+            songs: Vec::new(),
+        });
+        if album.name == "Unknown Album" && album_name != "Unknown Album" {
+            album.name = album_name;
+        }
+        album.songs.push(song.clone());
+    }
+
+    let mut artists: Vec<Artist> = by_artist
+        .iter()
+        .map(|(id, acc)| Artist {
+            id: id.clone(),
+            name: acc.name.clone(),
+            album_count: Some(acc.albums.len() as u32),
+            cover_art: acc
+                .albums
+                .values()
+                .flat_map(|a| a.songs.first())
+                .find_map(|s| s.cover_art.clone()),
+            starred: None,
+            album: Vec::new(),
+        })
+        .collect();
+    artists.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+
+    let mut albums_by_artist = HashMap::new();
+    let mut tracks_by_album = HashMap::new();
+
+    for (artist_id, acc) in by_artist {
+        let mut albums: Vec<Album> = acc
+            .albums
+            .into_iter()
+            .map(|(album_id, album_acc)| {
+                let mut songs = album_acc.songs;
+                sort_songs(&mut songs);
+                let song_count = songs.len() as u32;
+                let duration: u32 = songs.iter().filter_map(|s| s.duration).sum();
+                let year = songs.iter().find_map(|s| s.year);
+                let genre = songs.iter().find_map(|s| s.genre.clone());
+                let cover_art = songs
+                    .iter()
+                    .find_map(|s| s.cover_art.clone())
+                    .or_else(|| Some(album_id.clone()));
+                tracks_by_album.insert(album_id.clone(), songs);
+                Album {
+                    id: album_id,
+                    name: album_acc.name,
+                    artist: Some(album_acc.artist_name),
+                    artist_id: Some(artist_id.clone()),
+                    cover_art,
+                    song_count: Some(song_count),
+                    duration: if duration > 0 { Some(duration) } else { None },
+                    year,
+                    genre,
+                    starred: None,
+                    song: Vec::new(),
+                }
+            })
+            .collect();
+
+        albums.sort_by(|a, b| album_sort_key(a).cmp(&album_sort_key(b)));
+        albums_by_artist.insert(artist_id, albums);
+    }
+
+    BrowseSnapshot {
+        artists,
+        albums_by_artist,
+        tracks_by_album,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn browse_snapshot_groups_artists_albums_tracks() {
+        fn song(id: &str, artist: &str, album: &str, track: u32) -> Song {
+            Song {
+                id: id.into(),
+                title: format!("Track {track}"),
+                album: Some(album.into()),
+                artist: Some(artist.into()),
+                album_id: Some(format!("al-{album}")),
+                artist_id: Some(format!("ar-{artist}")),
+                track: Some(track),
+                disc_number: Some(1),
+                year: Some(2000),
+                genre: None,
+                cover_art: None,
+                duration: Some(180),
+                bit_rate: None,
+                content_type: None,
+                suffix: None,
+                size: None,
+                path: None,
+                starred: None,
+            }
+        }
+
+        let tracks = vec![
+            song("1", "Alice", "Alpha", 2),
+            song("2", "Alice", "Alpha", 1),
+            song("3", "Bob", "Beta", 1),
+        ];
+        let snap = build_browse_snapshot(&tracks);
+        assert_eq!(snap.artists.len(), 2);
+        assert_eq!(snap.artists[0].name, "Alice");
+        assert_eq!(snap.artists[1].name, "Bob");
+        let alice = snap.artists[0].id.clone();
+        let albums = snap.albums_by_artist.get(&alice).unwrap();
+        assert_eq!(albums.len(), 1);
+        assert_eq!(albums[0].name, "Alpha");
+        let album_tracks = snap.tracks_by_album.get(&albums[0].id).unwrap();
+        assert_eq!(album_tracks.len(), 2);
+        assert_eq!(album_tracks[0].track, Some(1));
+        assert_eq!(album_tracks[1].track, Some(2));
+    }
 
     #[test]
     fn parse_pick_line_basic() {

--- a/ratune/src/library_index.rs
+++ b/ratune/src/library_index.rs
@@ -259,11 +259,14 @@ pub fn build_browse_snapshot(tracks: &[Song]) -> BrowseSnapshot {
             artist.name = artist_name.clone();
         }
 
-        let album = artist.albums.entry(album_id.clone()).or_insert_with(|| AlbumAcc {
-            name: album_name.clone(),
-            artist_name: artist_name.clone(),
-            songs: Vec::new(),
-        });
+        let album = artist
+            .albums
+            .entry(album_id.clone())
+            .or_insert_with(|| AlbumAcc {
+                name: album_name.clone(),
+                artist_name: artist_name.clone(),
+                songs: Vec::new(),
+            });
         if album.name == "Unknown Album" && album_name != "Unknown Album" {
             album.name = album_name;
         }


### PR DESCRIPTION
Adds support for an "offline mode". See issue #24 

Features:
* Offline mode: support for all tabs using only cached music. 
* Tabs auto-update between displaying only cached music and all music depending on connection status
* Ability to switch into offline mode and boot into offline mode
* Periodic pings to check if connection still available w/ auto-switch to offline/online
* Optional manual check hotkey for users to force refresh (default: `Shift+c`)

Additionally added ability to cache favorited albums to make this offline mode a little more usable.