### PR TITLE
feat: optional alias for displayed server name

### DIFF
--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -47,6 +47,7 @@
 #
 # url       — Base URL of the server (no trailing path required in most setups).
 # username  — Subsonic username.
+# alias     — Optional label shown in the status bar instead of the server URL (privacy).
 #
 # Secret (pick one):
 #   password = "" (default) — OS keyring via keyring-core. First run prompts once; stored as service
@@ -66,6 +67,7 @@
 url = ""
 username = ""
 password = ""
+# alias = "Home server"
 # password_keyring = "keyutils"       # Linux only: "keyutils" (default) or "secret-service"
 # password_command = "secret-tool lookup service subsonic user you"
 # connection_check_interval_secs = 45  # background ping for online/offline; 0 = startup only

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -1443,10 +1443,7 @@ impl Config {
         Ok(Config {
             subsonic_url: file_cfg.server.url,
             subsonic_user: file_cfg.server.username,
-            server_alias: file_cfg
-                .server
-                .alias
-                .filter(|s| !s.trim().is_empty()),
+            server_alias: file_cfg.server.alias.filter(|s| !s.trim().is_empty()),
             connection_check_interval_secs: file_cfg.server.connection_check_interval_secs,
             subsonic_pass,
             default_volume: file_cfg.player.default_volume,

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -954,6 +954,9 @@ struct ServerSection {
     /// `0` disables periodic checks (startup ping still runs). Default: 45.
     #[serde(default = "default_connection_check_interval_secs")]
     connection_check_interval_secs: u64,
+    /// Optional label shown in the status bar instead of the server URL.
+    #[serde(default)]
+    alias: Option<String>,
 }
 
 fn default_connection_check_interval_secs() -> u64 {
@@ -1008,6 +1011,8 @@ pub struct Config {
     pub subsonic_url: String,
     pub subsonic_user: String,
     pub subsonic_pass: String,
+    /// When set, shown in the status bar instead of the server URL.
+    pub server_alias: Option<String>,
     /// Periodic Subsonic `ping` interval (seconds). `0` = startup ping only.
     pub connection_check_interval_secs: u64,
     pub default_volume: u8,
@@ -1438,6 +1443,10 @@ impl Config {
         Ok(Config {
             subsonic_url: file_cfg.server.url,
             subsonic_user: file_cfg.server.username,
+            server_alias: file_cfg
+                .server
+                .alias
+                .filter(|s| !s.trim().is_empty()),
             connection_check_interval_secs: file_cfg.server.connection_check_interval_secs,
             subsonic_pass,
             default_volume: file_cfg.player.default_volume,
@@ -2237,6 +2246,7 @@ password_keyring = "secret-service"
             password_command: "printf '%s' 'from-cmd'".into(),
             password_keyring: default_password_keyring(),
             connection_check_interval_secs: default_connection_check_interval_secs(),
+            alias: None,
         };
         assert_eq!(
             resolve_subsonic_secret(&server).expect("command"),

--- a/ratune/src/ui/status_bar.rs
+++ b/ratune/src/ui/status_bar.rs
@@ -134,15 +134,28 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
     } else {
         let hint = "i — help";
         let sep = "  ·  ";
-        let host = app
+        let host_label = if let Some(alias) = app
             .config
-            .subsonic_url
-            .trim_start_matches("http://")
-            .trim_start_matches("https://");
-        let host_label = if app.server_reachable {
-            host.to_string()
+            .server_alias
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+        {
+            if app.server_reachable {
+                alias.to_string()
+            } else {
+                format!("{alias} (offline)")
+            }
         } else {
-            format!("{host} (offline)")
+            let host = app
+                .config
+                .subsonic_url
+                .trim_start_matches("http://")
+                .trim_start_matches("https://");
+            if app.server_reachable {
+                host.to_string()
+            } else {
+                format!("{host} (offline)")
+            }
         };
         let vol_label = format!("{}%", app.config.default_volume);
 


### PR DESCRIPTION
Add alias to hide server name in bottom status bar. See #40.

Use:
```toml
[server]
alias = "navidrome"
```
Produces:
<img width="323" height="47" alt="screenshot_2026-06-23_23-16-42" src="https://github.com/user-attachments/assets/15a167ae-5f88-4060-8735-55deed09c525" />
