### PR TITLE
fix: refresh albums/songs when switching offline/online

### DIFF
--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -1789,6 +1789,8 @@ impl App {
         self.home_art_loading.clear();
         self.prepare_offline_browse();
         if self.browser_browse_mode != BrowseMode::Files {
+            self.library.albums.clear();
+            self.library.tracks.clear();
             self.fetch_artists();
         }
     }
@@ -1803,6 +1805,8 @@ impl App {
                 self.fetch_music_folders();
             }
         } else {
+            self.library.albums.clear();
+            self.library.tracks.clear();
             self.fetch_artists();
         }
         self.spawn_library_index_refresh(false);


### PR DESCRIPTION
When switching between offline or online mode, Ratune would update artists properly in browse tab, but not which albums or songs were available (requiring a restart of Ratune).

This force-refreshes albums and songs as well.