### PR TITLE
feat: Internet radio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ratune
 
 A terminal music player for Subsonic-compatible servers.
-Built in Rust with [Ratatui](https://github.com/ratatui/ratatui), featuring  album art graphics (including in tmux), gapless playback, fuzzy finder support, and a highly configurable UI.
+Built in Rust with [Ratatui](https://github.com/ratatui/ratatui), featuring album art graphics (including in tmux), gapless playback, internet radio, fuzzy finder support, and a highly configurable UI.
 
 <img src="docs/screenshots/customized_visual.png" alt="Visualizer now playing customization" width="90%" />
 
@@ -32,6 +32,7 @@ Ratune was built to bring together a combination of features often missing from 
 ## Highlights
 
 - **Playback**: Gapless queue, seek, shuffle/unshuffle, and playlist management.
+- **Internet radio**: Stations from your server
 - **Album Art**: Display using Kitty graphics and [ratatui-image](https://github.com/ratatui/ratatui-image) (see link for compatible terminals)
 - **Lyrics**: Synced lyrics via LRCLib (default) or your Subsonic server. Optional on-disk cache for offline use
 - **Offline mode**: Starts without a server when needed; plays cached tracks, browse from library index, and detects reconnect automatically
@@ -236,6 +237,10 @@ preset = "dynamic"
 
 [library]
 # enabled, index path, fzf binary, fzf args, …  → see sample-config.toml
+
+[radio]
+enabled = true
+# fetch_station_icons = true   # homepage favicons when no server logo
 ```
 
 Remapping is done in `[keybinds]`; colors in `[theme]`; now-playing strip vs queue are different keys — see the sample and in-app help (`i`).
@@ -250,6 +255,16 @@ Ratune syncs favorites with your server through the Subsonic **star** / **unstar
 - **Albums and artists** can be favorited too (Navidrome supports all three via the star API)
 - **Offline:** the favorites list is cached at `~/.cache/ratune/favorites.json`; open `F` without a connection to browse the last sync and play tracks already in the audio cache
 - **`[cache].cache_starred = true`:** while online, prefetch favorite **songs** into the offline cache (same `max_size_gb` pool as play-time caching)
+
+### Internet radio
+
+Ratune plays internet radio stations configured on your Subsonic-compatible server — no separate stream proxy; the client connects directly to each station URL.
+
+- **Enable / disable:** `[radio] enabled = true` (default) in [`docs/sample-config.toml`](docs/sample-config.toml); set `false` to disable radio entirely
+- **Station picker:** default keybinding **`Shift+R`** to browse, play, add, edit, and delete stations (`toggle_radio` in `[keybinds]`)
+- **Live playback:** progress shows **● LIVE** and elapsed listen time; **n** / **N** change stations while tuned in
+- **Formats:** direct Icecast/SHOUTcast URLs (MP3, AAC, and Ogg Vorbis).
+- **Station art:** Navidrome-uploaded logos, or optional homepage favicon fetch (`[radio] fetch_station_icons`)
 
 ### Folder navigation (Browse)
 
@@ -350,7 +365,9 @@ These are defaults; everything is overridable in `config.toml`. Press `i` in the
 | `n` / `N` | Next / previous |
 | `f` / `F` | Toggle favorite / toggle favorites panel (Browse) |
 | `x` / `z` | Shuffle / unshuffle |
-| `R` | Toggle queue loop |
+| `Q` | Toggle queue loop |
+| `Shift+R` | Internet radio station picker |
+| `Ctrl+g` | Now Playing: radio pane ↔ library queue |
 | `+` / `-` | Volume |
 | `←` / `→` | Seek (Now playing) |
 | `/` | Search |
@@ -377,7 +394,7 @@ Ratune captures pointer input when your terminal supports it. Keyboard navigatio
 | Progress bar | Seek to position |
 | Browse | Select artist, album, or track; folder mode: directory or preview row |
 | Home | Recent albums (including art strip), recent tracks, rediscover rows |
-| Now playing | Queue row to select; double-click same row to play |
+| Now playing | Queue row to select; double-click same row to play; radio pane row to select station |
 
 Scroll the mouse wheel over Browse lists to move the selection (`[ui.browsetab] mouse_wheel_scroll_lines` in the sample config).
 
@@ -469,7 +486,7 @@ Details: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 | Path | Purpose |
 | --- | --- |
 | `~/.config/ratune/config.toml` | Config |
-| `~/.config/ratune/state.json` | UI state, queue, browser position |
+| `~/.config/ratune/state.json` | UI state, queue, browser position, Now Playing pane focus |
 | `~/.local/share/ratune/history.json` | Play history |
 | `~/.local/share/ratune/scrobble-queue.json` | Pending Last.fm scrobbles (offline retry) |
 | `~/.cache/ratune/` | Track cache, library index JSON, etc. |

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -112,6 +112,8 @@ queue_loop = true
 # add_all_prepend     = "Ctrl+Shift+p"     # browser: prepend artist/album tracks
 # shuffle             = "x"
 # unshuffle           = "z"
+# toggle_queue_loop   = "Shift+q"     # wrap queue after last track
+# toggle_radio        = "Shift+r"     # open/close internet radio picker
 # clear_queue         = "Shift+d"     # clear entire queue
 # remove_from_queue   = "d"           # now playing: remove highlighted track
 # search              = "/"           # filter lists where supported
@@ -509,6 +511,17 @@ cache_starred_parallelism = 2
 #                      endpoint so Navidrome (etc.) records play counts. Uses the
 #                      local listen threshold (min(50%, 30 s)), independent of
 #                      Last.fm's min(50%, 4 min) rule.
+
+# [radio] — Internet radio
+#
+# enabled             — Show radio picker (Shift+R) and Now Playing radio pane (default: true)
+# fetch_station_icons — When true (default), download homepage icons for Now Playing
+#                       art if the station has no logo uploaded in Navidrome.
+#                       Set false to avoid outbound HTTP to station websites.
+
+# [radio]
+# enabled = true
+# fetch_station_icons = true
 
 [scrobble]
 enabled = false

--- a/ratune-player/src/adts_normalize.rs
+++ b/ratune-player/src/adts_normalize.rs
@@ -1,0 +1,143 @@
+//! Rewrite MPEG-2 ADTS sync (`0xFF 0xF9`) to MPEG-4 (`0xFF 0xF1`) on the fly.
+//!
+//! Symphonia's ADTS demuxer only scans for `0xFFF1`. Browser decoders and ffmpeg
+//! accept both; this adapter bridges the gap for live radio.
+
+use std::collections::VecDeque;
+use std::io::{Read, Seek, SeekFrom};
+
+const ADTS_HEADER_LEN: usize = 7;
+
+/// Pass-through reader that normalizes MPEG-2 ADTS headers for symphonia.
+pub struct AdtsNormalizeReader<R> {
+    inner: R,
+    /// AAC payload bytes remaining for the current ADTS frame (after the 7-byte header).
+    payload_remaining: usize,
+    pending: VecDeque<u8>,
+}
+
+impl<R> AdtsNormalizeReader<R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            payload_remaining: 0,
+            pending: VecDeque::new(),
+        }
+    }
+
+    fn reset_frame_state(&mut self) {
+        self.payload_remaining = 0;
+    }
+}
+
+/// ADTS frame length from a 7-byte header (protection-absent frames only).
+fn adts_frame_length(header: &[u8; ADTS_HEADER_LEN]) -> Option<usize> {
+    if header[0] != 0xFF || (header[1] & 0xF0) != 0xF0 {
+        return None;
+    }
+    let len = ((header[3] as usize & 0x03) << 11)
+        | ((header[4] as usize) << 3)
+        | (header[5] as usize >> 5);
+    (len >= ADTS_HEADER_LEN).then_some(len)
+}
+
+fn normalize_sync_byte(b: u8) -> u8 {
+    if b == 0xF9 { 0xF1 } else { b }
+}
+
+impl<R: Read> AdtsNormalizeReader<R> {
+    fn read_next_header(&mut self) -> std::io::Result<()> {
+        let mut header = [0u8; ADTS_HEADER_LEN];
+        self.inner.read_exact(&mut header[..2])?;
+        header[1] = normalize_sync_byte(header[1]);
+        self.inner.read_exact(&mut header[2..])?;
+        let frame_len = adts_frame_length(&header).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid ADTS header",
+            )
+        })?;
+        self.payload_remaining = frame_len - ADTS_HEADER_LEN;
+        self.pending.extend(header);
+        Ok(())
+    }
+
+    fn fill_pending(&mut self) -> std::io::Result<()> {
+        while self.payload_remaining == 0 && self.pending.is_empty() {
+            self.read_next_header()?;
+        }
+        Ok(())
+    }
+}
+
+impl<R: Read> Read for AdtsNormalizeReader<R> {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        if out.is_empty() {
+            return Ok(0);
+        }
+        let mut written = 0usize;
+        while written < out.len() {
+            while !self.pending.is_empty() && written < out.len() {
+                out[written] = self.pending.pop_front().expect("non-empty");
+                written += 1;
+            }
+            if written >= out.len() {
+                break;
+            }
+            if self.payload_remaining > 0 {
+                let want = out.len() - written;
+                let take = want.min(self.payload_remaining);
+                let n = self.inner.read(&mut out[written..written + take])?;
+                if n == 0 {
+                    return if written == 0 {
+                        Ok(0)
+                    } else {
+                        Ok(written)
+                    };
+                }
+                written += n;
+                self.payload_remaining -= n;
+                continue;
+            }
+            match self.fill_pending() {
+                Ok(()) => {}
+                Err(_) if written > 0 => return Ok(written),
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(written)
+    }
+}
+
+impl<R: Seek + Read> Seek for AdtsNormalizeReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.reset_frame_state();
+        self.pending.clear();
+        self.inner.seek(pos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn rewrites_mpeg2_sync_to_mpeg4() {
+        // Minimal valid-ish ADTS frame: 7-byte header + 4 payload bytes.
+        let mut raw = vec![
+            0xFF, 0xF9, 0x50, 0x80, 0x03, 0xE0, 0x00, 1, 2, 3, 4,
+        ];
+        // Fix frame length field to 11 (7 header + 4 payload): bits in bytes 3-5
+        raw[3] = 0x00;
+        raw[4] = 0x01;
+        raw[5] = 0x58;
+
+        let mut norm = AdtsNormalizeReader::new(Cursor::new(raw));
+        let mut out = vec![0u8; 11];
+        let n = norm.read(&mut out).unwrap();
+        assert_eq!(out[0], 0xFF);
+        assert_eq!(out[1], 0xF1, "MPEG-2 sync should be rewritten to MPEG-4");
+        assert!(n >= 7, "expected at least ADTS header, got {n} bytes");
+    }
+}

--- a/ratune-player/src/adts_normalize.rs
+++ b/ratune-player/src/adts_normalize.rs
@@ -42,7 +42,11 @@ fn adts_frame_length(header: &[u8; ADTS_HEADER_LEN]) -> Option<usize> {
 }
 
 fn normalize_sync_byte(b: u8) -> u8 {
-    if b == 0xF9 { 0xF1 } else { b }
+    if b == 0xF9 {
+        0xF1
+    } else {
+        b
+    }
 }
 
 impl<R: Read> AdtsNormalizeReader<R> {
@@ -52,10 +56,7 @@ impl<R: Read> AdtsNormalizeReader<R> {
         header[1] = normalize_sync_byte(header[1]);
         self.inner.read_exact(&mut header[2..])?;
         let frame_len = adts_frame_length(&header).ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "invalid ADTS header",
-            )
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid ADTS header")
         })?;
         self.payload_remaining = frame_len - ADTS_HEADER_LEN;
         self.pending.extend(header);
@@ -89,11 +90,7 @@ impl<R: Read> Read for AdtsNormalizeReader<R> {
                 let take = want.min(self.payload_remaining);
                 let n = self.inner.read(&mut out[written..written + take])?;
                 if n == 0 {
-                    return if written == 0 {
-                        Ok(0)
-                    } else {
-                        Ok(written)
-                    };
+                    return if written == 0 { Ok(0) } else { Ok(written) };
                 }
                 written += n;
                 self.payload_remaining -= n;
@@ -125,9 +122,7 @@ mod tests {
     #[test]
     fn rewrites_mpeg2_sync_to_mpeg4() {
         // Minimal valid-ish ADTS frame: 7-byte header + 4 payload bytes.
-        let mut raw = vec![
-            0xFF, 0xF9, 0x50, 0x80, 0x03, 0xE0, 0x00, 1, 2, 3, 4,
-        ];
+        let mut raw = vec![0xFF, 0xF9, 0x50, 0x80, 0x03, 0xE0, 0x00, 1, 2, 3, 4];
         // Fix frame length field to 11 (7 header + 4 payload): bits in bytes 3-5
         raw[3] = 0x00;
         raw[4] = 0x01;

--- a/ratune-player/src/engine.rs
+++ b/ratune-player/src/engine.rs
@@ -14,10 +14,12 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use reqwest::header::ACCEPT_ENCODING;
 use rodio::{Decoder, DeviceSinkBuilder, Player};
 
+use crate::adts_normalize::AdtsNormalizeReader;
+use crate::stream::{open_live_stream, StreamFormatHint, StreamingReader};
 use crate::tap::SampleTap;
 
 type SampleBuffer = Arc<Mutex<VecDeque<f32>>>;
@@ -40,6 +42,12 @@ pub enum PlayerCommand {
     PlayCached {
         path: PathBuf,
         duration: Option<Duration>,
+        gen: u64,
+    },
+    /// Same as [`PlayUrl`](Self::PlayUrl), but streams incrementally for live radio.
+    /// `duration` is always `None`; gapless enqueue is not used.
+    PlayLiveStream {
+        url: String,
         gen: u64,
     },
     /// Append the next track to the player queue for gapless playback.
@@ -178,6 +186,23 @@ fn player_thread(
                     play_payload(
                         PlayPayload::Cached(path),
                         duration,
+                        gen,
+                        &cmd_rx,
+                        &mut skip_gen,
+                        &player,
+                        &evt_tx,
+                        &mut current_total,
+                        &mut was_playing,
+                        &mut next_total,
+                        &mut next_queued,
+                        &mut about_to_finish_sent,
+                        &mut prev_elapsed,
+                        &sample_buffer,
+                    );
+                }
+                Ok(PlayerCommand::PlayLiveStream { url, gen }) => {
+                    play_live_stream(
+                        url,
                         gen,
                         &cmd_rx,
                         &mut skip_gen,
@@ -358,6 +383,28 @@ fn play_payload(
     let mut newer: Option<(PlayPayload, Option<Duration>, u64)> = None;
     loop {
         match cmd_rx.try_recv() {
+            Ok(PlayerCommand::PlayLiveStream {
+                url: u,
+                gen: g,
+            }) => {
+                *skip_gen = g;
+                play_live_stream(
+                    u,
+                    g,
+                    cmd_rx,
+                    skip_gen,
+                    player,
+                    evt_tx,
+                    current_total,
+                    was_playing,
+                    next_total,
+                    next_queued,
+                    about_to_finish_sent,
+                    prev_elapsed,
+                    sample_buffer,
+                );
+                return;
+            }
             Ok(PlayerCommand::PlayUrl {
                 url: u,
                 duration: d,
@@ -409,6 +456,146 @@ fn play_payload(
     let _ = evt_tx.send(PlayerEvent::TrackStarted);
 }
 
+/// Incrementally stream a live radio URL (no known duration, no gapless enqueue).
+#[allow(clippy::too_many_arguments)]
+fn play_live_stream(
+    url: String,
+    gen: u64,
+    cmd_rx: &mpsc::Receiver<PlayerCommand>,
+    skip_gen: &mut u64,
+    player: &Player,
+    evt_tx: &mpsc::Sender<PlayerEvent>,
+    current_total: &mut Option<Duration>,
+    was_playing: &mut bool,
+    next_total: &mut Option<Duration>,
+    next_queued: &mut bool,
+    about_to_finish_sent: &mut bool,
+    prev_elapsed: &mut Duration,
+    sample_buffer: &SampleBuffer,
+) {
+    *skip_gen = gen;
+
+    let mut final_url = url;
+    let mut final_gen = gen;
+    loop {
+        match cmd_rx.try_recv() {
+            Ok(PlayerCommand::PlayLiveStream {
+                url: u,
+                gen: g,
+            }) => {
+                final_url = u;
+                final_gen = g;
+                *skip_gen = g;
+            }
+            Ok(_other) => break,
+            Err(_) => break,
+        }
+    }
+
+    player.stop();
+    *was_playing = false;
+    *next_total = None;
+    *next_queued = false;
+    *about_to_finish_sent = false;
+    *prev_elapsed = Duration::ZERO;
+
+    let source = match live_stream_and_decode(&final_url) {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = evt_tx.send(PlayerEvent::Error(format!("playback error: {e}")));
+            return;
+        }
+    };
+
+    loop {
+        match cmd_rx.try_recv() {
+            Ok(PlayerCommand::PlayLiveStream {
+                url: u,
+                gen: g,
+            }) if g != final_gen => {
+                drop(source);
+                play_live_stream(
+                    u,
+                    g,
+                    cmd_rx,
+                    skip_gen,
+                    player,
+                    evt_tx,
+                    current_total,
+                    was_playing,
+                    next_total,
+                    next_queued,
+                    about_to_finish_sent,
+                    prev_elapsed,
+                    sample_buffer,
+                );
+                return;
+            }
+            Ok(PlayerCommand::PlayUrl {
+                url: u,
+                duration: d,
+                gen: g,
+            }) => {
+                drop(source);
+                play_payload(
+                    PlayPayload::Url(u),
+                    d,
+                    g,
+                    cmd_rx,
+                    skip_gen,
+                    player,
+                    evt_tx,
+                    current_total,
+                    was_playing,
+                    next_total,
+                    next_queued,
+                    about_to_finish_sent,
+                    prev_elapsed,
+                    sample_buffer,
+                );
+                return;
+            }
+            Ok(PlayerCommand::PlayCached {
+                path: p,
+                duration: d,
+                gen: g,
+            }) => {
+                drop(source);
+                play_payload(
+                    PlayPayload::Cached(p),
+                    d,
+                    g,
+                    cmd_rx,
+                    skip_gen,
+                    player,
+                    evt_tx,
+                    current_total,
+                    was_playing,
+                    next_total,
+                    next_queued,
+                    about_to_finish_sent,
+                    prev_elapsed,
+                    sample_buffer,
+                );
+                return;
+            }
+            Ok(_) => break,
+            Err(_) => break,
+        }
+    }
+
+    if *skip_gen != final_gen {
+        drop(source);
+        return;
+    }
+
+    *current_total = None;
+    let tapped = SampleTap::new(source, sample_buffer.clone());
+    player.append(tapped);
+    player.play();
+    let _ = evt_tx.send(PlayerEvent::TrackStarted);
+}
+
 #[allow(clippy::too_many_arguments)] // Engine thread: one place for all command side-effects.
 fn handle_command(
     cmd: PlayerCommand,
@@ -423,8 +610,10 @@ fn handle_command(
     sample_buffer: &SampleBuffer,
 ) {
     match cmd {
-        PlayerCommand::PlayUrl { .. } | PlayerCommand::PlayCached { .. } => {
-            unreachable!("PlayUrl / PlayCached must be dispatched via play_payload()");
+        PlayerCommand::PlayUrl { .. }
+        | PlayerCommand::PlayCached { .. }
+        | PlayerCommand::PlayLiveStream { .. } => {
+            unreachable!("PlayUrl / PlayCached / PlayLiveStream must be dispatched via play_payload()");
         }
         PlayerCommand::EnqueueNext { url, duration } => match download_and_decode(&url) {
             Ok(source) => {
@@ -527,6 +716,83 @@ fn build_symphonia_decoder(bytes: Vec<u8>) -> Result<Decoder<Cursor<Vec<u8>>>> {
         .with_coarse_seek(true)
         .build()
         .context("decoding audio (unsupported or corrupt file?)")
+}
+
+/// Live HTTP reader, optionally normalizing MPEG-2 ADTS for symphonia.
+enum LiveDecodeReader {
+    Raw(StreamingReader),
+    Aac(AdtsNormalizeReader<StreamingReader>),
+}
+
+impl std::io::Read for LiveDecodeReader {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Raw(r) => r.read(out),
+            Self::Aac(r) => r.read(out),
+        }
+    }
+}
+
+impl std::io::Seek for LiveDecodeReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        match self {
+            Self::Raw(r) => r.seek(pos),
+            Self::Aac(r) => r.seek(pos),
+        }
+    }
+}
+
+/// Max time to probe/decode after the stream has connected and prebuffered.
+const LIVE_DECODE_PROBE_TIMEOUT: Duration = Duration::from_secs(20);
+
+fn live_stream_and_decode(url: &str) -> Result<Decoder<LiveDecodeReader>> {
+    let mut reader = open_live_stream(url)?;
+    let decode_hint = reader.prepare_for_decode(url);
+    let reader = if decode_hint.format == StreamFormatHint::Aac {
+        LiveDecodeReader::Aac(AdtsNormalizeReader::new(reader))
+    } else {
+        LiveDecodeReader::Raw(reader)
+    };
+
+    let (tx, rx) = mpsc::channel();
+    thread::Builder::new()
+        .name("ratune-live-decode".into())
+        .spawn(move || {
+            let mut builder = Decoder::builder().with_data(reader).with_coarse_seek(true);
+            if let Some(ext) = decode_hint.extension_hint() {
+                builder = builder.with_hint(ext);
+            }
+            if let Some(mime) = decode_hint.mime_hint() {
+                builder = builder.with_mime_type(mime);
+            }
+            let result = builder
+                .build()
+                .context("decoding live stream (unsupported format?)");
+            let _ = tx.send(result);
+        })
+        .context("failed to spawn live decode thread")?;
+
+    match rx.recv_timeout(LIVE_DECODE_PROBE_TIMEOUT) {
+        Ok(Ok(decoder)) => Ok(decoder),
+        Ok(Err(e)) => Err(e),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(match decode_hint.format {
+            StreamFormatHint::Aac => anyhow!(
+                "AAC radio stream timed out during decode — server may be blocking or using an unsupported AAC variant"
+            ),
+            StreamFormatHint::Ogg => anyhow!(
+                "OGG radio stream timed out during decode"
+            ),
+            StreamFormatHint::Unknown => anyhow!(
+                "live stream timed out during decode (unsupported format or blocked URL)"
+            ),
+            StreamFormatHint::Mp3 => anyhow!(
+                "MP3 stream timed out during decode — server may be slow or blocking this client"
+            ),
+        }),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err(anyhow!("live stream decode thread exited unexpectedly"))
+        }
+    }
 }
 
 fn download_and_decode(url: &str) -> Result<Decoder<Cursor<Vec<u8>>>> {

--- a/ratune-player/src/engine.rs
+++ b/ratune-player/src/engine.rs
@@ -501,78 +501,75 @@ fn play_live_stream(
         }
     };
 
-    loop {
-        match cmd_rx.try_recv() {
-            Ok(PlayerCommand::PlayLiveStream { url: u, gen: g }) if g != final_gen => {
-                drop(source);
-                play_live_stream(
-                    u,
-                    g,
-                    cmd_rx,
-                    skip_gen,
-                    player,
-                    evt_tx,
-                    current_total,
-                    was_playing,
-                    next_total,
-                    next_queued,
-                    about_to_finish_sent,
-                    prev_elapsed,
-                    sample_buffer,
-                );
-                return;
-            }
-            Ok(PlayerCommand::PlayUrl {
-                url: u,
-                duration: d,
-                gen: g,
-            }) => {
-                drop(source);
-                play_payload(
-                    PlayPayload::Url(u),
-                    d,
-                    g,
-                    cmd_rx,
-                    skip_gen,
-                    player,
-                    evt_tx,
-                    current_total,
-                    was_playing,
-                    next_total,
-                    next_queued,
-                    about_to_finish_sent,
-                    prev_elapsed,
-                    sample_buffer,
-                );
-                return;
-            }
-            Ok(PlayerCommand::PlayCached {
-                path: p,
-                duration: d,
-                gen: g,
-            }) => {
-                drop(source);
-                play_payload(
-                    PlayPayload::Cached(p),
-                    d,
-                    g,
-                    cmd_rx,
-                    skip_gen,
-                    player,
-                    evt_tx,
-                    current_total,
-                    was_playing,
-                    next_total,
-                    next_queued,
-                    about_to_finish_sent,
-                    prev_elapsed,
-                    sample_buffer,
-                );
-                return;
-            }
-            Ok(_) => break,
-            Err(_) => break,
+    match cmd_rx.try_recv() {
+        Ok(PlayerCommand::PlayLiveStream { url: u, gen: g }) if g != final_gen => {
+            drop(source);
+            play_live_stream(
+                u,
+                g,
+                cmd_rx,
+                skip_gen,
+                player,
+                evt_tx,
+                current_total,
+                was_playing,
+                next_total,
+                next_queued,
+                about_to_finish_sent,
+                prev_elapsed,
+                sample_buffer,
+            );
+            return;
         }
+        Ok(PlayerCommand::PlayUrl {
+            url: u,
+            duration: d,
+            gen: g,
+        }) => {
+            drop(source);
+            play_payload(
+                PlayPayload::Url(u),
+                d,
+                g,
+                cmd_rx,
+                skip_gen,
+                player,
+                evt_tx,
+                current_total,
+                was_playing,
+                next_total,
+                next_queued,
+                about_to_finish_sent,
+                prev_elapsed,
+                sample_buffer,
+            );
+            return;
+        }
+        Ok(PlayerCommand::PlayCached {
+            path: p,
+            duration: d,
+            gen: g,
+        }) => {
+            drop(source);
+            play_payload(
+                PlayPayload::Cached(p),
+                d,
+                g,
+                cmd_rx,
+                skip_gen,
+                player,
+                evt_tx,
+                current_total,
+                was_playing,
+                next_total,
+                next_queued,
+                about_to_finish_sent,
+                prev_elapsed,
+                sample_buffer,
+            );
+            return;
+        }
+        Ok(_) | Err(_) => {}
     }
 
     if *skip_gen != final_gen {

--- a/ratune-player/src/engine.rs
+++ b/ratune-player/src/engine.rs
@@ -383,10 +383,7 @@ fn play_payload(
     let mut newer: Option<(PlayPayload, Option<Duration>, u64)> = None;
     loop {
         match cmd_rx.try_recv() {
-            Ok(PlayerCommand::PlayLiveStream {
-                url: u,
-                gen: g,
-            }) => {
+            Ok(PlayerCommand::PlayLiveStream { url: u, gen: g }) => {
                 *skip_gen = g;
                 play_live_stream(
                     u,
@@ -479,10 +476,7 @@ fn play_live_stream(
     let mut final_gen = gen;
     loop {
         match cmd_rx.try_recv() {
-            Ok(PlayerCommand::PlayLiveStream {
-                url: u,
-                gen: g,
-            }) => {
+            Ok(PlayerCommand::PlayLiveStream { url: u, gen: g }) => {
                 final_url = u;
                 final_gen = g;
                 *skip_gen = g;
@@ -509,10 +503,7 @@ fn play_live_stream(
 
     loop {
         match cmd_rx.try_recv() {
-            Ok(PlayerCommand::PlayLiveStream {
-                url: u,
-                gen: g,
-            }) if g != final_gen => {
+            Ok(PlayerCommand::PlayLiveStream { url: u, gen: g }) if g != final_gen => {
                 drop(source);
                 play_live_stream(
                     u,
@@ -613,7 +604,9 @@ fn handle_command(
         PlayerCommand::PlayUrl { .. }
         | PlayerCommand::PlayCached { .. }
         | PlayerCommand::PlayLiveStream { .. } => {
-            unreachable!("PlayUrl / PlayCached / PlayLiveStream must be dispatched via play_payload()");
+            unreachable!(
+                "PlayUrl / PlayCached / PlayLiveStream must be dispatched via play_payload()"
+            );
         }
         PlayerCommand::EnqueueNext { url, duration } => match download_and_decode(&url) {
             Ok(source) => {

--- a/ratune-player/src/lib.rs
+++ b/ratune-player/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod adts_normalize;
 pub mod engine;
 pub mod queue;
 pub mod stream;

--- a/ratune-player/src/stream.rs
+++ b/ratune-player/src/stream.rs
@@ -9,18 +9,38 @@
 //! without re-fetching.  Trade-off: memory grows with the file (~14–30 MB for
 //! a typical song), which is acceptable for a music player.
 //!
-//! Playback starts as soon as 256 KB have been buffered (PREBUFFER_BYTES).
+//! Playback starts as soon as enough bytes have been buffered (see constants).
 
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use reqwest::header::{ACCEPT, ACCEPT_ENCODING, CONTENT_TYPE};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-/// Minimum bytes buffered before `open_stream` returns.
+/// Minimum bytes buffered before [`open_stream`] returns (library-sized payloads).
 const PREBUFFER_BYTES: usize = 256 * 1024;
+
+/// Smaller prebuffer for unbounded live radio streams (MP3/OGG).
+const LIVE_PREBUFFER_BYTES: usize = 16 * 1024;
+
+/// AAC/Icecast streams often ship kilobytes of headers before the first ADTS frame.
+const LIVE_AAC_PREBUFFER_BYTES: usize = 64 * 1024;
+
+/// Hard cap while waiting for the first ADTS sync word.
+const LIVE_AAC_PREBUFFER_MAX: usize = 512 * 1024;
+
+/// Minimum bytes to accept when the download ends before reaching prebuffer.
+const MIN_LIVE_BYTES: usize = 2 * 1024;
+
+/// Max time to wait for live prebuffer before failing.
+const LIVE_PREBUFFER_WAIT: Duration = Duration::from_secs(20);
+
+/// Longer wait for AAC — Icecast can be slow to deliver the first audio frame.
+const LIVE_AAC_PREBUFFER_WAIT: Duration = Duration::from_secs(35);
 
 // ── Shared inner state ────────────────────────────────────────────────────────
 
@@ -31,6 +51,9 @@ struct StreamInner {
     cond: Condvar,
     /// Set to `true` once the download thread has finished (success or error).
     done: AtomicBool,
+    error: Mutex<Option<String>>,
+    /// HTTP `Content-Type` from the stream response, when present.
+    content_type: Mutex<Option<String>>,
 }
 
 // ── Public reader ─────────────────────────────────────────────────────────────
@@ -54,6 +77,12 @@ impl Read for StreamingReader {
                 })
                 .unwrap()
         };
+        if let Some(err) = self.inner.error.lock().unwrap().clone() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                err,
+            ));
+        }
         let available = buf.len().saturating_sub(pos);
         if available == 0 {
             return Ok(0); // EOF
@@ -72,16 +101,11 @@ impl Seek for StreamingReader {
             SeekFrom::Start(off) => off as i64,
             SeekFrom::Current(off) => self.pos as i64 + off,
             SeekFrom::End(off) => {
-                // Must wait until download is complete to know total length.
-                let buf = {
-                    let guard = self.inner.buf.lock().unwrap();
-                    self.inner
-                        .cond
-                        .wait_while(guard, |_| !self.inner.done.load(Ordering::Acquire))
-                        .unwrap()
-                };
-                let len = buf.len() as i64;
-                drop(buf);
+                // Use bytes received so far. Waiting for `done` hangs on live radio
+                // streams (symphonia probes with SeekFrom::End during format detection).
+                let guard = self.inner.buf.lock().unwrap();
+                let len = guard.len() as i64;
+                drop(guard);
                 len + off
             }
         };
@@ -104,46 +128,430 @@ impl Seek for StreamingReader {
 /// Returns after `PREBUFFER_BYTES` have been buffered (or the download
 /// completes, whichever comes first).
 pub fn open_stream(url: &str) -> Result<StreamingReader> {
+    open_stream_with_prebuffer(url, PREBUFFER_BYTES, None, PrebufferMode::MinBytes)
+}
+
+/// Max playlist indirections (M3U/PLS wrappers) before giving up.
+const MAX_PLAYLIST_DEPTH: u8 = 3;
+
+/// Same as [`open_stream`] but tuned for unbounded live radio (smaller prebuffer).
+/// Follows simple M3U/PLS playlist wrappers to the direct stream URL.
+pub fn open_live_stream(url: &str) -> Result<StreamingReader> {
+    open_live_stream_resolved(url, 0)
+}
+
+fn open_live_stream_resolved(url: &str, depth: u8) -> Result<StreamingReader> {
+    if depth >= MAX_PLAYLIST_DEPTH {
+        return Err(anyhow!("playlist redirect limit reached — use a direct stream URL"));
+    }
+    let likely_aac = hint_from_url(url) == StreamFormatHint::Aac;
+    let reader = if likely_aac {
+        open_stream_with_aac_prebuffer(url)?
+    } else {
+        open_stream_with_prebuffer(
+            url,
+            LIVE_PREBUFFER_BYTES,
+            Some(LIVE_PREBUFFER_WAIT),
+            PrebufferMode::MinBytes,
+        )?
+    };
+    if let Some(next_url) = try_resolve_playlist_url(&reader)? {
+        return open_live_stream_resolved(&next_url, depth + 1);
+    }
+    Ok(reader)
+}
+
+#[derive(Clone, Copy)]
+enum PrebufferMode {
+    MinBytes,
+    /// Keep buffering until an ADTS sync word appears (AAC/Icecast).
+    AdtsSync,
+}
+
+fn open_stream_with_aac_prebuffer(url: &str) -> Result<StreamingReader> {
+    open_stream_with_prebuffer(
+        url,
+        LIVE_AAC_PREBUFFER_BYTES,
+        Some(LIVE_AAC_PREBUFFER_WAIT),
+        PrebufferMode::AdtsSync,
+    )
+}
+
+fn open_stream_with_prebuffer(
+    url: &str,
+    prebuffer: usize,
+    max_wait: Option<Duration>,
+    mode: PrebufferMode,
+) -> Result<StreamingReader> {
     let inner = Arc::new(StreamInner {
         buf: Mutex::new(Vec::new()),
         cond: Condvar::new(),
         done: AtomicBool::new(false),
+        error: Mutex::new(None),
+        content_type: Mutex::new(None),
     });
 
-    // Spawn download thread.
     let inner_dl = inner.clone();
-    let url = url.to_owned();
+    let fetch_url = url.to_owned();
     std::thread::Builder::new()
         .name("ratune-stream".into())
-        .spawn(move || download_thread(&url, inner_dl))
+        .spawn(move || download_thread(&fetch_url, inner_dl))
         .context("failed to spawn stream thread")?;
 
-    // Wait until PREBUFFER_BYTES are ready (or download finishes early).
+    let deadline = max_wait.map(|d| Instant::now() + d);
+    loop {
+        if let Some(err) = inner.error.lock().unwrap().clone() {
+            return Err(anyhow!(err));
+        }
+        let (len, done) = {
+            let guard = inner.buf.lock().unwrap();
+            (guard.len(), inner.done.load(Ordering::Acquire))
+        };
+        let active_mode = effective_prebuffer_mode(mode, &inner, url);
+        let ready = match active_mode {
+            PrebufferMode::MinBytes => len >= prebuffer || (done && len >= MIN_LIVE_BYTES),
+            PrebufferMode::AdtsSync => {
+                find_adts_sync_offset(&inner.buf.lock().unwrap()).is_some()
+                    || len >= LIVE_AAC_PREBUFFER_MAX
+                    || (done && len >= MIN_LIVE_BYTES)
+            }
+        };
+        if ready {
+            break;
+        }
+        if done && len == 0 {
+            return Err(anyhow!("stream returned no data"));
+        }
+        if let Some(deadline) = deadline {
+            if Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "stream prebuffer timeout (got {len} bytes, need {prebuffer})"
+                ));
+            }
+        }
+        let guard = inner.buf.lock().unwrap();
+        let wait_for = Duration::from_millis(200);
+        let (guard, _) = inner
+            .cond
+            .wait_timeout(guard, wait_for)
+            .unwrap();
+        drop(guard);
+    }
+
     {
         let guard = inner.buf.lock().unwrap();
-        let _guard = inner
-            .cond
-            .wait_while(guard, |b| {
-                b.len() < PREBUFFER_BYTES && !inner.done.load(Ordering::Acquire)
-            })
-            .unwrap();
+        let active_mode = effective_prebuffer_mode(mode, &inner, url);
+        if matches!(active_mode, PrebufferMode::AdtsSync)
+            && find_adts_sync_offset(&guard).is_none()
+            && guard.len() >= MIN_LIVE_BYTES
+        {
+            return Err(anyhow!(
+                "no AAC ADTS audio found in stream (got {} bytes) — check the station URL",
+                guard.len()
+            ));
+        }
     }
 
     Ok(StreamingReader { inner, pos: 0 })
 }
 
+/// Guess audio container from the first buffered bytes (after skipping whitespace).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamFormatHint {
+    Mp3,
+    Ogg,
+    Aac,
+    Unknown,
+}
+
+impl StreamingReader {
+    /// Inspect bytes downloaded so far without consuming them.
+    pub fn format_hint(&self) -> StreamFormatHint {
+        let guard = self.inner.buf.lock().unwrap();
+        sniff_format(&guard)
+    }
+
+    /// Detect format from URL/buffer, align AAC streams to the first ADTS frame, and
+    /// return hints for symphonia. Without explicit hints symphonia probes every format
+    /// against the live stream and can hang indefinitely.
+    pub fn prepare_for_decode(&mut self, url: &str) -> LiveDecodeHint {
+        let guard = self.inner.buf.lock().unwrap();
+        let mut hint = sniff_format(&guard);
+        drop(guard);
+        if hint == StreamFormatHint::Unknown {
+            hint = hint_from_url(url);
+        }
+        if hint == StreamFormatHint::Unknown {
+            if let Some(ct) = self.inner.content_type.lock().unwrap().as_deref() {
+                hint = hint_from_content_type(ct);
+            }
+        }
+        if hint == StreamFormatHint::Aac {
+            let guard = self.inner.buf.lock().unwrap();
+            if let Some(offset) = find_preferred_adts_sync_offset(&guard) {
+                self.pos = offset as u64;
+            }
+        }
+        LiveDecodeHint { format: hint }
+    }
+}
+
+/// Format detected for a live stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LiveDecodeHint {
+    pub format: StreamFormatHint,
+}
+
+impl LiveDecodeHint {
+    #[must_use]
+    pub fn extension_hint(&self) -> Option<&'static str> {
+        match self.format {
+            StreamFormatHint::Mp3 => Some("mp3"),
+            StreamFormatHint::Aac => Some("aac"),
+            StreamFormatHint::Ogg => Some("ogg"),
+            StreamFormatHint::Unknown => None,
+        }
+    }
+
+    #[must_use]
+    pub fn mime_hint(&self) -> Option<&'static str> {
+        match self.format {
+            StreamFormatHint::Mp3 => Some("audio/mpeg"),
+            StreamFormatHint::Aac => Some("audio/aac"),
+            StreamFormatHint::Ogg => Some("audio/ogg"),
+            StreamFormatHint::Unknown => None,
+        }
+    }
+}
+
+/// ADTS sync is 12 bits `0xFFF` with layer field `00` (byte1 bits 2–1).
+fn is_adts_sync(b0: u8, b1: u8) -> bool {
+    b0 == 0xFF && (b1 & 0xF0) == 0xF0 && (b1 & 0x06) == 0x00
+}
+
+/// MP3 frame sync is 11 bits `0xFFE` with a non-zero layer field.
+fn is_mp3_sync(b0: u8, b1: u8) -> bool {
+    b0 == 0xFF && (b1 & 0xE0) == 0xE0 && (b1 & 0x06) != 0x00
+}
+
+fn sniff_format(buf: &[u8]) -> StreamFormatHint {
+    let trimmed = trim_leading_ws(buf);
+    if trimmed.starts_with(b"ID3") {
+        return StreamFormatHint::Mp3;
+    }
+    if trimmed.starts_with(b"OggS") {
+        return StreamFormatHint::Ogg;
+    }
+    // Only inspect stream start — MP3 frames (`0xFF 0xFB`) share the ADTS prefix.
+    if trimmed.len() >= 2 && is_adts_sync(trimmed[0], trimmed[1]) {
+        return StreamFormatHint::Aac;
+    }
+    if trimmed.len() >= 2 && is_mp3_sync(trimmed[0], trimmed[1]) {
+        return StreamFormatHint::Mp3;
+    }
+    StreamFormatHint::Unknown
+}
+
+fn hint_from_url(url: &str) -> StreamFormatHint {
+    let lower = url.to_ascii_lowercase();
+    if lower.contains("aac")
+        || lower.ends_with(".aacp")
+        || lower.contains("_aac")
+        || lower.contains("aac_")
+        || lower.contains("_sc")
+        || lower.contains("fmaac")
+    {
+        StreamFormatHint::Aac
+    } else if lower.ends_with(".mp3") || lower.ends_with("-mp3") {
+        StreamFormatHint::Mp3
+    } else if lower.ends_with(".ogg") || lower.ends_with(".oga") {
+        StreamFormatHint::Ogg
+    } else {
+        StreamFormatHint::Unknown
+    }
+}
+
+fn hint_from_content_type(content_type: &str) -> StreamFormatHint {
+    let lower = content_type.to_ascii_lowercase();
+    if lower.contains("aac") {
+        StreamFormatHint::Aac
+    } else if lower.contains("mpeg") || lower.contains("mp3") {
+        StreamFormatHint::Mp3
+    } else if lower.contains("ogg") {
+        StreamFormatHint::Ogg
+    } else {
+        StreamFormatHint::Unknown
+    }
+}
+
+fn effective_prebuffer_mode(mode: PrebufferMode, inner: &StreamInner, url: &str) -> PrebufferMode {
+    if matches!(mode, PrebufferMode::AdtsSync) {
+        return PrebufferMode::AdtsSync;
+    }
+    if hint_from_url(url) == StreamFormatHint::Aac {
+        return PrebufferMode::AdtsSync;
+    }
+    if inner
+        .content_type
+        .lock()
+        .unwrap()
+        .as_deref()
+        .is_some_and(|ct| hint_from_content_type(ct) == StreamFormatHint::Aac)
+    {
+        return PrebufferMode::AdtsSync;
+    }
+    PrebufferMode::MinBytes
+}
+
+/// Prefer MPEG-4 ADTS (`0xFFF1`); fall back to any ADTS sync (incl. MPEG-2 `0xFFF9`).
+fn find_preferred_adts_sync_offset(buf: &[u8]) -> Option<usize> {
+    find_mpeg4_adts_sync_offset(buf).or_else(|| find_adts_sync_offset(buf))
+}
+
+fn find_mpeg4_adts_sync_offset(buf: &[u8]) -> Option<usize> {
+    buf.windows(2).position(|w| w[0] == 0xFF && w[1] == 0xF1)
+}
+
+/// Byte offset of the first ADTS sync word (`0xFFF` + layer `00`).
+fn find_adts_sync_offset(buf: &[u8]) -> Option<usize> {
+    buf.windows(2)
+        .position(|w| is_adts_sync(w[0], w[1]))
+}
+
+fn trim_leading_ws(buf: &[u8]) -> &[u8] {
+    buf.iter()
+        .position(|b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+        .map_or(&[][..], |i| &buf[i..])
+}
+
+/// If the buffered response is a playlist wrapper, return the stream URL inside it.
+fn try_resolve_playlist_url(reader: &StreamingReader) -> Result<Option<String>> {
+    let guard = reader.inner.buf.lock().unwrap();
+    try_resolve_playlist_bytes(&guard)
+}
+
+fn try_resolve_playlist_bytes(buf: &[u8]) -> Result<Option<String>> {
+    let trimmed = trim_leading_ws(buf);
+    let head = &trimmed[..trimmed.len().min(4096)];
+    if head.starts_with(b"#EXTM3U") {
+        let text = std::str::from_utf8(head)
+            .context("playlist is not valid UTF-8")?;
+        if text.contains("#EXT-X-") || text.to_ascii_lowercase().contains(".m3u8") {
+            return Err(anyhow!(
+                "HLS stream (.m3u8) is not supported — find a direct MP3/Icecast URL"
+            ));
+        }
+        return Ok(parse_m3u_stream_url(text));
+    }
+    if head.starts_with(b"[playlist]") {
+        let text = std::str::from_utf8(head)
+            .context("playlist is not valid UTF-8")?;
+        return Ok(parse_pls_stream_url(text));
+    }
+    if let Some(url) = parse_bare_stream_url(head) {
+        return Ok(Some(url));
+    }
+    let lower: Vec<u8> = head
+        .iter()
+        .copied()
+        .take(64)
+        .map(|b| b.to_ascii_lowercase())
+        .collect();
+    if lower.starts_with(b"<!doctype") || lower.starts_with(b"<html") {
+        return Err(anyhow!(
+            "stream URL returned a web page, not audio — check the station URL"
+        ));
+    }
+    Ok(None)
+}
+
+fn parse_m3u_stream_url(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with("http://") || line.starts_with("https://") {
+            return Some(line.to_string());
+        }
+    }
+    None
+}
+
+fn parse_pls_stream_url(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(url) = line.strip_prefix("File1=") {
+            let url = url.trim();
+            if url.starts_with("http://") || url.starts_with("https://") {
+                return Some(url.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Some servers return a one-line M3U (URL only, no `#EXTM3U` header).
+fn parse_bare_stream_url(buf: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(buf).ok()?.trim();
+    if text.len() > 512 || text.lines().count() > 3 {
+        return None;
+    }
+    let line = text.lines().find(|l| !l.trim().is_empty())?.trim();
+    if (line.starts_with("http://") || line.starts_with("https://"))
+        && line.chars().all(|c| !c.is_control() || c == '\r' || c == '\n')
+    {
+        Some(line.to_string())
+    } else {
+        None
+    }
+}
+
 // ── Download thread ───────────────────────────────────────────────────────────
 
 fn download_thread(url: &str, inner: Arc<StreamInner>) {
-    let _ = download_into(url, &inner);
+    if let Err(e) = download_into(url, &inner) {
+        *inner.error.lock().unwrap() = Some(e.to_string());
+    }
     inner.done.store(true, Ordering::Release);
     inner.cond.notify_all();
 }
 
+fn live_http_client() -> &'static reqwest::blocking::Client {
+    static CLIENT: OnceLock<reqwest::blocking::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::blocking::Client::builder()
+            // Live streams never finish — only bound connect time, not total body read.
+            .connect_timeout(Duration::from_secs(15))
+            .user_agent(concat!(
+                "Mozilla/5.0 (compatible; ratune/",
+                env!("CARGO_PKG_VERSION"),
+                "; +https://github.com/acmagn/ratune)"
+            ))
+            .build()
+            .expect("live stream HTTP client")
+    })
+}
+
 fn download_into(url: &str, inner: &StreamInner) -> Result<()> {
     use std::io::Read as _;
-    let mut response = reqwest::blocking::get(url).context("HTTP request failed")?;
-    let mut chunk = vec![0u8; 32 * 1024]; // 32 KB read buffer
+    let response = live_http_client()
+        .get(url)
+        .header(ACCEPT, "*/*")
+        .header(ACCEPT_ENCODING, "identity")
+        .send()
+        .context("HTTP request failed")?
+        .error_for_status()
+        .with_context(|| format!("stream HTTP error for {url}"))?;
+    if let Some(ct) = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+    {
+        *inner.content_type.lock().unwrap() = Some(ct.to_string());
+    }
+    let mut response = response;
+    let mut chunk = vec![0u8; 32 * 1024];
     loop {
         let n = response.read(&mut chunk).context("stream read error")?;
         if n == 0 {
@@ -156,4 +564,63 @@ fn download_into(url: &str, inner: &StreamInner) -> Result<()> {
         inner.cond.notify_all();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod stream_tests {
+    use super::*;
+    use std::time::Instant;
+
+    /// Regression: symphonia probes with SeekFrom::End; waiting for EOF hung live radio.
+    #[test]
+    fn live_stream_end_seek_does_not_wait_for_eof() {
+        let inner = Arc::new(StreamInner {
+            buf: Mutex::new(vec![0u8; 4096]),
+            cond: Condvar::new(),
+            done: AtomicBool::new(false),
+            error: Mutex::new(None),
+            content_type: Mutex::new(None),
+        });
+        let mut reader = StreamingReader {
+            inner,
+            pos: 0,
+        };
+        let start = Instant::now();
+        reader.seek(SeekFrom::End(0)).unwrap();
+        assert!(start.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn resolves_m3u_playlist_bytes() {
+        let url = parse_m3u_stream_url("#EXTM3U\n#EXTINF:-1,Test\nhttp://x/stream.mp3\n");
+        assert_eq!(url.as_deref(), Some("http://x/stream.mp3"));
+    }
+
+    #[test]
+    fn detects_hls_in_m3u() {
+        let body = b"#EXTM3U\n#EXT-X-VERSION:3\nhttp://x/playlist.m3u8\n";
+        assert!(try_resolve_playlist_bytes(body).is_err());
+    }
+
+    #[test]
+    fn sniff_aac_adts_at_stream_start() {
+        let buf = [0xFFu8, 0xF1, 0x50, 0x80, 0x03, 0xE0, 0x00];
+        assert_eq!(sniff_format(&buf), StreamFormatHint::Aac);
+    }
+
+    #[test]
+    fn sniff_mp3_frame_not_aac() {
+        // Common Icecast MP3 frame header — old sniff misclassified this as ADTS.
+        let buf = [0xFFu8, 0xFB, 0x90, 0x00, 0x00, 0x00, 0x00];
+        assert_eq!(sniff_format(&buf), StreamFormatHint::Mp3);
+        assert!(find_adts_sync_offset(&buf).is_none());
+    }
+
+    #[test]
+    fn hint_from_url_somafm_mp3_suffix() {
+        assert_eq!(
+            hint_from_url("http://ice1.somafm.com/groovesalad-128-mp3"),
+            StreamFormatHint::Mp3
+        );
+    }
 }

--- a/ratune-player/src/stream.rs
+++ b/ratune-player/src/stream.rs
@@ -78,10 +78,7 @@ impl Read for StreamingReader {
                 .unwrap()
         };
         if let Some(err) = self.inner.error.lock().unwrap().clone() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                err,
-            ));
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, err));
         }
         let available = buf.len().saturating_sub(pos);
         if available == 0 {
@@ -142,7 +139,9 @@ pub fn open_live_stream(url: &str) -> Result<StreamingReader> {
 
 fn open_live_stream_resolved(url: &str, depth: u8) -> Result<StreamingReader> {
     if depth >= MAX_PLAYLIST_DEPTH {
-        return Err(anyhow!("playlist redirect limit reached — use a direct stream URL"));
+        return Err(anyhow!(
+            "playlist redirect limit reached — use a direct stream URL"
+        ));
     }
     let likely_aac = hint_from_url(url) == StreamFormatHint::Aac;
     let reader = if likely_aac {
@@ -231,10 +230,7 @@ fn open_stream_with_prebuffer(
         }
         let guard = inner.buf.lock().unwrap();
         let wait_for = Duration::from_millis(200);
-        let (guard, _) = inner
-            .cond
-            .wait_timeout(guard, wait_for)
-            .unwrap();
+        let (guard, _) = inner.cond.wait_timeout(guard, wait_for).unwrap();
         drop(guard);
     }
 
@@ -414,8 +410,7 @@ fn find_mpeg4_adts_sync_offset(buf: &[u8]) -> Option<usize> {
 
 /// Byte offset of the first ADTS sync word (`0xFFF` + layer `00`).
 fn find_adts_sync_offset(buf: &[u8]) -> Option<usize> {
-    buf.windows(2)
-        .position(|w| is_adts_sync(w[0], w[1]))
+    buf.windows(2).position(|w| is_adts_sync(w[0], w[1]))
 }
 
 fn trim_leading_ws(buf: &[u8]) -> &[u8] {
@@ -434,8 +429,7 @@ fn try_resolve_playlist_bytes(buf: &[u8]) -> Result<Option<String>> {
     let trimmed = trim_leading_ws(buf);
     let head = &trimmed[..trimmed.len().min(4096)];
     if head.starts_with(b"#EXTM3U") {
-        let text = std::str::from_utf8(head)
-            .context("playlist is not valid UTF-8")?;
+        let text = std::str::from_utf8(head).context("playlist is not valid UTF-8")?;
         if text.contains("#EXT-X-") || text.to_ascii_lowercase().contains(".m3u8") {
             return Err(anyhow!(
                 "HLS stream (.m3u8) is not supported — find a direct MP3/Icecast URL"
@@ -444,8 +438,7 @@ fn try_resolve_playlist_bytes(buf: &[u8]) -> Result<Option<String>> {
         return Ok(parse_m3u_stream_url(text));
     }
     if head.starts_with(b"[playlist]") {
-        let text = std::str::from_utf8(head)
-            .context("playlist is not valid UTF-8")?;
+        let text = std::str::from_utf8(head).context("playlist is not valid UTF-8")?;
         return Ok(parse_pls_stream_url(text));
     }
     if let Some(url) = parse_bare_stream_url(head) {
@@ -499,7 +492,9 @@ fn parse_bare_stream_url(buf: &[u8]) -> Option<String> {
     }
     let line = text.lines().find(|l| !l.trim().is_empty())?.trim();
     if (line.starts_with("http://") || line.starts_with("https://"))
-        && line.chars().all(|c| !c.is_control() || c == '\r' || c == '\n')
+        && line
+            .chars()
+            .all(|c| !c.is_control() || c == '\r' || c == '\n')
     {
         Some(line.to_string())
     } else {
@@ -581,10 +576,7 @@ mod stream_tests {
             error: Mutex::new(None),
             content_type: Mutex::new(None),
         });
-        let mut reader = StreamingReader {
-            inner,
-            pos: 0,
-        };
+        let mut reader = StreamingReader { inner, pos: 0 };
         let start = Instant::now();
         reader.seek(SeekFrom::End(0)).unwrap();
         assert!(start.elapsed() < Duration::from_secs(1));

--- a/ratune-player/src/stream.rs
+++ b/ratune-player/src/stream.rs
@@ -78,7 +78,7 @@ impl Read for StreamingReader {
                 .unwrap()
         };
         if let Some(err) = self.inner.error.lock().unwrap().clone() {
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, err));
+            return Err(std::io::Error::other(err));
         }
         let available = buf.len().saturating_sub(pos);
         if available == 0 {

--- a/ratune-player/tests/aac_decode.rs
+++ b/ratune-player/tests/aac_decode.rs
@@ -1,0 +1,93 @@
+use std::time::{Duration, Instant};
+
+use ratune_player::{spawn_player, PlayerCommand, PlayerEvent};
+
+#[test]
+#[ignore = "requires network"]
+fn aac_adts_stream_decodes_with_hint() {
+    let url = "http://18073.live.streamtheworld.com:80/WQHTFMAAC_SC";
+    let mut reader = ratune_player::stream::open_live_stream(url).expect("open");
+    let hint = reader.prepare_for_decode(url);
+    assert_eq!(hint.format, ratune_player::stream::StreamFormatHint::Aac);
+
+    let reader = ratune_player::adts_normalize::AdtsNormalizeReader::new(reader);
+    let t0 = Instant::now();
+    let mut builder = rodio::Decoder::builder()
+        .with_data(reader)
+        .with_coarse_seek(true)
+        .with_hint("aac")
+        .with_mime_type("audio/aac");
+    let mut decoder = builder.build().expect("decode");
+    eprintln!("decode in {:?}", t0.elapsed());
+    assert!(decoder.next().is_some());
+}
+
+#[test]
+#[ignore = "requires network"]
+fn spawn_player_plays_aac_stream() {
+    let (tx, rx, handle, _) = spawn_player();
+    tx.send(PlayerCommand::PlayLiveStream {
+        url: "http://18073.live.streamtheworld.com:80/WQHTFMAAC_SC".into(),
+        gen: 1,
+    })
+    .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut started = false;
+    let mut err = None;
+    while Instant::now() < deadline {
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                PlayerEvent::TrackStarted => started = true,
+                PlayerEvent::Error(e) => err = Some(e),
+                _ => {}
+            }
+        }
+        if started || err.is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    tx.send(PlayerCommand::Quit).unwrap();
+    let _ = handle.join();
+
+    if let Some(e) = err {
+        panic!("player error: {e}");
+    }
+    assert!(started, "TrackStarted never received for AAC stream");
+}
+
+#[test]
+#[ignore = "requires network"]
+fn mpeg2_adts_stream_plays() {
+    let (tx, rx, handle, _) = spawn_player();
+    tx.send(PlayerCommand::PlayLiveStream {
+        url: "http://ubuntu.hbr1.com:19800/ambient.aac".into(),
+        gen: 1,
+    })
+    .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(45);
+    let mut started = false;
+    let mut err = None;
+    while Instant::now() < deadline {
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                PlayerEvent::TrackStarted => started = true,
+                PlayerEvent::Error(e) => err = Some(e),
+                _ => {}
+            }
+        }
+        if started || err.is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    tx.send(PlayerCommand::Quit).unwrap();
+    let _ = handle.join();
+
+    if let Some(e) = err {
+        panic!("player error: {e}");
+    }
+    assert!(started, "MPEG-2 ADTS stream should play");
+}

--- a/ratune-player/tests/format_probe.rs
+++ b/ratune-player/tests/format_probe.rs
@@ -1,0 +1,25 @@
+use std::time::{Duration, Instant};
+
+fn probe(url: &str) {
+    eprintln!("\n=== {url} ===");
+    let t0 = Instant::now();
+    let open = ratune_player::stream::open_live_stream(url);
+    eprintln!("open ({:?}): {:?}", t0.elapsed(), open.as_ref().map(|_| "ok").map_err(|e| e.to_string()));
+    let Ok(reader) = open else { return };
+    let t1 = Instant::now();
+    let dec = rodio::Decoder::builder().with_data(reader).build();
+    eprintln!("decode ({:?}): {:?}", t1.elapsed(), dec.as_ref().map(|_| "ok").map_err(|e| e.to_string()));
+    if let Ok(mut d) = dec {
+        let t2 = Instant::now();
+        let s = d.next();
+        eprintln!("first sample ({:?}): {:?}", t2.elapsed(), s.is_some());
+    }
+}
+
+#[test]
+#[ignore = "requires network"]
+fn probe_common_radio_formats() {
+    probe("http://stream.dancewave.online:8080/dance.mp3");
+    probe("https://stream.4zzz.org.au:9200/4zzz");
+    probe("http://ice1.somafm.com/groovesalad-128-mp3");
+}

--- a/ratune-player/tests/format_probe.rs
+++ b/ratune-player/tests/format_probe.rs
@@ -4,11 +4,19 @@ fn probe(url: &str) {
     eprintln!("\n=== {url} ===");
     let t0 = Instant::now();
     let open = ratune_player::stream::open_live_stream(url);
-    eprintln!("open ({:?}): {:?}", t0.elapsed(), open.as_ref().map(|_| "ok").map_err(|e| e.to_string()));
+    eprintln!(
+        "open ({:?}): {:?}",
+        t0.elapsed(),
+        open.as_ref().map(|_| "ok").map_err(|e| e.to_string())
+    );
     let Ok(reader) = open else { return };
     let t1 = Instant::now();
     let dec = rodio::Decoder::builder().with_data(reader).build();
-    eprintln!("decode ({:?}): {:?}", t1.elapsed(), dec.as_ref().map(|_| "ok").map_err(|e| e.to_string()));
+    eprintln!(
+        "decode ({:?}): {:?}",
+        t1.elapsed(),
+        dec.as_ref().map(|_| "ok").map_err(|e| e.to_string())
+    );
     if let Ok(mut d) = dec {
         let t2 = Instant::now();
         let s = d.next();

--- a/ratune-player/tests/live_stream.rs
+++ b/ratune-player/tests/live_stream.rs
@@ -17,7 +17,11 @@ fn live_stream_opens_and_decodes() {
 
     let start = Instant::now();
     let sample = decoder.next();
-    eprintln!("first sample in {:?}: {:?}", start.elapsed(), sample.is_some());
+    eprintln!(
+        "first sample in {:?}: {:?}",
+        start.elapsed(),
+        sample.is_some()
+    );
     assert!(sample.is_some());
     assert!(start.elapsed() < Duration::from_secs(30));
 }
@@ -45,4 +49,3 @@ fn live_stream_decodes_past_prebuffer() {
         "decoder stalled after prebuffer (only {samples} samples in 5s)"
     );
 }
-

--- a/ratune-player/tests/live_stream.rs
+++ b/ratune-player/tests/live_stream.rs
@@ -1,0 +1,48 @@
+use std::time::{Duration, Instant};
+
+#[test]
+#[ignore = "requires network"]
+fn live_stream_opens_and_decodes() {
+    let url = "http://stream.dancewave.online:8080/dance.mp3";
+    let start = Instant::now();
+    let reader = ratune_player::stream::open_live_stream(url).expect("open_live_stream");
+    eprintln!("prebuffer in {:?}", start.elapsed());
+
+    let start = Instant::now();
+    let mut decoder = rodio::Decoder::builder()
+        .with_data(reader)
+        .build()
+        .expect("decoder build");
+    eprintln!("decoder build in {:?}", start.elapsed());
+
+    let start = Instant::now();
+    let sample = decoder.next();
+    eprintln!("first sample in {:?}: {:?}", start.elapsed(), sample.is_some());
+    assert!(sample.is_some());
+    assert!(start.elapsed() < Duration::from_secs(30));
+}
+
+#[test]
+#[ignore = "requires network"]
+fn live_stream_decodes_past_prebuffer() {
+    let url = "http://stream.dancewave.online:8080/dance.mp3";
+    let reader = ratune_player::stream::open_live_stream(url).expect("open");
+    let mut decoder = rodio::Decoder::builder()
+        .with_data(reader)
+        .build()
+        .expect("decode");
+
+    let start = Instant::now();
+    let mut samples = 0u64;
+    while start.elapsed() < Duration::from_secs(5) {
+        if decoder.next().is_some() {
+            samples += 1;
+        }
+    }
+    eprintln!("samples in 5s: {samples}");
+    assert!(
+        samples > 100_000,
+        "decoder stalled after prebuffer (only {samples} samples in 5s)"
+    );
+}
+

--- a/ratune-player/tests/playlist_resolve.rs
+++ b/ratune-player/tests/playlist_resolve.rs
@@ -1,0 +1,43 @@
+use std::time::{Duration, Instant};
+
+use ratune_player::{spawn_player, PlayerCommand, PlayerEvent};
+
+#[test]
+#[ignore = "requires network"]
+fn spawn_player_plays_pls_playlist_url() {
+    let (tx, rx, handle, _) = spawn_player();
+    tx.send(PlayerCommand::PlayLiveStream {
+        url: "http://provisioning.streamtheworld.com/pls/WQHTFM.pls".into(),
+        gen: 1,
+    })
+    .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut started = false;
+    let mut err = None;
+    while Instant::now() < deadline {
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                PlayerEvent::TrackStarted => started = true,
+                PlayerEvent::Error(e) => err = Some(e),
+                _ => {}
+            }
+        }
+        if started || err.is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    tx.send(PlayerCommand::Quit).unwrap();
+    let _ = handle.join();
+
+    if let Some(e) = err {
+        // PLS resolves to an AAC stream on this host — decode may fail, but not at playlist fetch.
+        assert!(
+            !e.contains("stream HTTP error for http://provisioning.streamtheworld.com"),
+            "playlist URL itself should not 404: {e}"
+        );
+        return;
+    }
+    assert!(started, "TrackStarted never received for .pls URL within 30s");
+}

--- a/ratune-player/tests/playlist_resolve.rs
+++ b/ratune-player/tests/playlist_resolve.rs
@@ -39,5 +39,8 @@ fn spawn_player_plays_pls_playlist_url() {
         );
         return;
     }
-    assert!(started, "TrackStarted never received for .pls URL within 30s");
+    assert!(
+        started,
+        "TrackStarted never received for .pls URL within 30s"
+    );
 }

--- a/ratune-player/tests/spawn_aac_fail.rs
+++ b/ratune-player/tests/spawn_aac_fail.rs
@@ -1,5 +1,5 @@
-use std::time::{Duration, Instant};
 use ratune_player::{spawn_player, PlayerCommand, PlayerEvent};
+use std::time::{Duration, Instant};
 
 #[test]
 #[ignore = "requires network"]
@@ -8,14 +8,19 @@ fn spawn_player_reports_decode_error_for_unsupported() {
     tx.send(PlayerCommand::PlayLiveStream {
         url: "https://stream.4zzz.org.au:9200/4zzz".into(),
         gen: 1,
-    }).unwrap();
+    })
+    .unwrap();
     let deadline = Instant::now() + Duration::from_secs(45);
     let mut err = None;
     while Instant::now() < deadline {
         while let Ok(ev) = rx.try_recv() {
-            if let PlayerEvent::Error(e) = ev { err = Some(e); }
+            if let PlayerEvent::Error(e) = ev {
+                err = Some(e);
+            }
         }
-        if err.is_some() { break; }
+        if err.is_some() {
+            break;
+        }
         std::thread::sleep(Duration::from_millis(50));
     }
     tx.send(PlayerCommand::Quit).unwrap();

--- a/ratune-player/tests/spawn_aac_fail.rs
+++ b/ratune-player/tests/spawn_aac_fail.rs
@@ -1,0 +1,25 @@
+use std::time::{Duration, Instant};
+use ratune_player::{spawn_player, PlayerCommand, PlayerEvent};
+
+#[test]
+#[ignore = "requires network"]
+fn spawn_player_reports_decode_error_for_unsupported() {
+    let (tx, rx, handle, _) = spawn_player();
+    tx.send(PlayerCommand::PlayLiveStream {
+        url: "https://stream.4zzz.org.au:9200/4zzz".into(),
+        gen: 1,
+    }).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(45);
+    let mut err = None;
+    while Instant::now() < deadline {
+        while let Ok(ev) = rx.try_recv() {
+            if let PlayerEvent::Error(e) = ev { err = Some(e); }
+        }
+        if err.is_some() { break; }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    tx.send(PlayerCommand::Quit).unwrap();
+    let _ = handle.join();
+    eprintln!("error: {:?}", err);
+    assert!(err.is_some(), "expected Error event within 45s");
+}

--- a/ratune-player/tests/spawn_live.rs
+++ b/ratune-player/tests/spawn_live.rs
@@ -1,0 +1,38 @@
+use std::time::{Duration, Instant};
+
+use ratune_player::{spawn_player, PlayerCommand, PlayerEvent};
+
+#[test]
+#[ignore = "requires network"]
+fn spawn_player_plays_live_stream() {
+    let (tx, rx, handle, _samples) = spawn_player();
+    tx.send(PlayerCommand::PlayLiveStream {
+        url: "http://stream.dancewave.online:8080/dance.mp3".into(),
+        gen: 1,
+    })
+    .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut started = false;
+    let mut err = None;
+    while Instant::now() < deadline {
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                PlayerEvent::TrackStarted => started = true,
+                PlayerEvent::Error(e) => err = Some(e),
+                _ => {}
+            }
+        }
+        if started || err.is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    tx.send(PlayerCommand::Quit).unwrap();
+    let _ = handle.join();
+
+    if let Some(e) = err {
+        panic!("player error: {e}");
+    }
+    assert!(started, "TrackStarted never received within 30s");
+}

--- a/ratune-subsonic/src/client.rs
+++ b/ratune-subsonic/src/client.rs
@@ -27,10 +27,11 @@ use crate::error::check_status;
 use crate::models::{
     parse_music_library_root_folder_id, structured_lyrics_to_lines, Album, AlbumEnvelope, Artist,
     ArtistEnvelope, Artists, ArtistsEnvelope, DirectoryChild, IndexesEnvelope,
-    LegacyLyricsEnvelope, LyricLine, LyricsBySongIdEnvelope, MusicDirectory,
-    MusicDirectoryEnvelope, MusicFolder, MusicFoldersEnvelope, PingEnvelope, Playlist,
-    PlaylistDetail, PlaylistEnvelope, PlaylistsEnvelope, ScanStatus, ScanStatusEnvelope,
-    SearchEnvelope, SearchResult3, Song, SongEnvelope, Starred2, Starred2Envelope, SubsonicLibrary,
+    InternetRadioStation, InternetRadioStationsEnvelope, LegacyLyricsEnvelope, LyricLine,
+    LyricsBySongIdEnvelope, MusicDirectory, MusicDirectoryEnvelope, MusicFolder,
+    MusicFoldersEnvelope, PingEnvelope, Playlist, PlaylistDetail, PlaylistEnvelope,
+    PlaylistsEnvelope, ScanStatus, ScanStatusEnvelope, SearchEnvelope, SearchResult3, Song,
+    SongEnvelope, Starred2, Starred2Envelope, SubsonicLibrary,
 };
 
 // ── Constants ──────────────────────────────────────────────────────────────────
@@ -40,6 +41,13 @@ pub const DEFAULT_SERVER_URL: &str = "http://localhost:4533";
 
 const API_VERSION: &str = "1.16.1";
 const CLIENT_NAME: &str = "ratune";
+
+/// HTTP User-Agent for Subsonic API and external image fetches (some sites block `reqwest/*`).
+pub const USER_AGENT: &str = concat!(
+    "Mozilla/5.0 (compatible; ratune/",
+    env!("CARGO_PKG_VERSION"),
+    "; +https://github.com/acmagn/ratune)"
+);
 
 /// Kind of library item for [`SubsonicClient::set_starred`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,6 +149,7 @@ impl SubsonicClient {
     /// Trailing slashes are stripped automatically.
     pub fn new(base_url: &str, username: &str, password: &str) -> Result<Self> {
         let http = ClientBuilder::new()
+            .user_agent(USER_AGENT)
             .timeout(Duration::from_secs(30))
             .build()?;
         Ok(Self {
@@ -494,6 +503,13 @@ impl SubsonicClient {
         Ok(bytes.to_vec())
     }
 
+    /// Fetch arbitrary image bytes from an external URL (e.g. station favicon).
+    pub async fn fetch_external_bytes(&self, url: &str) -> Result<Vec<u8>> {
+        let response = self.http.get(url).send().await?.error_for_status()?;
+        let bytes = response.bytes().await?;
+        Ok(bytes.to_vec())
+    }
+
     /// Fetch all playlists visible to the authenticated user (`getPlaylists`).
     pub async fn get_playlists(&self) -> Result<Vec<Playlist>> {
         let env: PlaylistsEnvelope = self
@@ -617,6 +633,89 @@ impl SubsonicClient {
         let env: PingEnvelope = self
             .http
             .get(self.endpoint_url("deletePlaylist"))
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        check_status(&env.response.status, env.response.error.as_ref())
+    }
+
+    /// List internet radio stations configured on the server (`getInternetRadioStations`).
+    pub async fn get_internet_radio_stations(&self) -> Result<Vec<InternetRadioStation>> {
+        let env: InternetRadioStationsEnvelope = self
+            .http
+            .get(self.endpoint_url("getInternetRadioStations"))
+            .query(&self.auth_params())
+            .send()
+            .await?
+            .json()
+            .await?;
+        let r = &env.response;
+        check_status(&r.status, r.error.as_ref())?;
+        Ok(r.internet_radio_stations
+            .as_ref()
+            .map(|c| c.internet_radio_station.clone())
+            .unwrap_or_default())
+    }
+
+    /// Add an internet radio station (`createInternetRadioStation`). Admin only.
+    pub async fn create_internet_radio_station(
+        &self,
+        name: &str,
+        stream_url: &str,
+        home_page_url: Option<&str>,
+    ) -> Result<()> {
+        let mut params = self.auth_params();
+        params.push(("name", name.to_string()));
+        params.push(("streamUrl", stream_url.to_string()));
+        if let Some(url) = home_page_url.filter(|s| !s.is_empty()) {
+            params.push(("homepageUrl", url.to_string()));
+        }
+        let env: PingEnvelope = self
+            .http
+            .get(self.endpoint_url("createInternetRadioStation"))
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        check_status(&env.response.status, env.response.error.as_ref())
+    }
+
+    /// Update an internet radio station (`updateInternetRadioStation`). Admin only.
+    pub async fn update_internet_radio_station(
+        &self,
+        id: &str,
+        name: &str,
+        stream_url: &str,
+        home_page_url: Option<&str>,
+    ) -> Result<()> {
+        let mut params = self.auth_params();
+        params.push(("id", id.to_string()));
+        params.push(("name", name.to_string()));
+        params.push(("streamUrl", stream_url.to_string()));
+        if let Some(url) = home_page_url.filter(|s| !s.is_empty()) {
+            params.push(("homepageUrl", url.to_string()));
+        }
+        let env: PingEnvelope = self
+            .http
+            .get(self.endpoint_url("updateInternetRadioStation"))
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        check_status(&env.response.status, env.response.error.as_ref())
+    }
+
+    /// Delete an internet radio station (`deleteInternetRadioStation`). Admin only.
+    pub async fn delete_internet_radio_station(&self, id: &str) -> Result<()> {
+        let mut params = self.auth_params();
+        params.push(("id", id.to_string()));
+        let env: PingEnvelope = self
+            .http
+            .get(self.endpoint_url("deleteInternetRadioStation"))
             .query(&params)
             .send()
             .await?

--- a/ratune-subsonic/src/lib.rs
+++ b/ratune-subsonic/src/lib.rs
@@ -9,7 +9,7 @@ pub use client::{
 pub use error::{is_auth_failure, SubsonicError, AUTH_ERROR_CODE};
 pub use models::{
     music_library_root_cache_key, parse_music_library_root_folder_id, Album, Artist, ArtistIndex,
-    Artists, DirectoryChild, Indexes, LyricLine, MusicDirectory, MusicFolder, Playlist,
-    PlaylistDetail, ScanStatus, SearchResult3, Song, Starred2, SubsonicLibrary,
-    MUSIC_FOLDER_ROOT_ID_PREFIX,
+    Artists, DirectoryChild, Indexes, InternetRadioStation, LyricLine, MusicDirectory,
+    MusicFolder, Playlist, PlaylistDetail, ScanStatus, SearchResult3, Song, Starred2,
+    SubsonicLibrary, MUSIC_FOLDER_ROOT_ID_PREFIX,
 };

--- a/ratune-subsonic/src/lib.rs
+++ b/ratune-subsonic/src/lib.rs
@@ -9,7 +9,7 @@ pub use client::{
 pub use error::{is_auth_failure, SubsonicError, AUTH_ERROR_CODE};
 pub use models::{
     music_library_root_cache_key, parse_music_library_root_folder_id, Album, Artist, ArtistIndex,
-    Artists, DirectoryChild, Indexes, InternetRadioStation, LyricLine, MusicDirectory,
-    MusicFolder, Playlist, PlaylistDetail, ScanStatus, SearchResult3, Song, Starred2,
-    SubsonicLibrary, MUSIC_FOLDER_ROOT_ID_PREFIX,
+    Artists, DirectoryChild, Indexes, InternetRadioStation, LyricLine, MusicDirectory, MusicFolder,
+    Playlist, PlaylistDetail, ScanStatus, SearchResult3, Song, Starred2, SubsonicLibrary,
+    MUSIC_FOLDER_ROOT_ID_PREFIX,
 };

--- a/ratune-subsonic/src/models.rs
+++ b/ratune-subsonic/src/models.rs
@@ -173,6 +173,80 @@ pub struct PlaylistDetail {
     pub songs: Vec<Song>,
 }
 
+/// An internet radio station from `getInternetRadioStations`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InternetRadioStation {
+    pub id: String,
+    pub name: String,
+    pub stream_url: String,
+    pub home_page_url: Option<String>,
+    /// OpenSubsonic / Navidrome uploaded image — pass to `getCoverArt`.
+    pub cover_art: Option<String>,
+}
+
+impl InternetRadioStation {
+    /// Stable cache key for now-playing art (not always a `getCoverArt` id).
+    #[must_use]
+    pub fn art_cache_key(&self) -> String {
+        format!("radio:{}", self.id)
+    }
+
+    /// Navidrome `getCoverArt` id when the station has an uploaded logo.
+    #[must_use]
+    pub fn uploaded_cover_art_id(&self) -> Option<&str> {
+        self.cover_art.as_deref().filter(|id| !id.is_empty())
+    }
+
+    /// Hostname for the now-playing subtitle (from `homePageUrl`).
+    #[must_use]
+    pub fn display_subtitle(&self) -> Option<String> {
+        self.home_page_url.as_ref().and_then(|u| {
+            url::Url::parse(u)
+                .ok()
+                .and_then(|p| p.host_str().map(str::to_string))
+        })
+    }
+
+    /// Favicon URL used by Navidrome when no uploaded station image exists.
+    #[must_use]
+    pub fn favicon_url(&self) -> Option<String> {
+        Self::site_origin(
+            self.home_page_url
+                .as_deref()
+                .or(Some(self.stream_url.as_str()))?,
+        )
+        .map(|origin| format!("{origin}/favicon.ico"))
+    }
+
+    /// Homepage logo candidates, best/largest sources first (`apple-touch-icon` then favicon).
+    #[must_use]
+    pub fn station_icon_urls(&self) -> Vec<String> {
+        let base = self
+            .home_page_url
+            .as_deref()
+            .or(Some(self.stream_url.as_str()));
+        let Some(origin) = base.and_then(Self::site_origin) else {
+            return Vec::new();
+        };
+        [
+            format!("{origin}/apple-touch-icon.png"),
+            format!("{origin}/apple-touch-icon-precomposed.png"),
+            format!("{origin}/favicon.ico"),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn site_origin(base: &str) -> Option<String> {
+        let mut parsed = url::Url::parse(base).ok()?;
+        parsed.set_path("/");
+        parsed.set_query(None);
+        parsed.set_fragment(None);
+        Some(parsed.as_str().trim_end_matches('/').to_string())
+    }
+}
+
 /// Combined search result from `search3`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct SearchResult3 {
@@ -564,6 +638,48 @@ impl Starred2 {
     }
 }
 
+fn deserialize_internet_radio_station_list<'de, D>(
+    deserializer: D,
+) -> Result<Vec<InternetRadioStation>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        Single(InternetRadioStation),
+        List(Vec<InternetRadioStation>),
+    }
+    match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::Single(o) => Ok(vec![o]),
+        OneOrMany::List(v) => Ok(v),
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct InternetRadioStationsContainer {
+    #[serde(
+        default,
+        rename = "internetRadioStation",
+        deserialize_with = "deserialize_internet_radio_station_list"
+    )]
+    pub internet_radio_station: Vec<InternetRadioStation>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct InternetRadioStationsEnvelope {
+    #[serde(rename = "subsonic-response")]
+    pub response: InternetRadioStationsBody,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct InternetRadioStationsBody {
+    pub status: String,
+    pub error: Option<SubsonicError>,
+    #[serde(rename = "internetRadioStations")]
+    pub internet_radio_stations: Option<InternetRadioStationsContainer>,
+}
+
 #[derive(Deserialize)]
 pub(crate) struct Starred2Envelope {
     #[serde(rename = "subsonic-response")]
@@ -734,6 +850,109 @@ mod tests {
         let starred = starred.normalize();
         assert_eq!(starred.songs().len(), 1);
         assert_eq!(starred.songs()[0].id, "1");
+    }
+
+    #[test]
+    fn deserialize_internet_radio_stations_envelope() {
+        let j = r#"{
+            "subsonic-response": {
+                "status": "ok",
+                "internetRadioStations": {
+                    "internetRadioStation": [
+                        {
+                            "id": "1",
+                            "name": "Dream Factory",
+                            "streamUrl": "http://example.com/stream.aac",
+                            "homePageUrl": "http://example.com/"
+                        },
+                        {
+                            "id": "2",
+                            "name": "Solo Station",
+                            "streamUrl": "http://example.com/solo.ogg"
+                        }
+                    ]
+                }
+            }
+        }"#;
+        let env: InternetRadioStationsEnvelope = serde_json::from_str(j).unwrap();
+        assert_eq!(env.response.status, "ok");
+        let stations = env
+            .response
+            .internet_radio_stations
+            .unwrap()
+            .internet_radio_station;
+        assert_eq!(stations.len(), 2);
+        assert_eq!(stations[0].name, "Dream Factory");
+        assert_eq!(stations[0].stream_url, "http://example.com/stream.aac");
+        assert_eq!(stations[1].home_page_url, None);
+    }
+
+    #[test]
+    fn internet_radio_station_art_cache_key() {
+        let s = InternetRadioStation {
+            id: "rd-1".into(),
+            name: "Test".into(),
+            stream_url: "http://x/stream".into(),
+            home_page_url: None,
+            cover_art: Some("ra-rd-1_abc".into()),
+        };
+        assert_eq!(s.art_cache_key(), "radio:rd-1");
+        assert_eq!(s.uploaded_cover_art_id(), Some("ra-rd-1_abc"));
+        let s2 = InternetRadioStation {
+            cover_art: None,
+            ..s
+        };
+        assert_eq!(s2.uploaded_cover_art_id(), None);
+        let s3 = InternetRadioStation {
+            cover_art: Some(String::new()),
+            ..s2
+        };
+        assert_eq!(s3.uploaded_cover_art_id(), None);
+    }
+
+    #[test]
+    fn deserialize_radio_station_with_cover_art() {
+        let j = r#"{"id":"1","name":"FM","streamUrl":"http://x/aac","coverArt":"ra-1_0"}"#;
+        let s: InternetRadioStation = serde_json::from_str(j).unwrap();
+        assert_eq!(s.cover_art.as_deref(), Some("ra-1_0"));
+    }
+
+    #[test]
+    fn internet_radio_station_favicon_url_from_homepage() {
+        let s = InternetRadioStation {
+            id: "1".into(),
+            name: "YourClassical".into(),
+            stream_url: "http://stream.example/aac".into(),
+            home_page_url: Some("https://www.yourclassical.org".into()),
+            cover_art: None,
+        };
+        assert_eq!(
+            s.favicon_url().as_deref(),
+            Some("https://www.yourclassical.org/favicon.ico")
+        );
+        assert_eq!(
+            s.station_icon_urls(),
+            vec![
+                "https://www.yourclassical.org/apple-touch-icon.png".to_string(),
+                "https://www.yourclassical.org/apple-touch-icon-precomposed.png".to_string(),
+                "https://www.yourclassical.org/favicon.ico".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn internet_radio_station_icon_urls_from_homepage_with_path() {
+        let s = InternetRadioStation {
+            id: "1".into(),
+            name: "Site".into(),
+            stream_url: "http://stream.example/aac".into(),
+            home_page_url: Some("https://www.example.com/listen/live".into()),
+            cover_art: None,
+        };
+        assert_eq!(
+            s.station_icon_urls().first().map(String::as_str),
+            Some("https://www.example.com/apple-touch-icon.png")
+        );
     }
 
     #[test]

--- a/ratune/examples/radio_art_probe.rs
+++ b/ratune/examples/radio_art_probe.rs
@@ -1,0 +1,78 @@
+//! Probe radio station icon URL build + HTTP fetch + image decode (no TUI).
+//!
+//! ```text
+//! cargo run -p ratune --example radio_art_probe -- https://www.yourclassical.org
+//! ```
+
+use anyhow::{Context, Result};
+use ratune_subsonic::InternetRadioStation;
+
+fn main() -> Result<()> {
+    let homepage = std::env::args()
+        .nth(1)
+        .context("usage: radio_art_probe <homepage-url> [stream-url]")?;
+    let stream_url = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "http://127.0.0.1/stream".into());
+
+    let station = InternetRadioStation {
+        id: "probe".into(),
+        name: "probe".into(),
+        stream_url,
+        home_page_url: Some(homepage.clone()),
+        cover_art: None,
+    };
+
+    println!("homepage:   {homepage}");
+    println!("cache key:  {}", station.art_cache_key());
+    for url in station.station_icon_urls() {
+        println!("candidate:  {url}");
+    }
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let client = reqwest::Client::builder()
+            .user_agent(ratune_subsonic::client::USER_AGENT)
+            .timeout(std::time::Duration::from_secs(15))
+            .build()?;
+
+        let mut best: Option<(String, usize, u32, u32, u32)> = None;
+        for url in station.station_icon_urls() {
+            let resp = client.get(&url).send().await;
+            let Ok(resp) = resp else {
+                println!("{url}: request failed");
+                continue;
+            };
+            if !resp.status().is_success() {
+                println!("{url}: HTTP {}", resp.status());
+                continue;
+            }
+            let bytes = resp.bytes().await?.to_vec();
+            let Some(img) = image::load_from_memory(&bytes).ok() else {
+                println!("{url}: {} bytes, decode failed", bytes.len());
+                continue;
+            };
+            let area = img.width().saturating_mul(img.height());
+            println!(
+                "{url}: {} bytes, {}x{}",
+                bytes.len(),
+                img.width(),
+                img.height()
+            );
+            if best
+                .as_ref()
+                .map(|(_, _, _, _, best_area)| area > *best_area)
+                .unwrap_or(true)
+            {
+                best = Some((url, bytes.len(), img.width(), img.height(), area));
+            }
+        }
+
+        let Some((url, nbytes, w, h, _)) = best else {
+            anyhow::bail!("no decodable icon from homepage");
+        };
+        println!("picked:     {url} ({nbytes} bytes, {w}x{h})");
+        Ok::<(), anyhow::Error>(())
+    })?;
+    Ok(())
+}

--- a/ratune/src/action.rs
+++ b/ratune/src/action.rs
@@ -15,9 +15,9 @@ pub enum Action {
     Navigate(Direction),
     Select,
     Back,
-    /// Cycle tabs forward: Home → Browser → NowPlaying → Home (Tab key)
+    /// Cycle tabs forward: Home → Browser → Now Playing → Home (Tab key)
     SwitchTab,
-    /// Cycle tabs backward: Home → NowPlaying → Browser → Home (Backtick / Shift+Tab)
+    /// Cycle tabs backward: Home → Now Playing → Browser → Home (Backtick / Shift+Tab)
     SwitchTabReverse,
     /// Jump directly to Home tab (key '1')
     GoToHome,
@@ -27,6 +27,12 @@ pub enum Action {
     ToggleBrowserFolder,
     /// Jump directly to NowPlaying tab (key '3')
     GoToNowPlaying,
+    /// Open or close the internet radio station picker (default: Shift+R).
+    ToggleRadioPicker,
+    /// Play the selected station from the radio picker and close it.
+    RadioPickerSelect,
+    /// Close the radio picker without playing.
+    RadioPickerCancel,
     FocusLeft,
     FocusRight,
     AddToQueue,
@@ -49,6 +55,8 @@ pub enum Action {
     Unshuffle,
     /// Toggle whether the queue loops after the last track (↻ control).
     ToggleQueueLoop,
+    /// Toggle Now Playing pane focus between live radio and library queue.
+    ToggleNpPaneFocus,
     SeekForward,
     SeekBackward,
     /// Seek to an exact position (used by progress-bar clicks).
@@ -92,6 +100,28 @@ pub enum Action {
     HomeSectionPrev,
     /// Refresh Home tab data (re-rolls rediscover suggestions).
     HomeRefresh,
+    /// Refresh internet radio stations while the picker is open.
+    RadioRefresh,
+    /// Open the new-station form on the Radio tab.
+    RadioCreate,
+    /// Open the edit-station form for the selected station.
+    RadioEdit,
+    /// Prompt to delete the selected station.
+    RadioDelete,
+    /// Move to the next field in the radio station form.
+    RadioFieldNext,
+    /// Move to the previous field in the radio station form.
+    RadioFieldPrev,
+    /// Submit the radio station form.
+    RadioInputConfirm,
+    /// Cancel the radio station form or delete prompt.
+    RadioInputCancel,
+    /// Feed a character into the focused radio form field.
+    RadioInputChar(char),
+    /// Confirm deleting a radio station.
+    RadioConfirmYes,
+    /// Cancel deleting a radio station.
+    RadioConfirmNo,
     /// Navigate the art strip left (decrement selected album).
     HomeAlbumLeft,
     /// Navigate the art strip right (increment selected album).

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -24,8 +24,8 @@ use crate::keybinds::Keybinds;
 use crate::state::{
     folder_left_default_row, folder_preview_rows, ConfirmAction, DirectoryListing,
     FavoritesCategory, FavoritesFocus, FavoritesOverlay, FolderBrowseState, FolderPreviewRow,
-    GlobalConfirm, LibraryState, LoadingState, NowPlayingPaneFocus, PlaybackState, PlaylistFocus, PlaylistInputMode,
-    PlaylistOverlay, QueueState, RadioField, RadioInputMode, RadioState,
+    GlobalConfirm, LibraryState, LoadingState, NowPlayingPaneFocus, PlaybackState, PlaylistFocus,
+    PlaylistInputMode, PlaylistOverlay, QueueState, RadioField, RadioInputMode, RadioState,
 };
 use crate::theme::Theme;
 use image::{imageops::FilterType, DynamicImage};
@@ -73,7 +73,8 @@ fn humanize_playback_error(message: &str) -> String {
         return "Playback failed: OGG stream could not start".to_string();
     }
     if lower.contains("playlist redirect limit") {
-        return "Playback failed: too many playlist redirects — use a direct stream URL".to_string();
+        return "Playback failed: too many playlist redirects — use a direct stream URL"
+            .to_string();
     }
     if lower.contains("m3u playlist") || lower.contains("pls playlist") {
         return "Playback failed: use a direct stream URL, not a playlist file".to_string();
@@ -994,11 +995,7 @@ impl App {
     /// Cover art id for the track shown in now playing (`Song::cover_art`).
     #[must_use]
     pub fn expected_cover_art_id(&self) -> Option<&str> {
-        self.playback
-            .current_song
-            .as_ref()?
-            .cover_art
-            .as_deref()
+        self.playback.current_song.as_ref()?.cover_art.as_deref()
     }
 
     /// True when `art_cache` belongs to the current now-playing track (not a stale queue fetch).
@@ -2282,15 +2279,14 @@ impl App {
             let flash = |msg: String| async {
                 crate::debug::log(&msg);
                 if crate::debug::enabled() {
-                    let _ = tx
-                        .send(LibraryUpdate::StatusFlash { msg, secs: 6 })
-                        .await;
+                    let _ = tx.send(LibraryUpdate::StatusFlash { msg, secs: 6 }).await;
                 }
             };
             if let Some(ref id) = uploaded_id {
                 match client.get_cover_art(id).await {
-                    Ok(bytes) if !bytes.is_empty()
-                        && crate::ui::art_prepare::art_bytes_decode(&bytes).is_some() =>
+                    Ok(bytes)
+                        if !bytes.is_empty()
+                            && crate::ui::art_prepare::art_bytes_decode(&bytes).is_some() =>
                     {
                         crate::debug::log(format!(
                             "radio art: using uploaded cover {id} ({} bytes)",
@@ -2700,10 +2696,7 @@ impl App {
                 if expected != Some(cover_id.as_str()) {
                     crate::debug::log(format!(
                         "cover art discarded: got {cover_id}, expected {expected:?} (current={:?})",
-                        self.playback
-                            .current_song
-                            .as_ref()
-                            .map(|s| s.id.as_str())
+                        self.playback.current_song.as_ref().map(|s| s.id.as_str())
                     ));
                     return;
                 }
@@ -3096,7 +3089,7 @@ impl App {
                     }
                     Err(e) => self.flash_status_secs(format!("Radio: {e}"), 5),
                 }
-            },
+            }
         }
     }
 
@@ -3261,9 +3254,7 @@ impl App {
                                 || self
                                     .art_cache
                                     .as_ref()
-                                    .is_some_and(|(cached_id, _)| {
-                                        cached_id == &cache_key
-                                    })
+                                    .is_some_and(|(cached_id, _)| cached_id == &cache_key)
                                     && self.art_cache_decoded.is_none();
                             if needs_fetch {
                                 self.apply_dynamic_accent(None);
@@ -3846,7 +3837,9 @@ impl App {
             _ => return,
         };
         let new_sel = if delta < 0 {
-            self.radio.selected.saturating_sub(delta.unsigned_abs() as usize)
+            self.radio
+                .selected
+                .saturating_sub(delta.unsigned_abs() as usize)
         } else {
             (self.radio.selected + delta as usize).min(len - 1)
         };
@@ -3949,11 +3942,7 @@ impl App {
                 stream_url,
                 home_page_url,
                 ..
-            } => Some((
-                name.as_str(),
-                stream_url.as_str(),
-                home_page_url.as_str(),
-            )),
+            } => Some((name.as_str(), stream_url.as_str(), home_page_url.as_str())),
             _ => None,
         }
     }
@@ -4057,40 +4046,38 @@ impl App {
                     }
                 }
             }
-            Action::RadioInputConfirm => {
-                match self.radio.input_mode.clone() {
-                    RadioInputMode::Creating {
-                        name,
-                        stream_url,
-                        home_page_url,
-                        ..
-                    } if Self::radio_form_is_valid(&self.radio.input_mode) => {
-                        let home = home_page_url.trim();
-                        self.spawn_save_radio_station(
-                            None,
-                            name.trim().to_string(),
-                            stream_url.trim().to_string(),
-                            (!home.is_empty()).then(|| home.to_string()),
-                        );
-                    }
-                    RadioInputMode::Editing {
-                        station_id,
-                        name,
-                        stream_url,
-                        home_page_url,
-                        ..
-                    } if Self::radio_form_is_valid(&self.radio.input_mode) => {
-                        let home = home_page_url.trim();
-                        self.spawn_save_radio_station(
-                            Some(station_id),
-                            name.trim().to_string(),
-                            stream_url.trim().to_string(),
-                            (!home.is_empty()).then(|| home.to_string()),
-                        );
-                    }
-                    _ => {}
+            Action::RadioInputConfirm => match self.radio.input_mode.clone() {
+                RadioInputMode::Creating {
+                    name,
+                    stream_url,
+                    home_page_url,
+                    ..
+                } if Self::radio_form_is_valid(&self.radio.input_mode) => {
+                    let home = home_page_url.trim();
+                    self.spawn_save_radio_station(
+                        None,
+                        name.trim().to_string(),
+                        stream_url.trim().to_string(),
+                        (!home.is_empty()).then(|| home.to_string()),
+                    );
                 }
-            }
+                RadioInputMode::Editing {
+                    station_id,
+                    name,
+                    stream_url,
+                    home_page_url,
+                    ..
+                } if Self::radio_form_is_valid(&self.radio.input_mode) => {
+                    let home = home_page_url.trim();
+                    self.spawn_save_radio_station(
+                        Some(station_id),
+                        name.trim().to_string(),
+                        stream_url.trim().to_string(),
+                        (!home.is_empty()).then(|| home.to_string()),
+                    );
+                }
+                _ => {}
+            },
             Action::RadioInputCancel => {
                 self.radio.input_mode = RadioInputMode::Normal;
             }
@@ -4889,7 +4876,13 @@ impl App {
             }
             Action::AddAllToQueuePrepend => self.handle_add_all_to_queue(AddAllMode::Prepend),
             Action::PlayPause => {
-                if self.is_playing_radio() || self.playback.current_song.as_ref().is_some_and(Self::is_radio_song) {
+                if self.is_playing_radio()
+                    || self
+                        .playback
+                        .current_song
+                        .as_ref()
+                        .is_some_and(Self::is_radio_song)
+                {
                     if !self.playback.player_loaded {
                         self.play_selected_radio_station();
                     } else if self.playback.paused {
@@ -5450,12 +5443,7 @@ impl App {
             Direction::PageUp => self.radio.selected.saturating_sub(page),
             Direction::PageDown => (self.radio.selected + page).min(len - 1),
         };
-        LibraryState::clamp_vertical_scroll(
-            &mut self.radio.scroll,
-            self.radio.selected,
-            len,
-            page,
-        );
+        LibraryState::clamp_vertical_scroll(&mut self.radio.scroll, self.radio.selected, len, page);
     }
 
     fn handle_navigate_home(&mut self, dir: Direction) {

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc;
 use tokio::sync::Semaphore;
 
 use ratune_player::{spawn_player, PlayerCommand, PlayerEvent, SampleBuffer};
-use ratune_subsonic::{StarItemType, SubsonicClient};
+use ratune_subsonic::{InternetRadioStation, StarItemType, SubsonicClient};
 
 use serde::{Deserialize, Serialize};
 
@@ -24,8 +24,8 @@ use crate::keybinds::Keybinds;
 use crate::state::{
     folder_left_default_row, folder_preview_rows, ConfirmAction, DirectoryListing,
     FavoritesCategory, FavoritesFocus, FavoritesOverlay, FolderBrowseState, FolderPreviewRow,
-    GlobalConfirm, LibraryState, LoadingState, PlaybackState, PlaylistFocus, PlaylistInputMode,
-    PlaylistOverlay, QueueState,
+    GlobalConfirm, LibraryState, LoadingState, NowPlayingPaneFocus, PlaybackState, PlaylistFocus, PlaylistInputMode,
+    PlaylistOverlay, QueueState, RadioField, RadioInputMode, RadioState,
 };
 use crate::theme::Theme;
 use image::{imageops::FilterType, DynamicImage};
@@ -56,6 +56,36 @@ fn humanize_playback_error(message: &str) -> String {
         || lower.contains("dns")
     {
         return "Playback failed: network error".to_string();
+    }
+    if lower.contains("decoding live stream") || lower.contains("format of the data") {
+        return "Playback failed: radio stream format not supported".to_string();
+    }
+    if lower.contains("live stream timed out") || lower.contains("timed out during decode") {
+        return "Playback failed: radio stream timed out".to_string();
+    }
+    if lower.contains("hls stream") || lower.contains(".m3u8") {
+        return "Playback failed: HLS streams are not supported".to_string();
+    }
+    if lower.contains("aac radio stream") {
+        return "Playback failed: AAC stream could not start".to_string();
+    }
+    if lower.contains("ogg radio stream") {
+        return "Playback failed: OGG stream could not start".to_string();
+    }
+    if lower.contains("playlist redirect limit") {
+        return "Playback failed: too many playlist redirects — use a direct stream URL".to_string();
+    }
+    if lower.contains("m3u playlist") || lower.contains("pls playlist") {
+        return "Playback failed: use a direct stream URL, not a playlist file".to_string();
+    }
+    if lower.contains("returned a web page") {
+        return "Playback failed: stream URL is not audio (check the station URL)".to_string();
+    }
+    if lower.contains("stream prebuffer timeout") {
+        return "Playback failed: radio stream too slow to start (retry)".to_string();
+    }
+    if lower.contains("stream returned no data") {
+        return "Playback failed: radio stream returned no data".to_string();
     }
     if lower.contains("enqueue error") {
         return "Next track: download failed".to_string();
@@ -90,15 +120,34 @@ enum ResolvedPlayback {
     Cached(PathBuf),
 }
 
+/// Prefix for synthetic [`Song::id`] values built from internet radio stations.
+pub const RADIO_SONG_ID_PREFIX: &str = "radio:";
+
 // ── Tab ───────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Tab {
     #[default]
     Home,
     Browser,
     NowPlaying,
+}
+
+impl<'de> Deserialize<'de> for Tab {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "home" => Tab::Home,
+            "browser" => Tab::Browser,
+            "now_playing" => Tab::NowPlaying,
+            "radio" => Tab::NowPlaying,
+            _ => Tab::Home,
+        })
+    }
 }
 
 impl Tab {
@@ -265,6 +314,11 @@ pub enum LibraryUpdate {
         cover_id: String,
         bytes: Vec<u8>,
     },
+    /// Brief status line (used for `RATUNE_DEBUG` diagnostics from background tasks).
+    StatusFlash {
+        msg: String,
+        secs: u64,
+    },
     /// Lyrics fetched for a song; `lines` is empty when the track has no lyrics.
     Lyrics {
         song_id: String,
@@ -356,6 +410,10 @@ pub enum LibraryUpdate {
         reachable: bool,
         forced: bool,
     },
+    /// Internet radio stations from `getInternetRadioStations`.
+    RadioStations(Result<Vec<InternetRadioStation>, String>),
+    /// Create / update / delete internet radio station finished.
+    RadioMutation(Result<(), String>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -407,6 +465,9 @@ pub struct App {
     pub active_tab: Tab,
     pub browser_focus: BrowserColumn,
     pub library: LibraryState,
+    pub radio: RadioState,
+    /// Now Playing tab: which pane receives j/k and the active border while radio is on.
+    pub np_pane_focus: NowPlayingPaneFocus,
     pub folders: FolderBrowseState,
     pub queue: QueueState,
     pub playback: PlaybackState,
@@ -679,6 +740,8 @@ impl App {
             active_tab: Tab::Home,
             browser_focus: BrowserColumn::Artists,
             library: LibraryState::default(),
+            radio: RadioState::default(),
+            np_pane_focus: NowPlayingPaneFocus::Queue,
             folders: FolderBrowseState::default(),
             queue: QueueState {
                 loop_enabled: config.queue_loop,
@@ -780,6 +843,10 @@ impl App {
             mpris: None,
         };
         app.load_persisted_favorites();
+        if !app.config.radio_enabled {
+            app.close_radio_picker();
+            app.np_pane_focus = NowPlayingPaneFocus::Queue;
+        }
         Ok(app)
     }
 
@@ -859,6 +926,9 @@ impl App {
 
     /// Decode the current cover once and cache in `art_cache_decoded`.
     pub fn ensure_art_cache_decoded(&mut self) -> bool {
+        if !self.np_art_cache_matches() {
+            return false;
+        }
         let Some(fp) = self.art_cache_fingerprint else {
             return false;
         };
@@ -911,11 +981,41 @@ impl App {
 
     /// Accent from cached cover pixels when available, else decode from bytes.
     fn accent_from_art_cache(&self) -> Option<Color> {
+        if !self.np_art_cache_matches() {
+            return None;
+        }
         if let Some((_, img)) = self.art_cache_decoded.as_ref() {
             return extract_accent_from_image(img);
         }
         let (_, bytes) = self.art_cache.as_ref()?;
         extract_accent(bytes)
+    }
+
+    /// Cover art id for the track shown in now playing (`Song::cover_art`).
+    #[must_use]
+    pub fn expected_cover_art_id(&self) -> Option<&str> {
+        self.playback
+            .current_song
+            .as_ref()?
+            .cover_art
+            .as_deref()
+    }
+
+    /// True when `art_cache` belongs to the current now-playing track (not a stale queue fetch).
+    #[must_use]
+    pub fn np_art_cache_matches(&self) -> bool {
+        matches!(
+            (self.expected_cover_art_id(), self.art_cache.as_ref()),
+            (Some(expected), Some((cached, _))) if expected == cached.as_str()
+        )
+    }
+
+    /// Drop now-playing cover bytes and ratatui/kitty prep state (e.g. switching to radio).
+    pub fn clear_now_playing_art_cache(&mut self) {
+        self.art_cache = None;
+        self.art_cache_fingerprint = None;
+        self.art_cache_decoded = None;
+        self.clear_np_ratatui_art_state();
     }
 
     /// Drop all `ratatui-image` protocol state (tab switch, help overlay, fzf suspend, …).
@@ -1811,6 +1911,9 @@ impl App {
         }
         self.spawn_library_index_refresh(false);
         self.fetch_starred();
+        if self.config.radio_enabled {
+            self.fetch_radio_stations();
+        }
         if self.config.scrobble_enabled {
             self.spawn_scrobble_queue_flush();
         }
@@ -2144,6 +2247,138 @@ impl App {
         });
     }
 
+    /// Station logo via Navidrome `getCoverArt` when uploaded, else homepage icons.
+    pub fn fetch_radio_station_art(&self, station: &InternetRadioStation) {
+        let cache_key = station.art_cache_key();
+        let uploaded_id = station.uploaded_cover_art_id().map(str::to_string);
+        let icon_urls = station.station_icon_urls();
+        crate::debug::log(format!(
+            "radio art fetch: station={:?} cache_key={cache_key} homepage={:?} icons={icon_urls:?} uploaded={uploaded_id:?}",
+            station.name,
+            station.home_page_url,
+        ));
+        if !self.remote_available() {
+            crate::debug::log("radio art fetch: skipped (offline / remote unavailable)");
+            return;
+        }
+        let needs_fetch = self
+            .art_cache
+            .as_ref()
+            .map(|(cached_id, _)| cached_id != &cache_key)
+            .unwrap_or(true)
+            || self
+                .art_cache
+                .as_ref()
+                .is_some_and(|(cached_id, _)| cached_id == &cache_key)
+                && self.art_cache_decoded.is_none();
+        if !needs_fetch {
+            crate::debug::log("radio art fetch: skipped (cache hit)");
+            return;
+        }
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        let fetch_icons = self.config.radio_fetch_station_icons;
+        tokio::spawn(async move {
+            let flash = |msg: String| async {
+                crate::debug::log(&msg);
+                if crate::debug::enabled() {
+                    let _ = tx
+                        .send(LibraryUpdate::StatusFlash { msg, secs: 6 })
+                        .await;
+                }
+            };
+            if let Some(ref id) = uploaded_id {
+                match client.get_cover_art(id).await {
+                    Ok(bytes) if !bytes.is_empty()
+                        && crate::ui::art_prepare::art_bytes_decode(&bytes).is_some() =>
+                    {
+                        crate::debug::log(format!(
+                            "radio art: using uploaded cover {id} ({} bytes)",
+                            bytes.len()
+                        ));
+                        let _ = tx
+                            .send(LibraryUpdate::CoverArt {
+                                cover_id: cache_key,
+                                bytes,
+                            })
+                            .await;
+                        return;
+                    }
+                    Ok(bytes) => {
+                        flash(format!(
+                            "radio art: uploaded cover {id} not decodable ({} bytes)",
+                            bytes.len()
+                        ))
+                        .await;
+                    }
+                    Err(e) => {
+                        flash(format!("radio art: getCoverArt({id}) failed: {e}")).await;
+                    }
+                }
+            }
+            if icon_urls.is_empty() {
+                flash("radio art: no homepage or stream URL for station icon".into()).await;
+                return;
+            }
+            if !fetch_icons {
+                flash("radio art: station icons disabled in config".into()).await;
+                return;
+            }
+            let mut best: Option<(String, Vec<u8>, u32)> = None;
+            for url in icon_urls {
+                match client.fetch_external_bytes(&url).await {
+                    Ok(bytes) if !bytes.is_empty() => {
+                        if let Some(img) = crate::ui::art_prepare::art_bytes_decode(&bytes) {
+                            let area = img.width().saturating_mul(img.height());
+                            if best
+                                .as_ref()
+                                .map(|(_, _, best_area)| area > *best_area)
+                                .unwrap_or(true)
+                            {
+                                best = Some((url, bytes, area));
+                            }
+                        } else {
+                            crate::debug::log(format!(
+                                "radio art: {url} not decodable ({} bytes)",
+                                bytes.len()
+                            ));
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        crate::debug::log(format!("radio art: {url} failed: {e}"));
+                    }
+                }
+            }
+            if let Some((url, bytes, area)) = best {
+                crate::debug::log(format!(
+                    "radio art: using {url} ({} bytes, ~{}px)",
+                    bytes.len(),
+                    area.isqrt()
+                ));
+                let _ = tx
+                    .send(LibraryUpdate::CoverArt {
+                        cover_id: cache_key,
+                        bytes,
+                    })
+                    .await;
+            } else {
+                flash("radio art: no decodable station icon from homepage".into()).await;
+            }
+        });
+    }
+
+    fn radio_station_for_song<'a>(
+        song: &ratune_subsonic::Song,
+        stations: &'a [InternetRadioStation],
+    ) -> Option<&'a InternetRadioStation> {
+        if !Self::is_radio_song(song) {
+            return None;
+        }
+        let station_id = song.id.strip_prefix(RADIO_SONG_ID_PREFIX)?;
+        stations.iter().find(|s| s.id == station_id)
+    }
+
     /// Spawn a task to fetch lyrics from the configured source.
     ///
     /// No network request is made when lyrics are disabled or the pane is hidden.
@@ -2457,8 +2692,27 @@ impl App {
                 }
             }
             LibraryUpdate::CoverArt { cover_id, bytes } => {
+                let expected = self
+                    .playback
+                    .current_song
+                    .as_ref()
+                    .and_then(|s| s.cover_art.as_deref());
+                if expected != Some(cover_id.as_str()) {
+                    crate::debug::log(format!(
+                        "cover art discarded: got {cover_id}, expected {expected:?} (current={:?})",
+                        self.playback
+                            .current_song
+                            .as_ref()
+                            .map(|s| s.id.as_str())
+                    ));
+                    return;
+                }
+                crate::debug::log(format!(
+                    "cover art applied: {cover_id} ({} bytes)",
+                    bytes.len()
+                ));
                 let fp = crate::ui::art_prepare::art_bytes_fingerprint(&bytes);
-                let decoded = image::load_from_memory(&bytes).ok();
+                let decoded = crate::ui::art_prepare::art_bytes_decode(&bytes);
                 let accent = decoded
                     .as_ref()
                     .and_then(extract_accent_from_image)
@@ -2470,6 +2724,9 @@ impl App {
                 self.apply_dynamic_accent(accent);
                 #[cfg(target_os = "linux")]
                 self.mpris_emit_props();
+            }
+            LibraryUpdate::StatusFlash { msg, secs } => {
+                self.flash_status_secs(msg, secs);
             }
             LibraryUpdate::Lyrics { song_id, lines } => {
                 self.lyrics_loading = false;
@@ -2814,12 +3071,41 @@ impl App {
             LibraryUpdate::ConnectivityChanged { reachable, forced } => {
                 self.apply_connectivity_changed(reachable, forced);
             }
+            LibraryUpdate::RadioStations(result) => match result {
+                Ok(stations) => {
+                    self.radio.stations = LoadingState::Loaded(stations);
+                    if let LoadingState::Loaded(list) = &self.radio.stations {
+                        if self.radio.selected >= list.len() {
+                            self.radio.selected = list.len().saturating_sub(1);
+                        }
+                        if self.radio_now_playing_active() {
+                            self.sync_radio_selection_from_playback();
+                        }
+                    }
+                }
+                Err(e) => {
+                    self.radio.stations = LoadingState::Error(e);
+                }
+            },
+            LibraryUpdate::RadioMutation(result) => {
+                self.radio.input_mode = RadioInputMode::Normal;
+                match result {
+                    Ok(()) => {
+                        self.flash_status("Radio stations updated");
+                        self.fetch_radio_stations();
+                    }
+                    Err(e) => self.flash_status_secs(format!("Radio: {e}"), 5),
+                }
+            },
         }
     }
 
     // ── Player event ingestion ────────────────────────────────────────────────
 
     fn scrobble_track_started(&mut self, song: &ratune_subsonic::Song) {
+        if Self::is_radio_song(song) {
+            return;
+        }
         self.play_recorded = false;
         self.audioscrobbler_scrobbled = false;
         self.track_started_at = Some(ratune_scrobble::TrackInfo::now_secs());
@@ -2834,6 +3120,9 @@ impl App {
         let Some(song) = self.playback.current_song.clone() else {
             return;
         };
+        if Self::is_radio_song(&song) {
+            return;
+        }
 
         if !self.play_recorded {
             let threshold =
@@ -2953,6 +3242,40 @@ impl App {
         match event {
             PlayerEvent::TrackStarted => {
                 self.playback.paused = false;
+                if let Some(song) = self.playback.current_song.clone() {
+                    if Self::is_radio_song(&song) {
+                        self.playback.player_loaded = true;
+                        let station = match &self.radio.stations {
+                            LoadingState::Loaded(stations) => {
+                                Self::radio_station_for_song(&song, stations).cloned()
+                            }
+                            _ => None,
+                        };
+                        if let Some(station) = station {
+                            let cache_key = station.art_cache_key();
+                            let needs_fetch = self
+                                .art_cache
+                                .as_ref()
+                                .map(|(cached_id, _)| cached_id != &cache_key)
+                                .unwrap_or(true)
+                                || self
+                                    .art_cache
+                                    .as_ref()
+                                    .is_some_and(|(cached_id, _)| {
+                                        cached_id == &cache_key
+                                    })
+                                    && self.art_cache_decoded.is_none();
+                            if needs_fetch {
+                                self.apply_dynamic_accent(None);
+                                self.fetch_radio_station_art(&station);
+                            } else if self.art_cache_decoded.is_some() {
+                                let accent = self.accent_from_art_cache();
+                                self.apply_dynamic_accent(accent);
+                            }
+                        }
+                        return;
+                    }
+                }
                 if let Some(song) = self.queue.current().cloned() {
                     // Fetch cover art when the track has one and it differs from cache.
                     let cover_id = song.cover_art.clone();
@@ -3092,6 +3415,18 @@ impl App {
                 }
             }
             PlayerEvent::TrackEnded => {
+                if self
+                    .playback
+                    .current_song
+                    .as_ref()
+                    .is_some_and(Self::is_radio_song)
+                {
+                    self.playback.current_song = None;
+                    self.playback.player_loaded = false;
+                    self.playback.elapsed = Duration::ZERO;
+                    self.playback.total = None;
+                    return;
+                }
                 if self.queue.next() {
                     self.play_current();
                 } else if !self.queue.songs.is_empty() && self.queue.loop_enabled {
@@ -3109,7 +3444,7 @@ impl App {
                 self.playback.player_loaded = false;
                 self.status_flash = Some((
                     humanize_playback_error(&e),
-                    Instant::now() + Duration::from_secs(10),
+                    Instant::now() + Duration::from_secs(12),
                 ));
             }
         }
@@ -3287,6 +3622,7 @@ impl App {
     /// Send a PlayUrl command for the song the queue cursor points at.
     fn play_current(&mut self) {
         if let Some(song) = self.queue.current().cloned() {
+            self.np_pane_focus = NowPlayingPaneFocus::Queue;
             self.play_gen += 1;
             // Advance the prefetch gen so stale background downloads are discarded.
             self.prefetch_gen.fetch_add(1, Ordering::Release);
@@ -3323,6 +3659,494 @@ impl App {
             }
         }
         ResolvedPlayback::Url(self.subsonic.stream_url(&song.id, self.config.max_bit_rate))
+    }
+
+    #[must_use]
+    pub fn is_radio_song(song: &ratune_subsonic::Song) -> bool {
+        song.id.starts_with(RADIO_SONG_ID_PREFIX)
+    }
+
+    fn song_from_radio_station(station: &InternetRadioStation) -> ratune_subsonic::Song {
+        ratune_subsonic::Song {
+            id: format!("{RADIO_SONG_ID_PREFIX}{}", station.id),
+            title: station.name.clone(),
+            artist: Some("Radio".into()),
+            album: station.display_subtitle(),
+            cover_art: Some(station.art_cache_key()),
+            album_id: None,
+            artist_id: None,
+            track: None,
+            disc_number: None,
+            year: None,
+            genre: None,
+            duration: None,
+            bit_rate: None,
+            content_type: None,
+            suffix: None,
+            size: None,
+            path: None,
+            starred: None,
+        }
+    }
+
+    /// Fetch internet radio stations for the picker and Now Playing radio pane.
+    pub fn fetch_radio_stations(&mut self) {
+        if !self.config.radio_enabled {
+            return;
+        }
+        if !self.remote_available() {
+            self.radio.stations = LoadingState::Error("Offline — radio unavailable".into());
+            return;
+        }
+        self.radio.stations = LoadingState::Loading;
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        tokio::spawn(async move {
+            let result = client
+                .get_internet_radio_stations()
+                .await
+                .map_err(|e| e.to_string());
+            let _ = tx.send(LibraryUpdate::RadioStations(result)).await;
+        });
+    }
+
+    fn on_tab_entered(&mut self) {
+        if self.active_tab == Tab::Home {
+            self.refresh_home_data();
+            self.home_art_needs_redraw = true;
+        }
+    }
+
+    pub fn close_radio_picker(&mut self) {
+        self.radio.picker_visible = false;
+        self.radio.input_mode = RadioInputMode::Normal;
+    }
+
+    pub fn open_radio_picker(&mut self) {
+        if !self.config.radio_enabled {
+            return;
+        }
+        self.radio.picker_visible = true;
+        if matches!(
+            &self.radio.stations,
+            LoadingState::NotLoaded | LoadingState::Error(_)
+        ) {
+            self.fetch_radio_stations();
+        }
+        self.sync_radio_selection_from_playback();
+    }
+
+    fn toggle_radio_picker(&mut self) {
+        if !self.config.radio_enabled {
+            return;
+        }
+        if self.radio.picker_visible && self.radio.input_mode.is_normal() {
+            self.close_radio_picker();
+        } else if !self.radio.picker_visible {
+            self.open_radio_picker();
+        }
+    }
+
+    fn play_radio_from_picker(&mut self) {
+        self.play_selected_radio_station();
+        self.close_radio_picker();
+        self.clear_art_on_tab_switch();
+        self.active_tab = Tab::NowPlaying;
+        self.clear_browser_search();
+    }
+
+    #[must_use]
+    pub fn radio_buffering(&self) -> bool {
+        self.playback
+            .current_song
+            .as_ref()
+            .is_some_and(Self::is_radio_song)
+            && !self.playback.player_loaded
+    }
+
+    fn play_radio_station(&mut self, station: &InternetRadioStation) {
+        if !self.config.radio_enabled {
+            return;
+        }
+        self.play_gen += 1;
+        self.prefetch_gen.fetch_add(1, Ordering::Release);
+        let song = Self::song_from_radio_station(station);
+        // Set now-playing metadata before spawning art fetch — otherwise a fast favicon
+        // response can arrive before `current_song` is set and be discarded as stale.
+        self.playback.current_song = Some(song);
+        self.np_pane_focus = NowPlayingPaneFocus::Radio;
+        self.sync_radio_selection_from_playback();
+        self.clear_now_playing_art_cache();
+        self.apply_dynamic_accent(None);
+        self.fetch_radio_station_art(station);
+        self.playback.player_loaded = false;
+        self.playback.paused = false;
+        self.playback.elapsed = Duration::ZERO;
+        self.playback.total = None;
+        let url = station.stream_url.trim().to_string();
+        if url.is_empty() {
+            self.flash_status_secs("Radio: stream URL is empty", 5);
+            return;
+        }
+        let gen = self.play_gen;
+        if self
+            .player_tx
+            .send(PlayerCommand::PlayLiveStream { url, gen })
+            .is_err()
+        {
+            self.flash_status_secs("Playback failed: audio engine unavailable", 5);
+        }
+    }
+
+    fn play_selected_radio_station(&mut self) {
+        let station = match &self.radio.stations {
+            LoadingState::Loaded(stations) => stations.get(self.radio.selected).cloned(),
+            _ => None,
+        };
+        if let Some(station) = station {
+            self.play_radio_station(&station);
+        }
+    }
+
+    /// Mouse click on a visible row in the radio picker list.
+    pub fn click_radio_row(&mut self, visible_row: usize) {
+        let len = match &self.radio.stations {
+            LoadingState::Loaded(stations) => stations.len(),
+            _ => return,
+        };
+        let idx = self.radio.scroll + visible_row;
+        if idx < len {
+            self.radio.selected = idx;
+            self.play_radio_from_picker();
+        }
+    }
+
+    /// Select a visible row in the Now Playing radio pane (does not start playback).
+    pub fn select_radio_visible_row(&mut self, visible_row: usize) {
+        let len = match &self.radio.stations {
+            LoadingState::Loaded(stations) => stations.len(),
+            _ => return,
+        };
+        let idx = self.radio.scroll + visible_row;
+        if idx < len {
+            self.radio.selected = idx;
+            self.np_pane_focus = NowPlayingPaneFocus::Radio;
+            LibraryState::clamp_vertical_scroll(
+                &mut self.radio.scroll,
+                self.radio.selected,
+                len,
+                self.queue_viewport_rows.max(1),
+            );
+        }
+    }
+
+    fn radio_station_step(&mut self, delta: i32) {
+        let len = match &self.radio.stations {
+            LoadingState::Loaded(stations) if !stations.is_empty() => stations.len(),
+            _ => return,
+        };
+        let new_sel = if delta < 0 {
+            self.radio.selected.saturating_sub(delta.unsigned_abs() as usize)
+        } else {
+            (self.radio.selected + delta as usize).min(len - 1)
+        };
+        self.radio.selected = new_sel;
+        let visible = self.queue_viewport_rows.max(1);
+        LibraryState::clamp_vertical_scroll(
+            &mut self.radio.scroll,
+            self.radio.selected,
+            len,
+            visible,
+        );
+        if self.is_playing_radio() {
+            self.play_selected_radio_station();
+        }
+    }
+
+    #[must_use]
+    pub fn is_playing_radio(&self) -> bool {
+        self.playback
+            .current_song
+            .as_ref()
+            .is_some_and(Self::is_radio_song)
+            && self.playback.player_loaded
+    }
+
+    /// Live radio is the current now-playing source (including while buffering).
+    #[must_use]
+    pub fn radio_now_playing_active(&self) -> bool {
+        self.playback
+            .current_song
+            .as_ref()
+            .is_some_and(Self::is_radio_song)
+    }
+
+    /// Now Playing can split the sidebar between radio stations and the library queue.
+    #[must_use]
+    pub fn np_radio_pane_available(&self) -> bool {
+        self.config.radio_enabled
+    }
+
+    /// Align Radio tab selection with the station in `playback.current_song`.
+    pub fn sync_radio_selection_from_playback(&mut self) {
+        let Some(song) = self.playback.current_song.as_ref() else {
+            return;
+        };
+        if !Self::is_radio_song(song) {
+            return;
+        };
+        let Some(station_id) = song.id.strip_prefix(RADIO_SONG_ID_PREFIX) else {
+            return;
+        };
+        let LoadingState::Loaded(stations) = &self.radio.stations else {
+            return;
+        };
+        if let Some(idx) = stations.iter().position(|s| s.id == station_id) {
+            self.radio.selected = idx;
+            LibraryState::clamp_vertical_scroll(
+                &mut self.radio.scroll,
+                self.radio.selected,
+                stations.len(),
+                self.queue_viewport_rows.max(1),
+            );
+        }
+    }
+
+    fn play_queue_from_np(&mut self) {
+        if self.queue.songs.is_empty() {
+            return;
+        }
+        self.np_pane_focus = NowPlayingPaneFocus::Queue;
+        self.play_current();
+    }
+
+    fn handle_toggle_np_pane_focus(&mut self) {
+        if !self.np_radio_pane_available() {
+            self.np_pane_focus = NowPlayingPaneFocus::Queue;
+            return;
+        }
+        self.np_pane_focus = match self.np_pane_focus {
+            NowPlayingPaneFocus::Radio => NowPlayingPaneFocus::Queue,
+            NowPlayingPaneFocus::Queue => {
+                if self.radio_now_playing_active() {
+                    self.sync_radio_selection_from_playback();
+                }
+                NowPlayingPaneFocus::Radio
+            }
+        };
+    }
+
+    fn radio_form_values(mode: &RadioInputMode) -> Option<(&str, &str, &str)> {
+        match mode {
+            RadioInputMode::Creating {
+                name,
+                stream_url,
+                home_page_url,
+                ..
+            }
+            | RadioInputMode::Editing {
+                name,
+                stream_url,
+                home_page_url,
+                ..
+            } => Some((
+                name.as_str(),
+                stream_url.as_str(),
+                home_page_url.as_str(),
+            )),
+            _ => None,
+        }
+    }
+
+    fn radio_form_is_valid(mode: &RadioInputMode) -> bool {
+        Self::radio_form_values(mode).is_some_and(|(name, stream_url, _)| {
+            !name.trim().is_empty() && !stream_url.trim().is_empty()
+        })
+    }
+
+    fn radio_form_focused_buffer(mode: &mut RadioInputMode) -> Option<&mut String> {
+        match mode {
+            RadioInputMode::Creating {
+                name,
+                stream_url,
+                home_page_url,
+                focused,
+            }
+            | RadioInputMode::Editing {
+                name,
+                stream_url,
+                home_page_url,
+                focused,
+                ..
+            } => Some(match focused {
+                RadioField::Name => name,
+                RadioField::StreamUrl => stream_url,
+                RadioField::HomePageUrl => home_page_url,
+            }),
+            _ => None,
+        }
+    }
+
+    fn radio_form_focused_field(mode: &RadioInputMode) -> Option<RadioField> {
+        match mode {
+            RadioInputMode::Creating { focused, .. } | RadioInputMode::Editing { focused, .. } => {
+                Some(*focused)
+            }
+            _ => None,
+        }
+    }
+
+    fn radio_form_set_focus(mode: &mut RadioInputMode, field: RadioField) {
+        match mode {
+            RadioInputMode::Creating { focused, .. } | RadioInputMode::Editing { focused, .. } => {
+                *focused = field;
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_radio_mutation(&mut self, action: Action) {
+        match action {
+            Action::RadioCreate => {
+                self.radio.input_mode = RadioInputMode::Creating {
+                    name: String::new(),
+                    stream_url: String::new(),
+                    home_page_url: String::new(),
+                    focused: RadioField::Name,
+                };
+            }
+            Action::RadioEdit => {
+                if let LoadingState::Loaded(stations) = &self.radio.stations {
+                    if let Some(station) = stations.get(self.radio.selected) {
+                        self.radio.input_mode = RadioInputMode::Editing {
+                            station_id: station.id.clone(),
+                            name: station.name.clone(),
+                            stream_url: station.stream_url.clone(),
+                            home_page_url: station.home_page_url.clone().unwrap_or_default(),
+                            focused: RadioField::Name,
+                        };
+                    }
+                }
+            }
+            Action::RadioDelete => {
+                if let LoadingState::Loaded(stations) = &self.radio.stations {
+                    if let Some(station) = stations.get(self.radio.selected) {
+                        self.radio.input_mode = RadioInputMode::ConfirmingDelete {
+                            station_id: station.id.clone(),
+                            name: station.name.clone(),
+                        };
+                    }
+                }
+            }
+            Action::RadioFieldNext => {
+                if let Some(focused) = Self::radio_form_focused_field(&self.radio.input_mode) {
+                    Self::radio_form_set_focus(&mut self.radio.input_mode, focused.next());
+                }
+            }
+            Action::RadioFieldPrev => {
+                if let Some(focused) = Self::radio_form_focused_field(&self.radio.input_mode) {
+                    Self::radio_form_set_focus(&mut self.radio.input_mode, focused.prev());
+                }
+            }
+            Action::RadioInputChar(c) => {
+                if let Some(buffer) = Self::radio_form_focused_buffer(&mut self.radio.input_mode) {
+                    if c == '\x08' {
+                        buffer.pop();
+                    } else {
+                        buffer.push(c);
+                    }
+                }
+            }
+            Action::RadioInputConfirm => {
+                match self.radio.input_mode.clone() {
+                    RadioInputMode::Creating {
+                        name,
+                        stream_url,
+                        home_page_url,
+                        ..
+                    } if Self::radio_form_is_valid(&self.radio.input_mode) => {
+                        let home = home_page_url.trim();
+                        self.spawn_save_radio_station(
+                            None,
+                            name.trim().to_string(),
+                            stream_url.trim().to_string(),
+                            (!home.is_empty()).then(|| home.to_string()),
+                        );
+                    }
+                    RadioInputMode::Editing {
+                        station_id,
+                        name,
+                        stream_url,
+                        home_page_url,
+                        ..
+                    } if Self::radio_form_is_valid(&self.radio.input_mode) => {
+                        let home = home_page_url.trim();
+                        self.spawn_save_radio_station(
+                            Some(station_id),
+                            name.trim().to_string(),
+                            stream_url.trim().to_string(),
+                            (!home.is_empty()).then(|| home.to_string()),
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            Action::RadioInputCancel => {
+                self.radio.input_mode = RadioInputMode::Normal;
+            }
+            Action::RadioConfirmYes => {
+                if let RadioInputMode::ConfirmingDelete { station_id, .. } =
+                    self.radio.input_mode.clone()
+                {
+                    self.spawn_delete_radio_station(station_id);
+                }
+            }
+            Action::RadioConfirmNo => {
+                self.radio.input_mode = RadioInputMode::Normal;
+            }
+            _ => {}
+        }
+    }
+
+    fn spawn_save_radio_station(
+        &self,
+        station_id: Option<String>,
+        name: String,
+        stream_url: String,
+        home_page_url: Option<String>,
+    ) {
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        tokio::spawn(async move {
+            let result = if let Some(id) = station_id {
+                client
+                    .update_internet_radio_station(
+                        &id,
+                        &name,
+                        &stream_url,
+                        home_page_url.as_deref(),
+                    )
+                    .await
+            } else {
+                client
+                    .create_internet_radio_station(&name, &stream_url, home_page_url.as_deref())
+                    .await
+            }
+            .map_err(|e| e.to_string());
+            let _ = tx.send(LibraryUpdate::RadioMutation(result)).await;
+        });
+    }
+
+    fn spawn_delete_radio_station(&self, station_id: String) {
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        tokio::spawn(async move {
+            let result = client
+                .delete_internet_radio_station(&station_id)
+                .await
+                .map_err(|e| e.to_string());
+            let _ = tx.send(LibraryUpdate::RadioMutation(result)).await;
+        });
     }
 
     /// Spawn a background task to download `song_id` for caching.
@@ -3939,39 +4763,36 @@ impl App {
             Action::SwitchTab => {
                 self.playlist_overlay.visible = false;
                 self.playlist_picker = None;
+                self.close_radio_picker();
                 self.clear_art_on_tab_switch();
                 self.active_tab = self.active_tab.next();
                 self.clear_browser_search();
-                if self.active_tab == Tab::Home {
-                    self.refresh_home_data();
-                    self.home_art_needs_redraw = true;
-                }
+                self.on_tab_entered();
             }
             Action::SwitchTabReverse => {
                 self.playlist_overlay.visible = false;
                 self.playlist_picker = None;
+                self.close_radio_picker();
                 self.clear_art_on_tab_switch();
                 self.active_tab = self.active_tab.prev();
                 self.clear_browser_search();
-                if self.active_tab == Tab::Home {
-                    self.refresh_home_data();
-                    self.home_art_needs_redraw = true;
-                }
+                self.on_tab_entered();
             }
             Action::GoToHome => {
                 self.playlist_overlay.visible = false;
                 self.playlist_picker = None;
+                self.close_radio_picker();
                 if self.kitty_apc_overlay_active() {
                     let _ = crate::ui::kitty_art::clear_image(self.in_tmux);
                 }
                 self.active_tab = Tab::Home;
                 self.clear_browser_search();
-                self.refresh_home_data();
-                self.home_art_needs_redraw = true;
+                self.on_tab_entered();
             }
             Action::GoToBrowser => {
                 self.playlist_overlay.visible = false;
                 self.playlist_picker = None;
+                self.close_radio_picker();
                 self.clear_art_on_tab_switch();
                 self.active_tab = Tab::Browser;
                 self.clear_browser_search();
@@ -3980,6 +4801,7 @@ impl App {
             Action::ToggleBrowserFolder => {
                 self.playlist_overlay.visible = false;
                 self.playlist_picker = None;
+                self.close_radio_picker();
                 self.clear_art_on_tab_switch();
                 self.pending_gg = false;
                 if !self.config.browse_folder_navigation {
@@ -4020,10 +4842,14 @@ impl App {
             Action::GoToNowPlaying => {
                 self.playlist_overlay.visible = false;
                 self.playlist_picker = None;
+                self.close_radio_picker();
                 self.clear_art_on_tab_switch();
                 self.active_tab = Tab::NowPlaying;
                 self.clear_browser_search();
             }
+            Action::ToggleRadioPicker => self.toggle_radio_picker(),
+            Action::RadioPickerSelect => self.play_radio_from_picker(),
+            Action::RadioPickerCancel => self.close_radio_picker(),
             Action::FocusLeft => self.handle_focus_left(),
             Action::FocusRight => self.handle_focus_right(),
             Action::Navigate(dir) => {
@@ -4063,7 +4889,17 @@ impl App {
             }
             Action::AddAllToQueuePrepend => self.handle_add_all_to_queue(AddAllMode::Prepend),
             Action::PlayPause => {
-                if !self.playback.player_loaded && self.queue.current().is_some() {
+                if self.is_playing_radio() || self.playback.current_song.as_ref().is_some_and(Self::is_radio_song) {
+                    if !self.playback.player_loaded {
+                        self.play_selected_radio_station();
+                    } else if self.playback.paused {
+                        self.playback.paused = false;
+                        let _ = self.player_tx.send(PlayerCommand::Resume);
+                    } else {
+                        self.playback.paused = true;
+                        let _ = self.player_tx.send(PlayerCommand::Pause);
+                    }
+                } else if !self.playback.player_loaded && self.queue.current().is_some() {
                     // Restored queue: engine has no track yet — load and start playing.
                     self.play_current();
                 } else if self.playback.paused {
@@ -4075,12 +4911,16 @@ impl App {
                 }
             }
             Action::NextTrack => {
-                if self.queue.next() {
+                if self.is_playing_radio() {
+                    self.radio_station_step(1);
+                } else if self.queue.next() {
                     self.play_current();
                 }
             }
             Action::PrevTrack => {
-                if self.queue.prev() {
+                if self.is_playing_radio() {
+                    self.radio_station_step(-1);
+                } else if self.queue.prev() {
                     self.play_current();
                 }
             }
@@ -4101,6 +4941,7 @@ impl App {
             Action::Shuffle => self.handle_shuffle(),
             Action::Unshuffle => self.handle_unshuffle(),
             Action::ToggleQueueLoop => self.handle_toggle_queue_loop(),
+            Action::ToggleNpPaneFocus => self.handle_toggle_np_pane_focus(),
             Action::SeekForward => {
                 let new_pos = if let Some(total) = self.playback.total {
                     (self.playback.elapsed + std::time::Duration::from_secs(10)).min(total)
@@ -4239,6 +5080,23 @@ impl App {
                     self.home.active_section = saved_section;
                     self.home_art_needs_redraw = true;
                 }
+            }
+            Action::RadioRefresh => {
+                if self.radio.picker_visible {
+                    self.fetch_radio_stations();
+                }
+            }
+            Action::RadioCreate
+            | Action::RadioEdit
+            | Action::RadioDelete
+            | Action::RadioFieldNext
+            | Action::RadioFieldPrev
+            | Action::RadioInputConfirm
+            | Action::RadioInputCancel
+            | Action::RadioInputChar(_)
+            | Action::RadioConfirmYes
+            | Action::RadioConfirmNo => {
+                self.handle_radio_mutation(action);
             }
             Action::HomeAlbumLeft => {
                 if self.active_tab == Tab::Home {
@@ -4552,11 +5410,52 @@ impl App {
     // ── Navigation ────────────────────────────────────────────────────────────
 
     fn handle_navigate(&mut self, dir: Direction) {
+        if self.radio.picker_visible && self.radio.input_mode.is_normal() {
+            self.handle_navigate_radio(dir);
+            return;
+        }
         match self.active_tab {
             Tab::Home => self.handle_navigate_home(dir),
             Tab::Browser => self.handle_navigate_browser(dir, 1),
-            Tab::NowPlaying => self.handle_navigate_queue(dir),
+            Tab::NowPlaying => {
+                if self.np_radio_pane_available() {
+                    match self.np_pane_focus {
+                        NowPlayingPaneFocus::Radio => self.handle_navigate_radio(dir),
+                        NowPlayingPaneFocus::Queue if !self.queue.songs.is_empty() => {
+                            self.handle_navigate_queue(dir);
+                        }
+                        NowPlayingPaneFocus::Queue => {}
+                    }
+                } else if !self.queue.songs.is_empty() {
+                    self.handle_navigate_queue(dir);
+                }
+            }
         }
+    }
+
+    fn handle_navigate_radio(&mut self, dir: Direction) {
+        if !self.radio.input_mode.is_normal() {
+            return;
+        }
+        let len = match &self.radio.stations {
+            LoadingState::Loaded(stations) if !stations.is_empty() => stations.len(),
+            _ => return,
+        };
+        let page = self.queue_viewport_rows.max(1);
+        self.radio.selected = match dir {
+            Direction::Up => self.radio.selected.saturating_sub(1),
+            Direction::Down => (self.radio.selected + 1).min(len - 1),
+            Direction::Top => 0,
+            Direction::Bottom => len - 1,
+            Direction::PageUp => self.radio.selected.saturating_sub(page),
+            Direction::PageDown => (self.radio.selected + page).min(len - 1),
+        };
+        LibraryState::clamp_vertical_scroll(
+            &mut self.radio.scroll,
+            self.radio.selected,
+            len,
+            page,
+        );
     }
 
     fn handle_navigate_home(&mut self, dir: Direction) {
@@ -4934,6 +5833,10 @@ impl App {
     // ── Select ────────────────────────────────────────────────────────────────
 
     fn handle_select(&mut self) {
+        if self.radio.picker_visible && self.radio.input_mode.is_normal() {
+            self.play_radio_from_picker();
+            return;
+        }
         match self.active_tab {
             Tab::Home => self.handle_select_home(),
             Tab::Browser => {
@@ -4952,8 +5855,17 @@ impl App {
                 }
             }
             Tab::NowPlaying => {
-                // Enter: jump playback to the highlighted queue row.
-                if !self.queue.songs.is_empty() {
+                if self.np_radio_pane_available() {
+                    match self.np_pane_focus {
+                        NowPlayingPaneFocus::Queue if !self.queue.songs.is_empty() => {
+                            self.play_queue_from_np();
+                        }
+                        NowPlayingPaneFocus::Radio => {
+                            self.play_selected_radio_station();
+                        }
+                        NowPlayingPaneFocus::Queue => {}
+                    }
+                } else if !self.queue.songs.is_empty() {
                     self.play_current();
                 }
             }

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -1429,10 +1429,7 @@ impl Config {
             && !scrobble_api_secret.is_empty()
             && !scrobble_session_key.is_empty();
 
-        let radio_enabled = file_cfg
-            .radio
-            .enabled
-            .unwrap_or_else(default_radio_enabled);
+        let radio_enabled = file_cfg.radio.enabled.unwrap_or_else(default_radio_enabled);
         let radio_fetch_station_icons = file_cfg
             .radio
             .fetch_station_icons

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -38,6 +38,26 @@ struct FileConfig {
     pub library: LibrarySection,
     #[serde(default)]
     pub scrobble: ScrobbleSection,
+    #[serde(default)]
+    pub radio: RadioSection,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct RadioSection {
+    /// Enable Internet Radio (Shift+R picker, Now Playing radio pane). Default: true.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Fetch homepage icons for station art when no logo is uploaded in Navidrome.
+    #[serde(default)]
+    pub fetch_station_icons: Option<bool>,
+}
+
+fn default_radio_enabled() -> bool {
+    true
+}
+
+fn default_radio_fetch_station_icons() -> bool {
+    true
 }
 
 // ── [keybinds] ────────────────────────────────────────────────────────────────
@@ -65,8 +85,12 @@ pub struct KeybindsSection {
     pub add_all_prepend: Option<String>,
     pub shuffle: Option<String>,
     pub unshuffle: Option<String>,
-    /// Toggle queue loop after the last track. Default: Shift+r
+    /// Toggle queue loop after the last track. Default: Shift+q
     pub toggle_queue_loop: Option<String>,
+    /// Open or close the internet radio station picker. Default: Shift+r
+    pub toggle_radio: Option<String>,
+    /// Toggle Now Playing focus between live radio and library queue. Default: Ctrl+g
+    pub np_focus_queue: Option<String>,
     pub clear_queue: Option<String>,
     /// Remove highlighted track from queue (Now Playing tab). Default: d
     pub remove_from_queue: Option<String>,
@@ -992,6 +1016,10 @@ pub struct Config {
     pub mpris_enabled: bool,
     /// When true, playback wraps to the first queue track after the last one ends.
     pub queue_loop: bool,
+    /// Internet Radio (picker, Now Playing pane, station management).
+    pub radio_enabled: bool,
+    /// When false, skip HTTP fetches to station homepages for Now Playing art.
+    pub radio_fetch_station_icons: bool,
     /// Raw keybind strings — parsed into `Keybinds` by `App::new`.
     pub keybinds: KeybindsSection,
     /// Raw theme colour strings — parsed into `Theme` by `App::new`.
@@ -1401,6 +1429,15 @@ impl Config {
             && !scrobble_api_secret.is_empty()
             && !scrobble_session_key.is_empty();
 
+        let radio_enabled = file_cfg
+            .radio
+            .enabled
+            .unwrap_or_else(default_radio_enabled);
+        let radio_fetch_station_icons = file_cfg
+            .radio
+            .fetch_station_icons
+            .unwrap_or_else(default_radio_fetch_station_icons);
+
         Ok(Config {
             subsonic_url: file_cfg.server.url,
             subsonic_user: file_cfg.server.username,
@@ -1410,6 +1447,8 @@ impl Config {
             max_bit_rate: file_cfg.player.max_bit_rate,
             mpris_enabled: file_cfg.player.mpris,
             queue_loop: file_cfg.player.queue_loop,
+            radio_enabled,
+            radio_fetch_station_icons,
             keybinds: file_cfg.keybinds,
             theme: file_cfg.theme,
             lyrics_visible,
@@ -1567,7 +1606,9 @@ max_bit_rate = 0   # 0 = unlimited; set e.g. 320 to cap streaming bitrate
 # add_all_prepend  = "Ctrl+Shift+p"
 # shuffle       = "x"
 # unshuffle     = "z"
-# toggle_queue_loop = "R"
+# toggle_queue_loop = "Q"
+# toggle_radio      = "R"
+# np_focus_queue = "Ctrl+g"
 # clear_queue   = "Shift+d"
 # remove_from_queue = "d"
 # search        = "/"
@@ -2330,5 +2371,17 @@ cache_enabled = false
     fn parses_queue_loop() {
         let fc: FileConfig = toml::from_str("[player]\nqueue_loop = false\n").expect("toml");
         assert!(!fc.player.queue_loop);
+    }
+
+    #[test]
+    fn radio_enabled_defaults_true() {
+        let fc: FileConfig = toml::from_str("").expect("toml");
+        assert_eq!(fc.radio.enabled, None);
+    }
+
+    #[test]
+    fn parses_radio_enabled() {
+        let fc: FileConfig = toml::from_str("[radio]\nenabled = false\n").expect("toml");
+        assert_eq!(fc.radio.enabled, Some(false));
     }
 }

--- a/ratune/src/debug.rs
+++ b/ratune/src/debug.rs
@@ -1,0 +1,14 @@
+//! Optional stderr diagnostics. Enable with `RATUNE_DEBUG=1` in the environment.
+
+/// True when `RATUNE_DEBUG` is set (any value).
+#[must_use]
+pub fn enabled() -> bool {
+    std::env::var_os("RATUNE_DEBUG").is_some()
+}
+
+/// Print to stderr when [`enabled`].
+pub fn log(msg: impl std::fmt::Display) {
+    if enabled() {
+        eprintln!("ratune: {msg}");
+    }
+}

--- a/ratune/src/keybinds.rs
+++ b/ratune/src/keybinds.rs
@@ -147,6 +147,8 @@ pub struct Keybinds {
     pub shuffle: KeySpec,
     pub unshuffle: KeySpec,
     pub toggle_queue_loop: KeySpec,
+    pub toggle_radio: KeySpec,
+    pub np_focus_queue: KeySpec,
     pub clear_queue: KeySpec,
     pub remove_from_queue: KeySpec,
     pub search: KeySpec,
@@ -323,8 +325,22 @@ impl Keybinds {
             toggle_queue_loop: resolve(
                 sec.toggle_queue_loop.as_deref(),
                 KeySpec {
+                    code: KeyCode::Char('q'),
+                    modifiers: KeyModifiers::SHIFT,
+                },
+            ),
+            toggle_radio: resolve(
+                sec.toggle_radio.as_deref(),
+                KeySpec {
                     code: KeyCode::Char('r'),
                     modifiers: KeyModifiers::SHIFT,
+                },
+            ),
+            np_focus_queue: resolve(
+                sec.np_focus_queue.as_deref(),
+                KeySpec {
+                    code: KeyCode::Char('g'),
+                    modifiers: KeyModifiers::CONTROL,
                 },
             ),
             clear_queue: resolve(

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -3,6 +3,7 @@ mod app;
 mod cache;
 mod color;
 mod config;
+mod debug;
 mod desktop_notify;
 mod favorites_cache;
 mod fzf_picker;
@@ -45,7 +46,7 @@ use action::{Action, Direction};
 use app::{App, BrowserColumn, Tab};
 use config::{AlbumArtBackend, BrowseMode, Config, HomePanel};
 use keybinds::Keybinds;
-use state::{FavoritesFocus, GlobalConfirm, LoadingState, PlaylistFocus, PlaylistInputMode};
+use state::{FavoritesFocus, GlobalConfirm, LoadingState, PlaylistFocus, PlaylistInputMode, RadioInputMode};
 
 /// Entry point shared by the `ratune` binary and integration tests.
 pub async fn run() -> Result<()> {
@@ -148,6 +149,9 @@ pub async fn run() -> Result<()> {
         // Background metadata index refresh when missing or stale (Milestone 2).
         app.spawn_library_index_refresh(false);
         app.fetch_starred();
+        if app.config.radio_enabled && app.server_reachable {
+            app.fetch_radio_stations();
+        }
     } else {
         app.prepare_offline_browse();
         if app.browser_browse_mode != BrowseMode::Files {
@@ -544,10 +548,11 @@ async fn run_loop(
                         }
                         continue;
                     };
-                    if let (Some(fp), Some(cover_id)) = (
-                        app.art_cache_fingerprint,
-                        app.art_cache.as_ref().map(|(id, _)| id.clone()),
-                    ) {
+                    if app.np_art_cache_matches() {
+                        if let (Some(fp), Some(cover_id)) = (
+                            app.art_cache_fingerprint,
+                            app.art_cache.as_ref().map(|(id, _)| id.clone()),
+                        ) {
                         let show_art = app.config.nowplaying_show_art;
                         let layout_opts = ui::layout::layout_options_for_app(app);
                         let center = ui::layout::build_layout(terminal_rect, &layout_opts).center;
@@ -658,8 +663,9 @@ async fn run_loop(
                             last_rendered_art = None;
                             art_displayed = false;
                         }
+                        }
                     } else if art_displayed {
-                        // In NowPlaying tab but no art — clear any stale image.
+                        // Stale cover (e.g. queue album art while radio is playing).
                         let _ = ui::kitty_art::clear_image(app.in_tmux);
                         last_rendered_art = None;
                         art_displayed = false;
@@ -730,6 +736,23 @@ async fn run_loop(
                                     // Picker is open: highest priority — swallow all keys.
                                     let action = map_picker_key(key.code, key.modifiers);
                                     app.dispatch(action);
+                                } else if app.radio.picker_visible
+                                    && !app.radio.input_mode.is_normal()
+                                    && !app.help_visible
+                                {
+                                    let action = map_radio_form_key(
+                                        key.code,
+                                        key.modifiers,
+                                        &app.radio.input_mode,
+                                    );
+                                    app.dispatch(action);
+                                } else if app.radio.picker_visible && !app.help_visible {
+                                    let action = map_radio_picker_key(
+                                        key.code,
+                                        key.modifiers,
+                                        &app.keybinds,
+                                    );
+                                    app.dispatch(action);
                                 } else if app.favorites_overlay.visible
                                     && app.active_tab == Tab::Browser
                                     && !app.help_visible
@@ -738,7 +761,7 @@ async fn run_loop(
                                         key.code,
                                         KeyCode::Tab
                                             | KeyCode::BackTab
-                                            | KeyCode::Char('1')
+                                            |                                         KeyCode::Char('1')
                                             | KeyCode::Char('2')
                                             | KeyCode::Char('3')
                                     );
@@ -774,7 +797,7 @@ async fn run_loop(
                                         key.code,
                                         KeyCode::Tab
                                             | KeyCode::BackTab
-                                            | KeyCode::Char('1')
+                                            |                                         KeyCode::Char('1')
                                             | KeyCode::Char('2')
                                             | KeyCode::Char('3')
                                     );
@@ -986,6 +1009,7 @@ async fn run_loop(
             );
             if app.kitty_apc_overlay_active()
                 && !art_displayed
+                && app.np_art_cache_matches()
                 && app.art_cache.is_some()
                 && app.active_tab == app::Tab::NowPlaying
                 && !app.help_visible
@@ -1293,6 +1317,48 @@ fn map_favorites_key(
     }
 }
 
+fn map_radio_picker_key(code: KeyCode, modifiers: KeyModifiers, kb: &Keybinds) -> Action {
+    if kb.toggle_radio.matches(code, modifiers) {
+        return Action::ToggleRadioPicker;
+    }
+    if kb.home_refresh.matches(code, modifiers) {
+        return Action::RadioRefresh;
+    }
+    let shift = modifiers.intersects(KeyModifiers::SHIFT);
+    match code {
+        KeyCode::Esc => Action::RadioPickerCancel,
+        KeyCode::Enter => Action::RadioPickerSelect,
+        KeyCode::Char('c') if !shift => Action::RadioCreate,
+        KeyCode::Char('e') if !shift => Action::RadioEdit,
+        KeyCode::Char('X') | KeyCode::Char('x') if code == KeyCode::Char('X') || shift => {
+            Action::RadioDelete
+        }
+        KeyCode::Char('k') | KeyCode::Up => Action::Navigate(Direction::Up),
+        KeyCode::Char('j') | KeyCode::Down => Action::Navigate(Direction::Down),
+        _ => Action::None,
+    }
+}
+
+fn map_radio_form_key(code: KeyCode, _modifiers: KeyModifiers, input_mode: &RadioInputMode) -> Action {
+    match input_mode {
+        RadioInputMode::ConfirmingDelete { .. } => match code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => Action::RadioConfirmYes,
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => Action::RadioConfirmNo,
+            _ => Action::None,
+        },
+        RadioInputMode::Creating { .. } | RadioInputMode::Editing { .. } => match code {
+            KeyCode::Esc => Action::RadioInputCancel,
+            KeyCode::Enter => Action::RadioInputConfirm,
+            KeyCode::Tab => Action::RadioFieldNext,
+            KeyCode::BackTab => Action::RadioFieldPrev,
+            KeyCode::Backspace => Action::RadioInputChar('\x08'),
+            KeyCode::Char(ch) => Action::RadioInputChar(ch),
+            _ => Action::None,
+        },
+        RadioInputMode::Normal => Action::None,
+    }
+}
+
 /// Translate a key event into an `Action` when the playlist overlay is open.
 ///
 /// Called instead of `map_key` whenever `playlist_overlay.visible` is true and
@@ -1528,6 +1594,13 @@ fn map_key(
     if kb.go_to_nowplaying.matches(code, modifiers) {
         return Action::GoToNowPlaying;
     }
+    // Legacy tab jump: `4` used to open Now Playing before Radio became a popup.
+    if code == KeyCode::Char('4') && modifiers.is_empty() {
+        return Action::GoToNowPlaying;
+    }
+    if kb.toggle_radio.matches(code, modifiers) {
+        return Action::ToggleRadioPicker;
+    }
     if let Some(spec) = &kb.toggle_folder_browse {
         if spec.matches(code, modifiers) {
             return Action::ToggleBrowserFolder;
@@ -1603,6 +1676,9 @@ fn map_key(
     }
     if kb.toggle_queue_loop.matches(code, modifiers) {
         return Action::ToggleQueueLoop;
+    }
+    if active_tab == Tab::NowPlaying && kb.np_focus_queue.matches(code, modifiers) {
+        return Action::ToggleNpPaneFocus;
     }
     if kb.clear_queue.matches(code, modifiers) {
         return Action::ClearQueue;
@@ -1811,15 +1887,13 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
     let center = areas.center;
     let now_playing = areas.now_playing;
 
-    // ── Tab bar: dispatch GoToHome / GoToBrowser / GoToNowPlaying ────────────
+    // ── Tab bar: dispatch GoToHome / GoToBrowser / GoToNowPlaying ──
     if y == areas.tab_bar.y {
-        // The labels are:  " Home "  " │ "  " Browse "  " │ "  " Now Playing "
-        // Measure cumulative widths to decide which label was clicked.
         // Label widths (chars): Home=6, sep=3, Browse=8, sep=3, NowPlaying=13
         let home_end: u16 = 6;
-        let browser_start: u16 = 9; // 6+3
-        let browser_end: u16 = 17; // 9+8
-        let np_start: u16 = 20; // 17+3
+        let browser_start: u16 = 9;
+        let browser_end: u16 = 17;
+        let np_start: u16 = 20;
 
         let action = if x < home_end {
             Action::GoToHome
@@ -1828,10 +1902,31 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
         } else if x >= np_start {
             Action::GoToNowPlaying
         } else {
-            Action::None // clicked a separator
+            Action::None
         };
         app.dispatch(action);
         return;
+    }
+
+    if app.radio.picker_visible && app.radio.input_mode.is_normal() {
+        let area = terminal_size;
+        let w = (area.width * 4 / 5).clamp(40, area.width);
+        let h = (area.height * 7 / 10).clamp(8, area.height);
+        let popup = ratatui::layout::Rect {
+            x: area.x + (area.width.saturating_sub(w)) / 2,
+            y: area.y + (area.height.saturating_sub(h)) / 2,
+            width: w,
+            height: h,
+        };
+        if x >= popup.x
+            && x < popup.x + popup.width
+            && y >= popup.y + 1
+            && y < popup.y + popup.height.saturating_sub(1)
+        {
+            let visible_row = (y - popup.y - 1) as usize;
+            app.click_radio_row(visible_row);
+            return;
+        }
     }
 
     // ── Now-playing bar (layout matches `ui::now_playing::render`) ───────────
@@ -2119,6 +2214,16 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                 return;
             }
             let visible_row = (y - queue_area.y - 1) as usize;
+            if app.np_radio_pane_available() && app.np_pane_focus == crate::state::NowPlayingPaneFocus::Radio {
+                let visible_rows = queue_area.height.saturating_sub(2) as usize;
+                let hint_rows = if app.queue.songs.is_empty() { 1 } else { 2 };
+                let list_rows = visible_rows.saturating_sub(hint_rows).max(1);
+                if visible_row >= list_rows {
+                    return;
+                }
+                app.select_radio_visible_row(visible_row);
+                return;
+            }
             let clicked_idx = app.queue.scroll + visible_row;
             app.set_queue_cursor(clicked_idx);
         }

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -46,7 +46,9 @@ use action::{Action, Direction};
 use app::{App, BrowserColumn, Tab};
 use config::{AlbumArtBackend, BrowseMode, Config, HomePanel};
 use keybinds::Keybinds;
-use state::{FavoritesFocus, GlobalConfirm, LoadingState, PlaylistFocus, PlaylistInputMode, RadioInputMode};
+use state::{
+    FavoritesFocus, GlobalConfirm, LoadingState, PlaylistFocus, PlaylistInputMode, RadioInputMode,
+};
 
 /// Entry point shared by the `ratune` binary and integration tests.
 pub async fn run() -> Result<()> {
@@ -553,116 +555,120 @@ async fn run_loop(
                             app.art_cache_fingerprint,
                             app.art_cache.as_ref().map(|(id, _)| id.clone()),
                         ) {
-                        let show_art = app.config.nowplaying_show_art;
-                        let layout_opts = ui::layout::layout_options_for_app(app);
-                        let center = ui::layout::build_layout(terminal_rect, &layout_opts).center;
+                            let show_art = app.config.nowplaying_show_art;
+                            let layout_opts = ui::layout::layout_options_for_app(app);
+                            let center =
+                                ui::layout::build_layout(terminal_rect, &layout_opts).center;
 
-                        let boxed = app
-                            .config
-                            .now_playing_layout
-                            .trim()
-                            .eq_ignore_ascii_case("boxed");
+                            let boxed = app
+                                .config
+                                .now_playing_layout
+                                .trim()
+                                .eq_ignore_ascii_case("boxed");
 
-                        let art_position =
-                            ui::layout::placement_from_str(&app.config.nowplaying_art_position)
-                                .unwrap_or(ui::layout::Placement::Left);
-                        let queue_position =
-                            ui::layout::placement_from_str(&app.config.nowplaying_queue_position)
-                                .unwrap_or(ui::layout::Placement::Right);
-                        let visualizer_position =
-                            ui::layout::placement_from_str(&app.config.visualizer_location)
-                                .unwrap_or(ui::layout::Placement::Right);
-                        let now_playing_position =
-                            ui::layout::placement_from_str(&app.config.now_playing_box_location)
-                                .unwrap_or(ui::layout::Placement::Right);
-                        let lyrics_position =
-                            ui::layout::placement_from_str(&app.config.lyrics_location)
-                                .unwrap_or(queue_position);
+                            let art_position =
+                                ui::layout::placement_from_str(&app.config.nowplaying_art_position)
+                                    .unwrap_or(ui::layout::Placement::Left);
+                            let queue_position = ui::layout::placement_from_str(
+                                &app.config.nowplaying_queue_position,
+                            )
+                            .unwrap_or(ui::layout::Placement::Right);
+                            let visualizer_position =
+                                ui::layout::placement_from_str(&app.config.visualizer_location)
+                                    .unwrap_or(ui::layout::Placement::Right);
+                            let now_playing_position = ui::layout::placement_from_str(
+                                &app.config.now_playing_box_location,
+                            )
+                            .unwrap_or(ui::layout::Placement::Right);
+                            let lyrics_position =
+                                ui::layout::placement_from_str(&app.config.lyrics_location)
+                                    .unwrap_or(queue_position);
 
-                        let rects = ui::layout::now_playing_rects(
-                            center,
-                            show_art,
-                            art_position,
-                            queue_position,
-                            app.config.nowplaying_left_width_percent,
-                            app.config.nowplaying_vertical_fill_top_percent,
-                            app.visualizer_visible,
-                            visualizer_position,
-                            app.lyrics_visible,
-                            lyrics_position,
-                            boxed,
-                            now_playing_position,
-                        );
-                        let art_rect_opt = rects.art;
+                            let rects = ui::layout::now_playing_rects(
+                                center,
+                                show_art,
+                                art_position,
+                                queue_position,
+                                app.config.nowplaying_left_width_percent,
+                                app.config.nowplaying_vertical_fill_top_percent,
+                                app.visualizer_visible,
+                                visualizer_position,
+                                app.lyrics_visible,
+                                lyrics_position,
+                                boxed,
+                                now_playing_position,
+                            );
+                            let art_rect_opt = rects.art;
 
-                        if kitty_cover_unrenderable.as_deref() == Some(cover_id.as_str()) {
-                            if art_displayed {
-                                let _ = ui::kitty_art::clear_image(app.in_tmux);
-                                art_displayed = false;
-                            }
-                        } else if let Some(art_rect) = art_rect_opt {
-                            let inner = ui::kitty_art::album_art_placeholder_inner(art_rect);
-                            let font = app
-                                .art_picker
-                                .as_ref()
-                                .map(|p| p.font_size())
-                                .or(app.cell_px)
-                                .unwrap_or((10, 20));
-                            let placement = if app.ensure_art_cache_decoded() {
-                                app.art_cache_decoded.as_ref().map(|(_, img)| {
-                                    ui::art_prepare::contain_fit_rect_in_cells(img, inner, font)
-                                })
-                            } else {
-                                None
-                            }
-                            .unwrap_or(inner);
-                            if placement.width == 0 || placement.height == 0 {
+                            if kitty_cover_unrenderable.as_deref() == Some(cover_id.as_str()) {
                                 if art_displayed {
                                     let _ = ui::kitty_art::clear_image(app.in_tmux);
                                     art_displayed = false;
                                 }
-                                last_rendered_art = None;
-                            } else {
-                                let stored_matches = last_rendered_art
+                            } else if let Some(art_rect) = art_rect_opt {
+                                let inner = ui::kitty_art::album_art_placeholder_inner(art_rect);
+                                let font = app
+                                    .art_picker
                                     .as_ref()
-                                    .map(|(last_fp, r)| *last_fp == fp && r == &placement)
-                                    .unwrap_or(false);
-
-                                if stored_matches && art_displayed {
-                                    // Image is already visible — nothing to do.
+                                    .map(|p| p.font_size())
+                                    .or(app.cell_px)
+                                    .unwrap_or((10, 20));
+                                let placement = if app.ensure_art_cache_decoded() {
+                                    app.art_cache_decoded.as_ref().map(|(_, img)| {
+                                        ui::art_prepare::contain_fit_rect_in_cells(img, inner, font)
+                                    })
                                 } else {
-                                    let prepared =
-                                        app.ensure_np_kitty_prepared(placement, font).cloned();
-                                    let in_tmux = app.in_tmux;
-                                    let tmux_offset = app.tmux_status_offset;
-                                    if let Some(prepared) = prepared {
-                                        match ui::kitty_art::transmit_np_image(
-                                            &prepared,
-                                            placement,
-                                            in_tmux,
-                                            tmux_offset,
-                                        ) {
-                                            Ok(()) => {
-                                                last_rendered_art = Some((fp, placement));
-                                                art_displayed = true;
-                                            }
-                                            Err(e) => {
-                                                eprintln!("kitty render: {e}");
-                                                let _ = ui::kitty_art::clear_image(app.in_tmux);
-                                                kitty_cover_unrenderable = Some(cover_id.clone());
-                                                last_rendered_art = None;
-                                                art_displayed = false;
+                                    None
+                                }
+                                .unwrap_or(inner);
+                                if placement.width == 0 || placement.height == 0 {
+                                    if art_displayed {
+                                        let _ = ui::kitty_art::clear_image(app.in_tmux);
+                                        art_displayed = false;
+                                    }
+                                    last_rendered_art = None;
+                                } else {
+                                    let stored_matches = last_rendered_art
+                                        .as_ref()
+                                        .map(|(last_fp, r)| *last_fp == fp && r == &placement)
+                                        .unwrap_or(false);
+
+                                    if stored_matches && art_displayed {
+                                        // Image is already visible — nothing to do.
+                                    } else {
+                                        let prepared =
+                                            app.ensure_np_kitty_prepared(placement, font).cloned();
+                                        let in_tmux = app.in_tmux;
+                                        let tmux_offset = app.tmux_status_offset;
+                                        if let Some(prepared) = prepared {
+                                            match ui::kitty_art::transmit_np_image(
+                                                &prepared,
+                                                placement,
+                                                in_tmux,
+                                                tmux_offset,
+                                            ) {
+                                                Ok(()) => {
+                                                    last_rendered_art = Some((fp, placement));
+                                                    art_displayed = true;
+                                                }
+                                                Err(e) => {
+                                                    eprintln!("kitty render: {e}");
+                                                    let _ = ui::kitty_art::clear_image(app.in_tmux);
+                                                    kitty_cover_unrenderable =
+                                                        Some(cover_id.clone());
+                                                    last_rendered_art = None;
+                                                    art_displayed = false;
+                                                }
                                             }
                                         }
                                     }
                                 }
+                            } else if art_displayed {
+                                // Art column hidden — clear Kitty overlay.
+                                let _ = ui::kitty_art::clear_image(app.in_tmux);
+                                last_rendered_art = None;
+                                art_displayed = false;
                             }
-                        } else if art_displayed {
-                            // Art column hidden — clear Kitty overlay.
-                            let _ = ui::kitty_art::clear_image(app.in_tmux);
-                            last_rendered_art = None;
-                            art_displayed = false;
-                        }
                         }
                     } else if art_displayed {
                         // Stale cover (e.g. queue album art while radio is playing).
@@ -1339,7 +1345,11 @@ fn map_radio_picker_key(code: KeyCode, modifiers: KeyModifiers, kb: &Keybinds) -
     }
 }
 
-fn map_radio_form_key(code: KeyCode, _modifiers: KeyModifiers, input_mode: &RadioInputMode) -> Action {
+fn map_radio_form_key(
+    code: KeyCode,
+    _modifiers: KeyModifiers,
+    input_mode: &RadioInputMode,
+) -> Action {
     match input_mode {
         RadioInputMode::ConfirmingDelete { .. } => match code {
             KeyCode::Char('y') | KeyCode::Char('Y') => Action::RadioConfirmYes,
@@ -2214,7 +2224,9 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                 return;
             }
             let visible_row = (y - queue_area.y - 1) as usize;
-            if app.np_radio_pane_available() && app.np_pane_focus == crate::state::NowPlayingPaneFocus::Radio {
+            if app.np_radio_pane_available()
+                && app.np_pane_focus == crate::state::NowPlayingPaneFocus::Radio
+            {
                 let visible_rows = queue_area.height.saturating_sub(2) as usize;
                 let hint_rows = if app.queue.songs.is_empty() { 1 } else { 2 };
                 let list_rows = visible_rows.saturating_sub(hint_rows).max(1);

--- a/ratune/src/persist.rs
+++ b/ratune/src/persist.rs
@@ -7,6 +7,7 @@ use ratune_player::PlayerCommand;
 use ratune_subsonic::Song;
 
 use crate::app::{App, BrowserColumn, Tab};
+use crate::state::NowPlayingPaneFocus;
 
 // ── Saved state ───────────────────────────────────────────────────────────────
 
@@ -30,6 +31,9 @@ pub struct SavedState {
     /// Omitted in older state files: keep volume from `config.toml` on restore.
     #[serde(default)]
     pub player_volume: Option<u8>,
+    /// Now Playing sidebar: library queue vs radio station list.
+    #[serde(default)]
+    pub np_pane_focus: NowPlayingPaneFocus,
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -57,6 +61,7 @@ pub fn save_state(app: &App) -> Result<()> {
         queue: app.queue.songs.clone(),
         queue_cursor: app.queue.cursor,
         player_volume: Some(app.config.default_volume),
+        np_pane_focus: app.np_pane_focus,
     };
     let path = state_path()?;
     if let Some(parent) = path.parent() {
@@ -92,6 +97,12 @@ pub fn restore_state(app: &mut App) -> Result<()> {
         .min(app.queue.songs.len().saturating_sub(1));
     app.queue.scroll = app.queue.cursor;
     app.queue.adopt_current_order_as_shuffle_baseline();
+
+    app.np_pane_focus = if app.config.radio_enabled {
+        state.np_pane_focus
+    } else {
+        NowPlayingPaneFocus::Queue
+    };
 
     if let Some(vol) = state.player_volume {
         let v = vol.min(100);

--- a/ratune/src/state.rs
+++ b/ratune/src/state.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use ratune_subsonic::models::{Album, Artist, MusicFolder, Song};
+use ratune_subsonic::models::{Album, Artist, InternetRadioStation, MusicFolder, Song};
+use serde::{Deserialize, Serialize};
 
 // ── LoadingState ──────────────────────────────────────────────────────────────
 
@@ -80,6 +81,106 @@ impl LibraryState {
             self.selected_track.and_then(|i| songs.get(i))
         } else {
             None
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NowPlayingPaneFocus {
+    #[default]
+    Queue,
+    Radio,
+}
+
+// ── RadioState ────────────────────────────────────────────────────────────────
+
+/// Which field is focused in the radio station create/edit form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RadioField {
+    Name,
+    StreamUrl,
+    HomePageUrl,
+}
+
+impl RadioField {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Name => Self::StreamUrl,
+            Self::StreamUrl => Self::HomePageUrl,
+            Self::HomePageUrl => Self::Name,
+        }
+    }
+
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Name => Self::HomePageUrl,
+            Self::StreamUrl => Self::Name,
+            Self::HomePageUrl => Self::StreamUrl,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Name => "Name",
+            Self::StreamUrl => "Stream URL",
+            Self::HomePageUrl => "Homepage (optional)",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum RadioInputMode {
+    Normal,
+    Creating {
+        name: String,
+        stream_url: String,
+        home_page_url: String,
+        focused: RadioField,
+    },
+    Editing {
+        station_id: String,
+        name: String,
+        stream_url: String,
+        home_page_url: String,
+        focused: RadioField,
+    },
+    ConfirmingDelete {
+        station_id: String,
+        name: String,
+    },
+}
+
+impl Default for RadioInputMode {
+    fn default() -> Self {
+        Self::Normal
+    }
+}
+
+impl RadioInputMode {
+    pub fn is_normal(&self) -> bool {
+        matches!(self, Self::Normal)
+    }
+}
+
+/// Internet radio station list (`getInternetRadioStations`) and Shift+R picker.
+#[derive(Debug)]
+pub struct RadioState {
+    pub stations: LoadingState<Vec<InternetRadioStation>>,
+    pub selected: usize,
+    pub scroll: usize,
+    pub input_mode: RadioInputMode,
+    pub picker_visible: bool,
+}
+
+impl Default for RadioState {
+    fn default() -> Self {
+        Self {
+            stations: LoadingState::NotLoaded,
+            selected: 0,
+            scroll: 0,
+            input_mode: RadioInputMode::Normal,
+            picker_visible: false,
         }
     }
 }

--- a/ratune/src/ui/art_prepare.rs
+++ b/ratune/src/ui/art_prepare.rs
@@ -24,17 +24,20 @@ pub fn fit_image_to_pixel_budget(img: DynamicImage, max_w: u32, max_h: u32) -> D
     if iw == 0 || ih == 0 {
         return img;
     }
-    let (tw, th) = fit_inside(iw, ih, max_w, max_h);
+    let (tw, th) = fit_inside_scaled(iw, ih, max_w, max_h, false);
     if (tw, th) == (iw, ih) {
         return img;
     }
     img.resize_exact(tw, th, FilterType::Triangle)
 }
 
-fn fit_inside(w: u32, h: u32, max_w: u32, max_h: u32) -> (u32, u32) {
+fn fit_inside_scaled(w: u32, h: u32, max_w: u32, max_h: u32, allow_upscale: bool) -> (u32, u32) {
     let wratio = max_w as f64 / w as f64;
     let hratio = max_h as f64 / h as f64;
-    let ratio = f64::min(wratio, hratio);
+    let mut ratio = f64::min(wratio, hratio);
+    if !allow_upscale {
+        ratio = ratio.min(1.0);
+    }
     let nw = ((w as f64 * ratio).round() as u32).max(1);
     let nh = ((h as f64 * ratio).round() as u32).max(1);
     (nw, nh)
@@ -56,7 +59,7 @@ pub fn contain_fit_rect_in_cells(img: &DynamicImage, inner: Rect, font: FontSize
     }
     let max_w_px = inner.width as u32 * fw;
     let max_h_px = inner.height as u32 * fh;
-    let (fit_w_px, fit_h_px) = fit_inside(iw, ih, max_w_px, max_h_px);
+    let (fit_w_px, fit_h_px) = fit_inside_scaled(iw, ih, max_w_px, max_h_px, false);
 
     let w = fit_w_px.div_ceil(fw).max(1).min(inner.width as u32) as u16;
     let h = fit_h_px.div_ceil(fh).max(1).min(inner.height as u32) as u16;
@@ -89,6 +92,12 @@ pub fn art_bytes_fingerprint(bytes: &[u8]) -> u64 {
         h = h.wrapping_mul(PRIME);
     }
     h
+}
+
+/// Decode cover bytes (JPEG, PNG, ICO, …) for display.
+#[must_use]
+pub fn art_bytes_decode(bytes: &[u8]) -> Option<DynamicImage> {
+    image::load_from_memory(bytes).ok()
 }
 
 #[cfg(test)]
@@ -132,5 +141,35 @@ mod tests {
         let font = (10u16, 20u16);
         let fit = contain_fit_rect_in_cells(&img, inner, font);
         assert_eq!(fit, inner);
+    }
+
+    #[test]
+    fn contain_fit_rect_small_icon_not_upscaled() {
+        let inner = Rect::new(0, 0, 20, 10);
+        let img = solid(48, 48);
+        let font = (10u16, 10u16);
+        let fit = contain_fit_rect_in_cells(&img, inner, font);
+        assert_eq!(fit.width, 5);
+        assert_eq!(fit.height, 5);
+        assert_eq!(fit.x, 7);
+        assert_eq!(fit.y, 2);
+    }
+
+    #[test]
+    fn fit_image_does_not_upscale_small_sources() {
+        let img = solid(48, 48);
+        let out = fit_image_to_pixel_budget(img, 400, 400);
+        assert_eq!(out.width(), 48);
+        assert_eq!(out.height(), 48);
+    }
+
+    #[test]
+    fn decode_ico_favicon_file() {
+        let bytes = std::fs::read("/tmp/favicon.ico").unwrap_or_default();
+        if bytes.len() < 6 {
+            return;
+        }
+        let img = art_bytes_decode(&bytes).expect("ico decode");
+        assert!(img.width() > 0 && img.height() > 0);
     }
 }

--- a/ratune/src/ui/kitty_art.rs
+++ b/ratune/src/ui/kitty_art.rs
@@ -431,17 +431,16 @@ fn placeholder_row(cols: u16, image_id: u32, row_index: usize) -> String {
 
 // ── Rendering ─────────────────────────────────────────────────────────────────
 
-/// Same [`Block`] as `nowplaying_tab::render_art_placeholder` — use with [`album_art_placeholder_inner`].
+/// Bordered shell for the Now Playing art column (no title — set at render time).
 pub fn album_art_block() -> Block<'static> {
     Block::default()
-        .title(" Album Art ")
         .borders(Borders::ALL)
         .border_type(BorderType::Plain)
 }
 
-/// Content rectangle inside the "Album Art" bordered box (matches ratatui’s [`Block::inner`]).
+/// Content rectangle inside the album-art bordered box (matches ratatui’s [`Block::inner`]).
 pub fn album_art_placeholder_inner(outer: Rect) -> Rect {
-    album_art_block().inner(outer)
+    album_art_block().title(" Album Art ").inner(outer)
 }
 
 /// Cached resize + zlib for Now Playing Kitty APC (image id 1).

--- a/ratune/src/ui/mod.rs
+++ b/ratune/src/ui/mod.rs
@@ -14,6 +14,8 @@ pub mod nowplaying_tab;
 pub mod playlist_overlay;
 pub mod popup;
 pub mod queue;
+pub mod radio_nowplaying;
+pub mod radio_popup;
 pub mod status_bar;
 pub mod tab_bar;
 pub mod terminal_palette;
@@ -24,10 +26,6 @@ use crate::app::{App, Tab};
 use ratatui::Frame;
 
 use home_tab::render_home_tab;
-
-// Colour palette constants removed — all colours are now accessed via
-// `app.theme.*` (see `ratune/src/theme.rs`) so that the [theme] config
-// section can override them at runtime.
 
 // ── Top-level render ──────────────────────────────────────────────────────────
 
@@ -40,7 +38,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             render_home_tab(frame, areas.center, app, app.accent(), app.help_visible);
             now_playing::render(app, frame, areas.now_playing);
             status_bar::render(app, frame, areas.status_bar);
-            // Tab bar (skip if terminal is too small).
             if total_rows >= 20 {
                 tab_bar::render_tab_bar(
                     frame,
@@ -56,7 +53,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             browser::render(app, frame, areas.center);
             now_playing::render(app, frame, areas.now_playing);
             status_bar::render(app, frame, areas.status_bar);
-            // Tab bar (skip if terminal is too small).
             if total_rows >= 20 {
                 tab_bar::render_tab_bar(
                     frame,
@@ -72,7 +68,6 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             nowplaying_tab::render(app, frame, areas.center);
             now_playing::render(app, frame, areas.now_playing);
             status_bar::render(app, frame, areas.status_bar);
-            // Tab bar (skip if terminal is too small).
             if total_rows >= 20 {
                 tab_bar::render_tab_bar(
                     frame,
@@ -84,7 +79,9 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             }
         }
     }
-    // Popup renders last so it layers on top of everything.
+    if app.radio.picker_visible && app.config.radio_enabled {
+        radio_popup::render(app, frame, frame.area());
+    }
     if app.help_visible {
         popup::render_help(app, frame);
     }

--- a/ratune/src/ui/now_playing.rs
+++ b/ratune/src/ui/now_playing.rs
@@ -607,14 +607,27 @@ fn queue_position_now_playing(app: &App) -> Option<(usize, usize)> {
 }
 
 fn np_context(app: &App) -> NowPlayingContext<'_> {
+    let is_radio = app
+        .playback
+        .current_song
+        .as_ref()
+        .is_some_and(App::is_radio_song);
     NowPlayingContext {
         song: app.playback.current_song.as_ref(),
         elapsed: app.playback.elapsed,
         total: app.playback.total,
         paused: app.playback.paused,
         volume_percent: app.config.default_volume,
-        queue_total_duration_secs: queue_total_duration_secs(&app.queue),
-        queue_position: queue_position_now_playing(app),
+        queue_total_duration_secs: if is_radio {
+            None
+        } else {
+            queue_total_duration_secs(&app.queue)
+        },
+        queue_position: if is_radio {
+            None
+        } else {
+            queue_position_now_playing(app)
+        },
     }
 }
 
@@ -817,8 +830,79 @@ fn build_progress_bar(
     }
 }
 
+fn render_live_progress_line(
+    app: &App,
+    frame: &mut Frame,
+    area: Rect,
+    t: &crate::theme::Theme,
+    accent_color: ratatui::style::Color,
+    label: &str,
+    right: String,
+    animate: bool,
+) {
+    let col_w = area.width as usize;
+    let bar_w = col_w.saturating_sub(label.len() + right.len() + 4);
+    let ratio = if animate {
+        0.35 + 0.1 * ((app.playback.elapsed.as_secs() % 4) as f64 / 4.0)
+    } else {
+        0.0
+    };
+    let spec = parse_progress_style(&app.config.progress_style);
+    let (filled_str, partial_str, empty_str) = build_progress_bar(spec, ratio, bar_w);
+    let progress = Line::from(vec![
+        Span::styled(label, Style::default().fg(accent_color)),
+        Span::raw("  "),
+        Span::styled(filled_str, Style::default().fg(accent_color)),
+        Span::styled(partial_str, Style::default().fg(accent_color)),
+        Span::styled(empty_str, Style::default().fg(t.dimmed)),
+        Span::raw("  "),
+        Span::styled(right, Style::default().fg(t.dimmed)),
+    ]);
+    if area.height <= 1 {
+        frame.render_widget(
+            Paragraph::new(progress).style(style_with_bg(t.surface)),
+            area,
+        );
+        return;
+    }
+    let lines = vec![Line::from(""), Line::from(""), progress, Line::from("")];
+    frame.render_widget(Paragraph::new(lines).style(style_with_bg(t.surface)), area);
+}
+
 fn render_progress_widget(app: &App, frame: &mut Frame, area: Rect) {
     let t = &app.theme;
+    let accent_color = app.accent();
+
+    if app.radio_buffering() {
+        render_live_progress_line(
+            app,
+            frame,
+            area,
+            t,
+            accent_color,
+            "Buffering",
+            String::new(),
+            false,
+        );
+        return;
+    }
+
+    if app.radio_now_playing_active() && app.playback.current_song.is_some() {
+        let e = app.playback.elapsed.as_secs();
+        let elapsed_str = format!("{}:{:02}", e / 60, e % 60);
+        render_live_progress_line(
+            app,
+            frame,
+            area,
+            t,
+            accent_color,
+            "● LIVE",
+            elapsed_str,
+            true,
+        );
+        return;
+    }
+
     let (elapsed_str, total_str, ratio) = if app.playback.current_song.is_some() {
         let e = app.playback.elapsed.as_secs();
         let elapsed_str = format!("{}:{:02}", e / 60, e % 60);
@@ -841,8 +925,6 @@ fn render_progress_widget(app: &App, frame: &mut Frame, area: Rect) {
 
     let col_w = area.width as usize;
     let bar_w = col_w.saturating_sub(elapsed_str.len() + total_str.len() + 4);
-
-    let accent_color = app.accent();
 
     let spec = parse_progress_style(&app.config.progress_style);
     let (filled_str, partial_str, empty_str) = build_progress_bar(spec, ratio, bar_w);

--- a/ratune/src/ui/nowplaying_tab.rs
+++ b/ratune/src/ui/nowplaying_tab.rs
@@ -51,7 +51,18 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
         render_art_placeholder(app, frame, r);
     }
     if let Some(r) = rects.queue {
-        queue::render(app, frame, r, true);
+        if app.np_radio_pane_available() {
+            match app.np_pane_focus {
+                crate::state::NowPlayingPaneFocus::Radio => {
+                    super::radio_nowplaying::render(app, frame, r, true);
+                }
+                crate::state::NowPlayingPaneFocus::Queue => {
+                    queue::render(app, frame, r, true);
+                }
+            }
+        } else {
+            queue::render(app, frame, r, true);
+        }
     }
     if let Some(r) = rects.visualizer {
         render_visualizer_pane(app, frame, r);
@@ -89,6 +100,11 @@ fn sync_np_ratatui_protocol(app: &mut App, art_rect: Rect) {
     }
     if let Some(p) = app.art_picker.as_mut() {
         p.set_background_color(crate::theme::surface_pad_rgba(app.theme.surface));
+    }
+    if !app.np_art_cache_matches() {
+        app.np_art_state = None;
+        app.np_art_prep_key = None;
+        return;
     }
     if app.art_cache.is_none() {
         app.np_art_state = None;
@@ -134,7 +150,15 @@ fn sync_np_ratatui_protocol(app: &mut App, art_rect: Rect) {
 
 fn render_art_placeholder(app: &mut App, frame: &mut Frame, area: Rect) {
     let t = &app.theme;
+    let art_title = app
+        .playback
+        .current_song
+        .as_ref()
+        .filter(|s| App::is_radio_song(s))
+        .map(|s| format!(" {} ", s.title))
+        .unwrap_or_else(|| " Album Art ".to_string());
     let block = crate::ui::kitty_art::album_art_block()
+        .title(art_title)
         .title_style(Style::default().fg(t.dimmed).add_modifier(Modifier::BOLD))
         .border_style(Style::default().fg(t.border));
     frame.render_widget(block, area);
@@ -143,6 +167,7 @@ fn render_art_placeholder(app: &mut App, frame: &mut Frame, area: Rect) {
         && !app.ratatui_uses_kitty_apc()
         && !app.help_visible
         && app.config.nowplaying_show_art
+        && app.np_art_cache_matches()
     {
         let inner = crate::ui::kitty_art::album_art_placeholder_inner(area);
         if inner.width > 0 && inner.height > 0 {

--- a/ratune/src/ui/popup.rs
+++ b/ratune/src/ui/popup.rs
@@ -12,8 +12,21 @@ use crate::theme::style_with_bg;
 /// Width reserved for the key column (padded with spaces to align descriptions).
 const KEY_COL_W: usize = 12;
 
-fn sections() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
-    vec![
+fn sections(radio_enabled: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+    let mut playback = vec![
+        ("p / Space", "Play / pause"),
+        ("n / N", "Next / previous track"),
+        ("f", "Toggle favorite (song / album / artist)"),
+        ("F", "Favorites panel (Browse tab)"),
+        ("x / Z", "Shuffle / unshuffle"),
+        ("Q", "Toggle queue loop"),
+    ];
+    if radio_enabled {
+        playback.push(("Shift+R", "Open / close internet radio picker"));
+    }
+    playback.push(("\u{2190} / \u{2192}", "Seek \u{b1}10s"));
+
+    let mut out = vec![
         (
             "Navigation",
             vec![
@@ -40,18 +53,7 @@ fn sections() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("Enter", "Go to artist in Browse"),
             ],
         ),
-        (
-            "Playback",
-            vec![
-                ("p / Space", "Play / pause"),
-                ("n / N", "Next / previous track"),
-                ("f", "Toggle favorite (song / album / artist)"),
-                ("F", "Favorites panel (Browse tab)"),
-                ("x / Z", "Shuffle / unshuffle"),
-                ("R", "Toggle queue loop"),
-                ("\u{2190} / \u{2192}", "Seek \u{b1}10s"),
-            ],
-        ),
+        ("Playback", playback),
         (
             "Queue",
             vec![
@@ -87,7 +89,40 @@ fn sections() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
             "App",
             vec![("i", "Toggle this help"), ("q", "Quit (or close help)")],
         ),
-    ]
+    ];
+
+    if radio_enabled {
+        out.insert(
+            3,
+            (
+                "Radio",
+                vec![
+                    ("Shift+R", "Open / close station picker"),
+                    ("Enter", "Play selected station"),
+                    ("c", "Add a new station"),
+                    ("e", "Edit selected station"),
+                    ("X", "Delete selected station"),
+                    ("n / N", "Next / previous station (while playing)"),
+                    ("r", "Refresh station list"),
+                ],
+            ),
+        );
+        out.insert(
+            4,
+            (
+                "Now Playing (radio)",
+                vec![
+                    ("j / k", "Change station (radio pane)"),
+                    ("Enter", "Tune in to selected station"),
+                    ("Ctrl+g", "Switch radio pane ↔ library queue"),
+                    ("p / Space", "Pause / resume live stream"),
+                    ("n / N", "Next / previous station"),
+                ],
+            ),
+        );
+    }
+
+    out
 }
 
 fn playlist_sections() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
@@ -193,7 +228,7 @@ pub fn render_help(app: &mut App, frame: &mut Frame) {
     // Keep each category within one column where possible, while aiming for
     // roughly equal column heights.
 
-    let mut blocks = build_blocks(sections(), accent, fg, dim);
+    let mut blocks = build_blocks(sections(app.config.radio_enabled), accent, fg, dim);
     blocks.push(vec![Line::from("")]);
     blocks.extend(build_blocks(playlist_sections(), accent, fg, dim));
     let (left_all, right_all) = pack_blocks_into_two_columns(blocks);

--- a/ratune/src/ui/popup.rs
+++ b/ratune/src/ui/popup.rs
@@ -112,8 +112,6 @@ fn sections(radio_enabled: bool) -> Vec<(&'static str, Vec<(&'static str, &'stat
             (
                 "Now Playing (radio)",
                 vec![
-                    ("j / k", "Change station (radio pane)"),
-                    ("Enter", "Tune in to selected station"),
                     ("Ctrl+g", "Switch radio pane ↔ library queue"),
                     ("p / Space", "Pause / resume live stream"),
                     ("n / N", "Next / previous station"),

--- a/ratune/src/ui/queue.rs
+++ b/ratune/src/ui/queue.rs
@@ -38,13 +38,23 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         .style(style_with_bg(t.surface));
 
     if app.queue.songs.is_empty() {
-        let mut msg = "Queue is empty — press 'a' to add tracks".to_string();
-        if app.config.show_fzf_hint
-            && app.config.library_index_enabled
-            && app.keybinds.library_fzf.is_some()
+        let msg = if app
+            .playback
+            .current_song
+            .as_ref()
+            .is_some_and(App::is_radio_song)
         {
-            msg.push_str(" · Ctrl+f: library picker");
-        }
+            "Playing live radio — library queue is unchanged".to_string()
+        } else {
+            let mut m = "Queue is empty — press 'a' to add tracks".to_string();
+            if app.config.show_fzf_hint
+                && app.config.library_index_enabled
+                && app.keybinds.library_fzf.is_some()
+            {
+                m.push_str(" · Ctrl+f: library picker");
+            }
+            m
+        };
         let item = ListItem::new(msg).style(Style::default().fg(t.dimmed));
         let list = List::new(vec![item]).block(block);
         frame.render_widget(list, area);

--- a/ratune/src/ui/radio_nowplaying.rs
+++ b/ratune/src/ui/radio_nowplaying.rs
@@ -13,11 +13,7 @@ use crate::theme::style_with_bg;
 pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
     let t = &app.theme;
     let accent = app.accent();
-    let border_color = if is_active {
-        t.border_active
-    } else {
-        t.border
-    };
+    let border_color = if is_active { t.border_active } else { t.border };
     let title_color = if is_active { accent } else { t.dimmed };
 
     let queue_n = app.queue.songs.len();
@@ -48,25 +44,25 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
 
     match &app.radio.stations {
         LoadingState::NotLoaded | LoadingState::Loading => {
-            let list = List::new(vec![ListItem::new("Loading stations…").style(
-                Style::default().fg(t.dimmed),
-            )])
+            let list = List::new(vec![
+                ListItem::new("Loading stations…").style(Style::default().fg(t.dimmed))
+            ])
             .block(block);
             frame.render_widget(list, area);
         }
         LoadingState::Error(e) => {
-            let list = List::new(vec![ListItem::new(format!("Error: {e}")).style(
-                Style::default().fg(accent),
-            )])
+            let list = List::new(vec![
+                ListItem::new(format!("Error: {e}")).style(Style::default().fg(accent))
+            ])
             .block(block);
             frame.render_widget(list, area);
         }
         LoadingState::Loaded(stations) => {
             if stations.is_empty() {
-                let list = List::new(vec![ListItem::new("No stations configured").style(
-                    Style::default().fg(t.dimmed),
-                )])
-                .block(block);
+                let list =
+                    List::new(vec![ListItem::new("No stations configured")
+                        .style(Style::default().fg(t.dimmed))])
+                    .block(block);
                 frame.render_widget(list, area);
                 return;
             }
@@ -103,9 +99,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                     };
                     let label = format!("{marker}{}", station.name);
                     let style = if global_idx == app.radio.selected {
-                        Style::default()
-                            .fg(accent)
-                            .add_modifier(Modifier::BOLD)
+                        Style::default().fg(accent).add_modifier(Modifier::BOLD)
                     } else if playing {
                         Style::default().fg(t.foreground)
                     } else {
@@ -117,11 +111,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
 
             let list = List::new(items)
                 .block(block)
-                .highlight_style(
-                    Style::default()
-                        .fg(accent)
-                        .add_modifier(Modifier::BOLD),
-                )
+                .highlight_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
                 .style(style_with_bg(t.surface));
 
             let mut state = ListState::default();
@@ -198,12 +188,10 @@ fn render_radio_hints(app: &App, frame: &mut Frame, area: Rect, hint_rows: usize
         );
     } else {
         frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled(
-                    "j/k station · Enter tune · Ctrl+g queue",
-                    Style::default().fg(t.dimmed),
-                ),
-            ])),
+            Paragraph::new(Line::from(vec![Span::styled(
+                "j/k station · Enter tune · Ctrl+g queue",
+                Style::default().fg(t.dimmed),
+            )])),
             hint_area,
         );
     }

--- a/ratune/src/ui/radio_nowplaying.rs
+++ b/ratune/src/ui/radio_nowplaying.rs
@@ -68,8 +68,8 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
             }
 
             let visible_rows = area.height.saturating_sub(2) as usize;
-            let hint_rows = radio_hint_rows(app.queue.songs.len());
-            let list_rows = visible_rows.saturating_sub(hint_rows).max(1);
+            const HINT_ROWS: usize = 1;
+            let list_rows = visible_rows.saturating_sub(HINT_ROWS).max(1);
             app.queue_viewport_rows = list_rows;
             LibraryState::clamp_vertical_scroll(
                 &mut app.radio.scroll,
@@ -123,76 +123,31 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
             state.select(Some(selected));
             frame.render_stateful_widget(list, area, &mut state);
 
-            if hint_rows > 0 {
-                render_radio_hints(app, frame, area, hint_rows, queue_n);
+            if area.height > 4 {
+                render_radio_hints(app, frame, area, queue_n);
             }
         }
     }
 }
 
-fn radio_hint_rows(queue_len: usize) -> usize {
-    if queue_len > 0 {
-        2
-    } else {
-        1
-    }
-}
-
-fn render_radio_hints(app: &App, frame: &mut Frame, area: Rect, hint_rows: usize, queue_n: usize) {
+fn render_radio_hints(app: &App, frame: &mut Frame, area: Rect, queue_n: usize) {
     let t = &app.theme;
-    let y = area.y + area.height.saturating_sub(hint_rows as u16 + 1);
+    let hint = if queue_n > 0 {
+        "Ctrl+g library queue · Enter play queue"
+    } else {
+        "Ctrl+g library queue"
+    };
     let hint_area = Rect {
         x: area.x + 1,
-        y,
+        y: area.y + area.height.saturating_sub(1),
         width: area.width.saturating_sub(2),
-        height: hint_rows as u16,
+        height: 1,
     };
-    if hint_area.height == 0 {
-        return;
-    }
-
-    let line1 = Line::from(vec![
-        Span::styled("j/k", Style::default().fg(t.dimmed)),
-        Span::styled(" change station  ·  ", Style::default().fg(t.dimmed)),
-        Span::styled("Enter", Style::default().fg(t.dimmed)),
-        Span::styled(" tune in", Style::default().fg(t.dimmed)),
-    ]);
-    if queue_n == 0 {
-        frame.render_widget(Paragraph::new(line1), hint_area);
-        return;
-    }
-
-    let line2 = Line::from(vec![
-        Span::styled("Ctrl+g", Style::default().fg(t.dimmed)),
-        Span::styled(" library queue  ·  ", Style::default().fg(t.dimmed)),
-        Span::styled("Enter", Style::default().fg(t.dimmed)),
-        Span::styled(" play queue", Style::default().fg(t.dimmed)),
-    ]);
-    if hint_area.height >= 2 {
-        let row_h = hint_area.height / 2;
-        frame.render_widget(
-            Paragraph::new(line1),
-            Rect {
-                height: row_h,
-                ..hint_area
-            },
-        );
-        frame.render_widget(
-            Paragraph::new(line2),
-            Rect {
-                y: hint_area.y + row_h,
-                height: hint_area.height - row_h,
-                x: hint_area.x,
-                width: hint_area.width,
-            },
-        );
-    } else {
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![Span::styled(
-                "j/k station · Enter tune · Ctrl+g queue",
-                Style::default().fg(t.dimmed),
-            )])),
-            hint_area,
-        );
-    }
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            hint,
+            Style::default().fg(t.dimmed),
+        )])),
+        hint_area,
+    );
 }

--- a/ratune/src/ui/radio_nowplaying.rs
+++ b/ratune/src/ui/radio_nowplaying.rs
@@ -1,0 +1,210 @@
+//! Radio station list pane on the Now Playing tab (while live radio is active).
+
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+
+use crate::app::App;
+use crate::state::{LibraryState, LoadingState};
+use crate::theme::style_with_bg;
+
+pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
+    let t = &app.theme;
+    let accent = app.accent();
+    let border_color = if is_active {
+        t.border_active
+    } else {
+        t.border
+    };
+    let title_color = if is_active { accent } else { t.dimmed };
+
+    let queue_n = app.queue.songs.len();
+    let title = if queue_n == 0 {
+        " Radio ".to_string()
+    } else {
+        format!(" Radio · {queue_n} queued ")
+    };
+
+    let block = Block::default()
+        .title(title)
+        .title_style(
+            Style::default()
+                .fg(title_color)
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(border_color))
+        .style(style_with_bg(t.surface));
+
+    let playing_id = app
+        .playback
+        .current_song
+        .as_ref()
+        .filter(|s| App::is_radio_song(s))
+        .and_then(|s| s.id.strip_prefix("radio:"));
+
+    match &app.radio.stations {
+        LoadingState::NotLoaded | LoadingState::Loading => {
+            let list = List::new(vec![ListItem::new("Loading stations…").style(
+                Style::default().fg(t.dimmed),
+            )])
+            .block(block);
+            frame.render_widget(list, area);
+        }
+        LoadingState::Error(e) => {
+            let list = List::new(vec![ListItem::new(format!("Error: {e}")).style(
+                Style::default().fg(accent),
+            )])
+            .block(block);
+            frame.render_widget(list, area);
+        }
+        LoadingState::Loaded(stations) => {
+            if stations.is_empty() {
+                let list = List::new(vec![ListItem::new("No stations configured").style(
+                    Style::default().fg(t.dimmed),
+                )])
+                .block(block);
+                frame.render_widget(list, area);
+                return;
+            }
+
+            let visible_rows = area.height.saturating_sub(2) as usize;
+            let hint_rows = radio_hint_rows(app.queue.songs.len());
+            let list_rows = visible_rows.saturating_sub(hint_rows).max(1);
+            app.queue_viewport_rows = list_rows;
+            LibraryState::clamp_vertical_scroll(
+                &mut app.radio.scroll,
+                app.radio.selected,
+                stations.len(),
+                list_rows,
+            );
+
+            let items: Vec<ListItem> = stations
+                .iter()
+                .enumerate()
+                .skip(app.radio.scroll)
+                .take(list_rows)
+                .map(|(i, station)| {
+                    let global_idx = app.radio.scroll + i;
+                    let buffering =
+                        playing_id == Some(station.id.as_str()) && app.radio_buffering();
+                    let playing = playing_id == Some(station.id.as_str())
+                        && !app.playback.paused
+                        && app.playback.player_loaded;
+                    let marker = if playing {
+                        "▶ "
+                    } else if buffering {
+                        "◌ "
+                    } else {
+                        "  "
+                    };
+                    let label = format!("{marker}{}", station.name);
+                    let style = if global_idx == app.radio.selected {
+                        Style::default()
+                            .fg(accent)
+                            .add_modifier(Modifier::BOLD)
+                    } else if playing {
+                        Style::default().fg(t.foreground)
+                    } else {
+                        Style::default().fg(t.dimmed)
+                    };
+                    ListItem::new(label).style(style)
+                })
+                .collect();
+
+            let list = List::new(items)
+                .block(block)
+                .highlight_style(
+                    Style::default()
+                        .fg(accent)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .style(style_with_bg(t.surface));
+
+            let mut state = ListState::default();
+            let selected = app
+                .radio
+                .selected
+                .saturating_sub(app.radio.scroll)
+                .min(list_rows.saturating_sub(1));
+            state.select(Some(selected));
+            frame.render_stateful_widget(list, area, &mut state);
+
+            if hint_rows > 0 {
+                render_radio_hints(app, frame, area, hint_rows, queue_n);
+            }
+        }
+    }
+}
+
+fn radio_hint_rows(queue_len: usize) -> usize {
+    if queue_len > 0 {
+        2
+    } else {
+        1
+    }
+}
+
+fn render_radio_hints(app: &App, frame: &mut Frame, area: Rect, hint_rows: usize, queue_n: usize) {
+    let t = &app.theme;
+    let y = area.y + area.height.saturating_sub(hint_rows as u16 + 1);
+    let hint_area = Rect {
+        x: area.x + 1,
+        y,
+        width: area.width.saturating_sub(2),
+        height: hint_rows as u16,
+    };
+    if hint_area.height == 0 {
+        return;
+    }
+
+    let line1 = Line::from(vec![
+        Span::styled("j/k", Style::default().fg(t.dimmed)),
+        Span::styled(" change station  ·  ", Style::default().fg(t.dimmed)),
+        Span::styled("Enter", Style::default().fg(t.dimmed)),
+        Span::styled(" tune in", Style::default().fg(t.dimmed)),
+    ]);
+    if queue_n == 0 {
+        frame.render_widget(Paragraph::new(line1), hint_area);
+        return;
+    }
+
+    let line2 = Line::from(vec![
+        Span::styled("Ctrl+g", Style::default().fg(t.dimmed)),
+        Span::styled(" library queue  ·  ", Style::default().fg(t.dimmed)),
+        Span::styled("Enter", Style::default().fg(t.dimmed)),
+        Span::styled(" play queue", Style::default().fg(t.dimmed)),
+    ]);
+    if hint_area.height >= 2 {
+        let row_h = hint_area.height / 2;
+        frame.render_widget(
+            Paragraph::new(line1),
+            Rect {
+                height: row_h,
+                ..hint_area
+            },
+        );
+        frame.render_widget(
+            Paragraph::new(line2),
+            Rect {
+                y: hint_area.y + row_h,
+                height: hint_area.height - row_h,
+                x: hint_area.x,
+                width: hint_area.width,
+            },
+        );
+    } else {
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(
+                    "j/k station · Enter tune · Ctrl+g queue",
+                    Style::default().fg(t.dimmed),
+                ),
+            ])),
+            hint_area,
+        );
+    }
+}

--- a/ratune/src/ui/radio_popup.rs
+++ b/ratune/src/ui/radio_popup.rs
@@ -1,0 +1,254 @@
+//! Internet radio station picker (Shift+R) — play, browse, and manage stations.
+
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+
+use crate::app::App;
+use crate::state::{LoadingState, RadioField, RadioInputMode};
+use crate::theme::style_with_bg;
+
+pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
+    if !app.radio.input_mode.is_normal() {
+        render_form(app, frame, area);
+        return;
+    }
+
+    let w = (area.width * 4 / 5).clamp(40, area.width);
+    let h = (area.height * 7 / 10).clamp(8, area.height);
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    frame.render_widget(Clear, popup);
+
+    let t = &app.theme;
+    let accent = app.accent();
+    let block = Block::default()
+        .title(" Internet Radio ")
+        .title_style(
+            Style::default()
+                .fg(accent)
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
+        .style(style_with_bg(t.surface));
+
+    match &app.radio.stations {
+        LoadingState::NotLoaded | LoadingState::Loading => {
+            let list = List::new(vec![ListItem::new("Loading stations…").style(
+                Style::default().fg(t.dimmed),
+            )])
+            .block(block);
+            frame.render_widget(list, popup);
+        }
+        LoadingState::Error(e) => {
+            let list = List::new(vec![
+                ListItem::new(format!("Error: {e}")).style(Style::default().fg(accent)),
+                ListItem::new("Press r to retry · c to add a station").style(
+                    Style::default().fg(t.dimmed),
+                ),
+            ])
+            .block(block);
+            frame.render_widget(list, popup);
+        }
+        LoadingState::Loaded(stations) => {
+            if stations.is_empty() {
+                let list = List::new(vec![
+                    ListItem::new("No stations yet").style(Style::default().fg(t.dimmed)),
+                    ListItem::new("Press c to add a station").style(Style::default().fg(t.dimmed)),
+                ])
+                .block(block);
+                frame.render_widget(list, popup);
+                return;
+            }
+
+            let playing_id = app
+                .playback
+                .current_song
+                .as_ref()
+                .filter(|s| App::is_radio_song(s))
+                .and_then(|s| s.id.strip_prefix("radio:"));
+
+            let visible_rows = popup.height.saturating_sub(2) as usize;
+            let items: Vec<ListItem> = stations
+                .iter()
+                .enumerate()
+                .skip(app.radio.scroll)
+                .take(visible_rows.max(1))
+                .map(|(i, station)| {
+                    let global_idx = app.radio.scroll + i;
+                    let buffering =
+                        playing_id == Some(station.id.as_str()) && app.radio_buffering();
+                    let playing = playing_id == Some(station.id.as_str())
+                        && !app.playback.paused
+                        && app.playback.player_loaded;
+                    let marker = if playing {
+                        "▶ "
+                    } else if buffering {
+                        "◌ "
+                    } else {
+                        "  "
+                    };
+                    let label = format!("{marker}{}", station.name);
+                    let style = if global_idx == app.radio.selected {
+                        Style::default()
+                            .fg(accent)
+                            .add_modifier(Modifier::BOLD)
+                    } else if playing {
+                        Style::default().fg(t.foreground)
+                    } else {
+                        Style::default().fg(t.dimmed)
+                    };
+                    ListItem::new(label).style(style)
+                })
+                .collect();
+
+            let list = List::new(items).block(block);
+            let mut state = ListState::default();
+            if app.radio.selected >= app.radio.scroll {
+                let local = app.radio.selected - app.radio.scroll;
+                if local < visible_rows.max(1) {
+                    state.select(Some(local));
+                }
+            }
+            frame.render_stateful_widget(list, popup, &mut state);
+
+            let hint = Paragraph::new(Line::from(vec![Span::styled(
+                "Enter play · c add · e edit · X delete · r refresh · Esc close",
+                Style::default().fg(t.dimmed),
+            )]));
+            let hint_area = Rect {
+                x: popup.x + 1,
+                y: popup.y + popup.height.saturating_sub(1),
+                width: popup.width.saturating_sub(2),
+                height: 1,
+            };
+            if hint_area.height > 0 && popup.height > 4 {
+                frame.render_widget(hint, hint_area);
+            }
+        }
+    }
+}
+
+fn render_form(app: &App, frame: &mut Frame, area: Rect) {
+    let t = &app.theme;
+    let accent = app.accent();
+
+    match &app.radio.input_mode {
+        RadioInputMode::ConfirmingDelete { name, .. } => {
+            let popup_w = (area.width * 3 / 4).clamp(32, area.width);
+            let popup_h = 5u16.min(area.height);
+            let popup = Rect {
+                x: area.x + (area.width.saturating_sub(popup_w)) / 2,
+                y: area.y + (area.height.saturating_sub(popup_h)) / 2,
+                width: popup_w,
+                height: popup_h,
+            };
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(" Delete station? ")
+                .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .style(style_with_bg(t.surface));
+            let text = format!("Delete \"{name}\"?\n\ny confirm · n cancel");
+            let para = Paragraph::new(text).block(block);
+            frame.render_widget(para, popup);
+            return;
+        }
+        RadioInputMode::Creating { .. } | RadioInputMode::Editing { .. } => {
+            let title = match &app.radio.input_mode {
+                RadioInputMode::Creating { .. } => " New radio station ",
+                RadioInputMode::Editing { .. } => " Edit radio station ",
+                _ => unreachable!(),
+            };
+            let popup_w = (area.width * 4 / 5).clamp(40, area.width);
+            let popup_h = 11u16.min(area.height);
+            let popup = Rect {
+                x: area.x + (area.width.saturating_sub(popup_w)) / 2,
+                y: area.y + (area.height.saturating_sub(popup_h)) / 2,
+                width: popup_w,
+                height: popup_h,
+            };
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(title)
+                .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .style(style_with_bg(t.surface));
+
+            let focused = match &app.radio.input_mode {
+                RadioInputMode::Creating { focused, .. }
+                | RadioInputMode::Editing { focused, .. } => *focused,
+                _ => RadioField::Name,
+            };
+
+            let (name, stream_url, home_page_url) = match &app.radio.input_mode {
+                RadioInputMode::Creating {
+                    name,
+                    stream_url,
+                    home_page_url,
+                    ..
+                }
+                | RadioInputMode::Editing {
+                    name,
+                    stream_url,
+                    home_page_url,
+                    ..
+                } => (name.as_str(), stream_url.as_str(), home_page_url.as_str()),
+                _ => ("", "", ""),
+            };
+
+            let fields = [
+                (RadioField::Name, name),
+                (RadioField::StreamUrl, stream_url),
+                (RadioField::HomePageUrl, home_page_url),
+            ];
+
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+
+            let rows = Layout::vertical([
+                Constraint::Length(2),
+                Constraint::Length(2),
+                Constraint::Length(2),
+                Constraint::Min(1),
+            ])
+            .split(inner);
+
+            for (i, (field, value)) in fields.iter().enumerate() {
+                let is_focus = *field == focused;
+                let label = format!("{}: ", field.label());
+                let display = if value.is_empty() && is_focus {
+                    format!("{label}_")
+                } else if is_focus {
+                    format!("{label}{value}_")
+                } else {
+                    format!("{label}{value}")
+                };
+                let style = if is_focus {
+                    Style::default().fg(accent).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(t.dimmed)
+                };
+                frame.render_widget(Paragraph::new(display).style(style), rows[i]);
+            }
+
+            frame.render_widget(
+                Paragraph::new("Tab next field · Enter save · Esc cancel").style(
+                    Style::default().fg(t.dimmed),
+                ),
+                rows[3],
+            );
+        }
+        RadioInputMode::Normal => {}
+    }
+}

--- a/ratune/src/ui/radio_popup.rs
+++ b/ratune/src/ui/radio_popup.rs
@@ -30,11 +30,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
     let accent = app.accent();
     let block = Block::default()
         .title(" Internet Radio ")
-        .title_style(
-            Style::default()
-                .fg(accent)
-                .add_modifier(Modifier::BOLD),
-        )
+        .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
         .border_type(BorderType::Plain)
         .border_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
@@ -42,18 +38,17 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
 
     match &app.radio.stations {
         LoadingState::NotLoaded | LoadingState::Loading => {
-            let list = List::new(vec![ListItem::new("Loading stations…").style(
-                Style::default().fg(t.dimmed),
-            )])
+            let list = List::new(vec![
+                ListItem::new("Loading stations…").style(Style::default().fg(t.dimmed))
+            ])
             .block(block);
             frame.render_widget(list, popup);
         }
         LoadingState::Error(e) => {
             let list = List::new(vec![
                 ListItem::new(format!("Error: {e}")).style(Style::default().fg(accent)),
-                ListItem::new("Press r to retry · c to add a station").style(
-                    Style::default().fg(t.dimmed),
-                ),
+                ListItem::new("Press r to retry · c to add a station")
+                    .style(Style::default().fg(t.dimmed)),
             ])
             .block(block);
             frame.render_widget(list, popup);
@@ -98,9 +93,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
                     };
                     let label = format!("{marker}{}", station.name);
                     let style = if global_idx == app.radio.selected {
-                        Style::default()
-                            .fg(accent)
-                            .add_modifier(Modifier::BOLD)
+                        Style::default().fg(accent).add_modifier(Modifier::BOLD)
                     } else if playing {
                         Style::default().fg(t.foreground)
                     } else {
@@ -243,9 +236,8 @@ fn render_form(app: &App, frame: &mut Frame, area: Rect) {
             }
 
             frame.render_widget(
-                Paragraph::new("Tab next field · Enter save · Esc cancel").style(
-                    Style::default().fg(t.dimmed),
-                ),
+                Paragraph::new("Tab next field · Enter save · Esc cancel")
+                    .style(Style::default().fg(t.dimmed)),
                 rows[3],
             );
         }


### PR DESCRIPTION
Radio support! See #37 

Includes:
- radio panel (`shift+r` is default in browse tab)
- full support for mp3, aac, and ogg streams
- visualizer support
- station art (when available)
- ability to switch between radio list and queue in now playing
- ability to add/edit/remove stations with radio popup

Two config options available:
```toml
[radio]
enabled = true
fetch_station_icons = true
```