### PR TITLE
fix: mouse functionality for popup panes

### DIFF
--- a/ratune/src/action.rs
+++ b/ratune/src/action.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Direction {
     Up,
     Down,

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -2797,9 +2797,7 @@ impl App {
                 if self.playlist_overlay.loaded_playlist_id.as_deref() == Some(&playlist_id) {
                     self.playlist_overlay.loaded_playlist_id = None;
                     self.playlist_overlay.tracks = LoadingState::Error(error.clone());
-                    crate::debug::log(format!(
-                        "get_playlist({playlist_id}) failed — {error}"
-                    ));
+                    crate::debug::log(format!("get_playlist({playlist_id}) failed — {error}"));
                     self.flash_status_secs("Could not load playlist tracks", 4);
                 }
             }
@@ -6901,8 +6899,7 @@ impl App {
             );
             return;
         }
-        self.playlist_tracks_fetch_deadline =
-            Some(Instant::now() + Duration::from_millis(250));
+        self.playlist_tracks_fetch_deadline = Some(Instant::now() + Duration::from_millis(250));
         let _ = playlist_id;
     }
 

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -347,6 +347,11 @@ pub enum LibraryUpdate {
         playlist_id: String,
         songs: Vec<ratune_subsonic::Song>,
     },
+    /// `getPlaylist` failed for a playlist preview fetch.
+    PlaylistTracksError {
+        playlist_id: String,
+        error: String,
+    },
     /// A new playlist was successfully created.
     PlaylistCreated(ratune_subsonic::Playlist),
     /// A playlist was successfully deleted (carries the deleted ID).
@@ -458,6 +463,7 @@ pub struct PlaylistPicker {
     pub song_id: String,
     /// `true` while a `getPlaylists` fetch is in flight.
     pub loading: bool,
+    pub scroll: usize,
 }
 
 // ── App ───────────────────────────────────────────────────────────────────────
@@ -634,6 +640,10 @@ pub struct App {
     pub pending_global_confirm: Option<GlobalConfirm>,
     /// First visible line index inside the help popup (scroll).
     pub help_scroll: usize,
+    /// Last list click for timed double-click detection.
+    pub(crate) last_mouse_click: Option<(Instant, crate::mouse_click::MouseClickTarget)>,
+    /// Debounced `getPlaylist` after scrolling the playlist list.
+    playlist_tracks_fetch_deadline: Option<Instant>,
 
     // ── Play history (Phase 6.1) ──────────────────────────────────────────────
     /// Persistent play history (loaded on startup, saved on quit).
@@ -808,6 +818,8 @@ impl App {
             pending_gg: false,
             pending_global_confirm: None,
             help_scroll: 0,
+            last_mouse_click: None,
+            playlist_tracks_fetch_deadline: None,
             history: crate::history::PlayHistory::default(),
             play_recorded: false,
             track_started_at: None,
@@ -2773,8 +2785,22 @@ impl App {
                 // Ignore stale results if the user navigated to a different playlist
                 // while this fetch was in flight.
                 if self.playlist_overlay.loaded_playlist_id.as_deref() == Some(&playlist_id) {
+                    self.playlist_overlay
+                        .tracks_cache
+                        .insert(playlist_id.clone(), songs.clone());
                     self.playlist_overlay.tracks = LoadingState::Loaded(songs);
                     self.playlist_overlay.selected_track_index = 0;
+                    self.playlist_overlay.tracks_scroll = 0;
+                }
+            }
+            LibraryUpdate::PlaylistTracksError { playlist_id, error } => {
+                if self.playlist_overlay.loaded_playlist_id.as_deref() == Some(&playlist_id) {
+                    self.playlist_overlay.loaded_playlist_id = None;
+                    self.playlist_overlay.tracks = LoadingState::Error(error.clone());
+                    crate::debug::log(format!(
+                        "get_playlist({playlist_id}) failed — {error}"
+                    ));
+                    self.flash_status_secs("Could not load playlist tracks", 4);
                 }
             }
             LibraryUpdate::PlaylistCreated(p) => {
@@ -3812,6 +3838,77 @@ impl App {
         if idx < len {
             self.radio.selected = idx;
             self.play_radio_from_picker();
+        }
+    }
+
+    /// Mouse click on a playlist row in the playlist overlay left column.
+    pub fn click_playlist_overlay_list(&mut self, index: usize) {
+        if let LoadingState::Loaded(ref playlists) = self.playlist_overlay.playlists {
+            if index < playlists.len() {
+                self.playlist_overlay.focus = PlaylistFocus::List;
+                self.playlist_overlay.selected_playlist_index = index;
+                self.playlist_overlay.selected_track_index = 0;
+                self.schedule_playlist_tracks_for_selection();
+            }
+        }
+    }
+
+    pub fn double_click_playlist_overlay_list(&mut self, index: usize) {
+        self.click_playlist_overlay_list(index);
+        self.sync_playlist_tracks_for_selection();
+        self.handle_playlist_action(Action::PlaylistAppendAll);
+    }
+
+    /// Mouse click on a track row in the playlist overlay right column.
+    pub fn click_playlist_overlay_track(&mut self, index: usize) {
+        if let LoadingState::Loaded(ref songs) = self.playlist_overlay.tracks {
+            if index < songs.len() {
+                self.playlist_overlay.focus = PlaylistFocus::Tracks;
+                self.playlist_overlay.selected_track_index = index;
+            }
+        }
+    }
+
+    pub fn double_click_playlist_overlay_track(&mut self, index: usize) {
+        self.click_playlist_overlay_track(index);
+        self.handle_playlist_action(Action::PlaylistAppendTrack);
+    }
+
+    /// Mouse click on a category row in the favorites overlay.
+    pub fn click_favorites_category(&mut self, index: usize) {
+        if index < FavoritesCategory::ALL.len() {
+            self.favorites_overlay.focus = FavoritesFocus::Categories;
+            self.favorites_overlay.selected_category_index = index;
+            self.favorites_overlay.selected_item_index = 0;
+            self.favorites_overlay.sync_category_from_index();
+        }
+    }
+
+    pub fn double_click_favorites_category(&mut self, index: usize) {
+        self.click_favorites_category(index);
+        self.favorites_queue_action(false);
+    }
+
+    /// Mouse click on an item row in the favorites overlay.
+    pub fn click_favorites_item(&mut self, index: usize) {
+        let count = self.favorites_overlay.item_count();
+        if index < count {
+            self.favorites_overlay.focus = FavoritesFocus::Items;
+            self.favorites_overlay.selected_item_index = index;
+        }
+    }
+
+    pub fn double_click_favorites_item(&mut self, index: usize) {
+        self.click_favorites_item(index);
+        self.favorites_queue_action(false);
+    }
+
+    /// Mouse click on a row in the add-to-playlist picker popup.
+    pub fn click_playlist_picker_row(&mut self, index: usize) {
+        if let Some(ref mut picker) = self.playlist_picker {
+            if index < picker.playlists.len() {
+                picker.selected_index = index;
+            }
         }
     }
 
@@ -5989,6 +6086,47 @@ impl App {
 
     // ── Queue helpers ─────────────────────────────────────────────────────────
 
+    /// Append a Home-tab recent track to the queue (double-click).
+    pub fn append_home_recent_track(&mut self, idx: usize) {
+        let Some(record) = self.home.recent_tracks.get(idx).cloned() else {
+            return;
+        };
+        let song = ratune_subsonic::Song {
+            id: record.song_id.clone(),
+            title: record.track_name.clone(),
+            artist: Some(record.artist_name.clone()),
+            artist_id: Some(record.artist_id.clone()),
+            album: Some(record.album_name.clone()),
+            album_id: Some(record.album_id.clone()),
+            duration: Some(record.duration_secs as u32),
+            track: None,
+            disc_number: None,
+            year: None,
+            genre: None,
+            cover_art: None,
+            path: None,
+            suffix: None,
+            content_type: None,
+            bit_rate: None,
+            size: None,
+            starred: None,
+        };
+        let was_empty = self.queue.songs.is_empty();
+        self.queue.push(song);
+        if was_empty {
+            self.queue.cursor = 0;
+            self.play_current();
+        }
+    }
+
+    /// Append all tracks for a Home-tab rediscover artist (double-click).
+    pub fn append_home_rediscover_artist(&mut self, idx: usize) {
+        let Some((artist_id, _)) = self.home.rediscover.get(idx).cloned() else {
+            return;
+        };
+        self.fetch_all_tracks_for_artist(artist_id, self.queue.songs.is_empty(), false);
+    }
+
     fn handle_add_to_queue(&mut self) {
         if self.browse_files() {
             if let Some(song) = self
@@ -6473,6 +6611,42 @@ impl App {
         self.handle_navigate_browser(dir, steps);
     }
 
+    pub fn navigate_playlist_wheel(&mut self, dir: Direction) {
+        let steps = self.config.browse_mouse_wheel_scroll_lines.max(1);
+        for _ in 0..steps {
+            let action = match dir {
+                Direction::Up => Action::PlaylistScrollUp,
+                Direction::Down => Action::PlaylistScrollDown,
+                _ => break,
+            };
+            self.handle_playlist_action(action);
+        }
+    }
+
+    pub fn navigate_favorites_wheel(&mut self, dir: Direction) {
+        let steps = self.config.browse_mouse_wheel_scroll_lines.max(1);
+        for _ in 0..steps {
+            let action = match dir {
+                Direction::Up => Action::FavoritesScrollUp,
+                Direction::Down => Action::FavoritesScrollDown,
+                _ => break,
+            };
+            self.handle_favorites_action(action);
+        }
+    }
+
+    pub fn navigate_playlist_picker_wheel(&mut self, dir: Direction) {
+        let steps = self.config.browse_mouse_wheel_scroll_lines.max(1);
+        for _ in 0..steps {
+            let action = match dir {
+                Direction::Up => Action::PlaylistPickerScrollUp,
+                Direction::Down => Action::PlaylistPickerScrollDown,
+                _ => break,
+            };
+            self.handle_playlist_mutation(action);
+        }
+    }
+
     pub fn click_browser_artist(&mut self, orig_idx: usize) {
         if let LoadingState::Loaded(artists) = &self.library.artists {
             if orig_idx >= artists.len() {
@@ -6494,6 +6668,15 @@ impl App {
                 .albums
                 .insert(artist_id.clone(), LoadingState::Loading);
             self.fetch_albums(artist_id);
+        }
+    }
+
+    pub fn double_click_browser_artist(&mut self, orig_idx: usize) {
+        self.click_browser_artist(orig_idx);
+        self.browser_focus = BrowserColumn::Artists;
+        if let Some(artist) = self.library.current_artist() {
+            let artist_id = artist.id.clone();
+            self.fetch_all_tracks_for_artist(artist_id, self.queue.songs.is_empty(), false);
         }
     }
 
@@ -6522,34 +6705,82 @@ impl App {
         }
     }
 
+    pub fn double_click_browser_album(&mut self, orig_idx: usize) {
+        let album_id = match self.library.current_artist() {
+            Some(artist) => match self.library.albums.get(&artist.id) {
+                Some(LoadingState::Loaded(albums)) => albums.get(orig_idx).map(|a| a.id.clone()),
+                _ => None,
+            },
+            None => None,
+        };
+        self.click_browser_album(orig_idx);
+        if let Some(album_id) = album_id {
+            self.browser_focus = BrowserColumn::Albums;
+            self.fetch_and_append_album_to_queue(album_id);
+        }
+    }
+
     pub fn click_folder_dir(&mut self, visible_pos: usize) {
         self.folders.folder_default_row_pending = false;
         self.folders.selected_dir = Some(visible_pos);
         self.folder_activate_selected_dir();
     }
 
-    pub fn click_folder_preview_row(&mut self, visible_row: usize) {
-        let Some(ref pid) = self.folders.preview_dir_id.clone() else {
-            return;
-        };
-        let listing = match self.folders.listings.get(pid) {
+    pub fn double_click_folder_dir(&mut self, visible_pos: usize) {
+        self.click_folder_dir(visible_pos);
+        self.browser_focus = BrowserColumn::Tracks;
+        self.handle_add_all_to_queue(AddAllMode::Append);
+    }
+
+    pub fn folder_preview_row_index(&self, visible_row: usize) -> Option<usize> {
+        let pid = self.folders.preview_dir_id.clone()?;
+        let listing = match self.folders.listings.get(&pid) {
             Some(LoadingState::Loaded(l)) => l,
-            _ => return,
+            _ => return None,
         };
         let rows = folder_preview_rows(listing, self.browser_column_filter(BrowserColumn::Tracks));
         if rows.is_empty() {
-            return;
+            return None;
         }
         let vh = self.browser_list_viewport_rows.max(1);
         let sel_pos = self
             .folders
             .preview_selected_row
             .min(rows.len().saturating_sub(1));
-        FolderBrowseState::clamp_scroll(&mut self.folders.tracks_scroll, sel_pos, rows.len(), vh);
-        let scroll = self.folders.tracks_scroll;
+        let mut scroll = self.folders.tracks_scroll;
+        FolderBrowseState::clamp_scroll(&mut scroll, sel_pos, rows.len(), vh);
         let clicked = scroll + visible_row;
-        if clicked < rows.len() {
-            self.folders.preview_selected_row = clicked;
+        (clicked < rows.len()).then_some(clicked)
+    }
+
+    pub fn click_folder_preview_row(&mut self, visible_row: usize) {
+        let Some(clicked) = self.folder_preview_row_index(visible_row) else {
+            return;
+        };
+        self.folders.preview_selected_row = clicked;
+    }
+
+    pub fn double_click_folder_preview_row(&mut self, visible_row: usize) {
+        let Some(clicked) = self.folder_preview_row_index(visible_row) else {
+            return;
+        };
+        let Some(pid) = self.folders.preview_dir_id.clone() else {
+            return;
+        };
+        let listing = match self.folders.listings.get(&pid) {
+            Some(LoadingState::Loaded(l)) => l,
+            _ => return,
+        };
+        let rows = folder_preview_rows(listing, self.browser_column_filter(BrowserColumn::Tracks));
+        self.folders.preview_selected_row = clicked;
+        match rows[clicked] {
+            FolderPreviewRow::Track(_) => {
+                self.browser_focus = BrowserColumn::Tracks;
+                self.handle_add_to_queue();
+            }
+            FolderPreviewRow::Dir(_) => {
+                self.folder_activate_preview_selection();
+            }
         }
     }
 
@@ -6565,6 +6796,22 @@ impl App {
         if valid {
             self.library.selected_track = Some(orig_idx);
         }
+    }
+
+    pub fn double_click_browser_track(&mut self, orig_idx: usize) {
+        self.click_browser_track(orig_idx);
+        self.browser_focus = BrowserColumn::Tracks;
+        self.handle_add_to_queue();
+    }
+
+    /// Mouse click on a visible queue row in the Now Playing tab.
+    pub fn click_queue_row(&mut self, idx: usize) {
+        self.set_queue_cursor(idx);
+    }
+
+    pub fn double_click_queue_row(&mut self, idx: usize) {
+        self.set_queue_cursor(idx);
+        self.play_queue_from_np();
     }
 
     pub fn set_queue_cursor(&mut self, idx: usize) {
@@ -6617,6 +6864,12 @@ impl App {
 
     /// Load tracks for the highlighted playlist (browse-style preview in the right column).
     fn sync_playlist_tracks_for_selection(&mut self) {
+        self.playlist_tracks_fetch_deadline = None;
+        self.sync_playlist_tracks_for_selection_now();
+    }
+
+    /// Debounce track preview fetches while scrolling the playlist list.
+    fn schedule_playlist_tracks_for_selection(&mut self) {
         if !self.playlist_overlay.visible {
             return;
         }
@@ -6632,7 +6885,63 @@ impl App {
         if self.playlist_overlay.loaded_playlist_id.as_deref() == Some(&playlist_id) {
             return;
         }
+        if self
+            .playlist_overlay
+            .tracks_cache
+            .contains_key(&playlist_id)
+        {
+            self.playlist_overlay.loaded_playlist_id = Some(playlist_id.clone());
+            self.playlist_overlay.selected_track_index = 0;
+            self.playlist_overlay.tracks = LoadingState::Loaded(
+                self.playlist_overlay
+                    .tracks_cache
+                    .get(&playlist_id)
+                    .cloned()
+                    .unwrap_or_default(),
+            );
+            return;
+        }
+        self.playlist_tracks_fetch_deadline =
+            Some(Instant::now() + Duration::from_millis(250));
+        let _ = playlist_id;
+    }
+
+    pub fn tick_playlist_tracks_fetch(&mut self) {
+        let Some(deadline) = self.playlist_tracks_fetch_deadline else {
+            return;
+        };
+        if Instant::now() < deadline {
+            return;
+        }
+        self.playlist_tracks_fetch_deadline = None;
+        self.sync_playlist_tracks_for_selection_now();
+    }
+
+    fn sync_playlist_tracks_for_selection_now(&mut self) {
+        if !self.playlist_overlay.visible {
+            return;
+        }
+        let playlist_id = match &self.playlist_overlay.playlists {
+            LoadingState::Loaded(playlists) => playlists
+                .get(self.playlist_overlay.selected_playlist_index)
+                .map(|p| p.id.clone()),
+            _ => None,
+        };
+        let Some(playlist_id) = playlist_id else {
+            return;
+        };
+        if self.playlist_overlay.loaded_playlist_id.as_deref() == Some(&playlist_id) {
+            return;
+        }
+        if let Some(cached) = self.playlist_overlay.tracks_cache.get(&playlist_id) {
+            self.playlist_overlay.loaded_playlist_id = Some(playlist_id);
+            self.playlist_overlay.selected_track_index = 0;
+            self.playlist_overlay.tracks_scroll = 0;
+            self.playlist_overlay.tracks = LoadingState::Loaded(cached.clone());
+            return;
+        }
         self.playlist_overlay.selected_track_index = 0;
+        self.playlist_overlay.tracks_scroll = 0;
         self.playlist_overlay.tracks = LoadingState::Loading;
         self.playlist_overlay.loaded_playlist_id = Some(playlist_id.clone());
         self.fetch_playlist_tracks(playlist_id);
@@ -6655,7 +6964,14 @@ impl App {
                         })
                         .await;
                 }
-                Err(e) => eprintln!("ratune: get_playlist({playlist_id}) failed — {e}"),
+                Err(e) => {
+                    let _ = tx
+                        .send(LibraryUpdate::PlaylistTracksError {
+                            playlist_id,
+                            error: e.to_string(),
+                        })
+                        .await;
+                }
             }
         });
     }
@@ -6692,7 +7008,7 @@ impl App {
                         .selected_playlist_index
                         .saturating_sub(1);
                     self.playlist_overlay.selected_track_index = 0;
-                    self.sync_playlist_tracks_for_selection();
+                    self.schedule_playlist_tracks_for_selection();
                 }
                 PlaylistFocus::Tracks => {
                     self.playlist_overlay.selected_track_index =
@@ -6706,7 +7022,7 @@ impl App {
                         self.playlist_overlay.selected_playlist_index =
                             (self.playlist_overlay.selected_playlist_index + 1).min(max);
                         self.playlist_overlay.selected_track_index = 0;
-                        self.sync_playlist_tracks_for_selection();
+                        self.schedule_playlist_tracks_for_selection();
                     }
                 }
                 PlaylistFocus::Tracks => {
@@ -7082,6 +7398,7 @@ impl App {
                                 selected_index: 0,
                                 song_id,
                                 loading: false,
+                                scroll: 0,
                             });
                         }
                         _ => {
@@ -7090,6 +7407,7 @@ impl App {
                                 selected_index: 0,
                                 song_id,
                                 loading: true,
+                                scroll: 0,
                             });
                             self.spawn_fetch_playlists_for_picker();
                         }

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -14,6 +14,7 @@ mod library_index;
 mod lyrics;
 mod lyrics_cache;
 mod mpris;
+mod mouse_click;
 mod persist;
 mod scrobble;
 mod scrobble_queue;
@@ -478,6 +479,7 @@ async fn run_loop(
 
         // Expire status flash messages.
         app.tick_status_flash();
+        app.tick_playlist_tracks_fetch();
 
         if connectivity_interval != Duration::MAX
             && last_connectivity_check.elapsed() >= connectivity_interval
@@ -1241,10 +1243,8 @@ fn home_click_panel(x: u16, y: u16, area: Rect, panel: HomePanel, app: &mut App)
             ) else {
                 return;
             };
-            if app.home.active_section == app::HomeSection::RecentAlbums
-                && app.home.album_selected_index == album_index
-            {
-                app.dispatch(Action::Select);
+            if mouse_click::is_double_click(app, mouse_click::MouseClickTarget::HomeRecentAlbum(album_index)) {
+                app.dispatch(Action::HomeAlbumAddToQueue);
             } else {
                 app.home.active_section = app::HomeSection::RecentAlbums;
                 app.home.selected_index = 0;
@@ -1259,10 +1259,8 @@ fn home_click_panel(x: u16, y: u16, area: Rect, panel: HomePanel, app: &mut App)
             }
             let row = (y - inner_y) as usize;
             if row < app.home.recent_tracks.len() {
-                if app.home.active_section == app::HomeSection::RecentTracks
-                    && app.home.selected_index == row
-                {
-                    app.dispatch(Action::Select);
+                if mouse_click::is_double_click(app, mouse_click::MouseClickTarget::HomeRecentTrack(row)) {
+                    app.append_home_recent_track(row);
                 } else {
                     app.home.active_section = app::HomeSection::RecentTracks;
                     app.home.selected_index = row;
@@ -1277,10 +1275,8 @@ fn home_click_panel(x: u16, y: u16, area: Rect, panel: HomePanel, app: &mut App)
             }
             let row = (y - inner_y) as usize;
             if row < app.home.rediscover.len() {
-                if app.home.active_section == app::HomeSection::Rediscover
-                    && app.home.selected_index == row
-                {
-                    app.dispatch(Action::Select);
+                if mouse_click::is_double_click(app, mouse_click::MouseClickTarget::HomeRediscover(row)) {
+                    app.append_home_rediscover_artist(row);
                 } else {
                     app.home.active_section = app::HomeSection::Rediscover;
                     app.home.selected_index = row;
@@ -1875,12 +1871,189 @@ fn browser_column_hit(
     })
 }
 
+fn rect_contains(r: Rect, x: u16, y: u16) -> bool {
+    x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height
+}
+
+/// Visible list row inside a bordered column (skips top/bottom border rows).
+fn list_row_at(col: Rect, x: u16, y: u16) -> Option<usize> {
+    if x < col.x || x >= col.x + col.width {
+        return None;
+    }
+    if y <= col.y || y >= col.y + col.height.saturating_sub(1) {
+        return None;
+    }
+    Some((y - col.y - 1) as usize)
+}
+
+fn picker_list_row_at(popup: Rect, x: u16, y: u16) -> Option<usize> {
+    if x < popup.x || x >= popup.x + popup.width {
+        return None;
+    }
+    if y <= popup.y || y >= popup.y + popup.height.saturating_sub(1) {
+        return None;
+    }
+    Some((y - popup.y - 1) as usize)
+}
+
+/// Returns true when the click was consumed by a browser-tab overlay or popup.
+fn handle_browser_overlay_click(x: u16, y: u16, app: &mut App, center: Rect) -> bool {
+    use crate::state::LoadingState;
+    use crate::ui::{favorites_overlay, list_scroll, playlist_overlay};
+
+    // Render order: playlist overlay → picker → favorites (topmost last).
+    if app.favorites_overlay.visible {
+        let layout = favorites_overlay::panel_layout(center);
+        if rect_contains(layout.area, x, y) {
+            let cat_len = crate::state::FavoritesCategory::ALL.len();
+            if let Some(idx) = list_scroll::list_index_at_click(
+                layout.categories_col,
+                x,
+                y,
+                app.favorites_overlay.categories_scroll,
+                cat_len,
+            ) {
+                let target = mouse_click::MouseClickTarget::FavoritesCategory(idx);
+                if mouse_click::is_double_click(app, target) {
+                    app.double_click_favorites_category(idx);
+                } else {
+                    app.click_favorites_category(idx);
+                }
+            } else {
+                let item_len = app.favorites_overlay.item_count();
+                if let Some(idx) = list_scroll::list_index_at_click(
+                    layout.items_col,
+                    x,
+                    y,
+                    app.favorites_overlay.items_scroll,
+                    item_len,
+                ) {
+                    let target = mouse_click::MouseClickTarget::FavoritesItem(idx);
+                    if mouse_click::is_double_click(app, target) {
+                        app.double_click_favorites_item(idx);
+                    } else {
+                        app.click_favorites_item(idx);
+                    }
+                }
+            }
+            return true;
+        }
+    }
+
+    if app.playlist_picker.is_some() {
+        let popup = playlist_overlay::picker_rect(center);
+        if rect_contains(popup, x, y) {
+            if let Some(ref picker) = app.playlist_picker {
+                let len = picker.playlists.len();
+                if let Some(idx) =
+                    list_scroll::list_index_at_click(popup, x, y, picker.scroll, len)
+                {
+                    app.click_playlist_picker_row(idx);
+                }
+            }
+            return true;
+        }
+    }
+
+    if app.playlist_overlay.visible {
+        let layout = playlist_overlay::panel_layout(center, &app.playlist_overlay.input_mode);
+        if rect_contains(layout.area, x, y) {
+            let list_len = match &app.playlist_overlay.playlists {
+                LoadingState::Loaded(playlists) => playlists.len(),
+                _ => 0,
+            };
+            if let Some(idx) = list_scroll::list_index_at_click(
+                layout.list_rows,
+                x,
+                y,
+                app.playlist_overlay.list_scroll,
+                list_len,
+            ) {
+                let target = mouse_click::MouseClickTarget::PlaylistList(idx);
+                if mouse_click::is_double_click(app, target) {
+                    app.double_click_playlist_overlay_list(idx);
+                } else {
+                    app.click_playlist_overlay_list(idx);
+                }
+            } else {
+                let track_len = match &app.playlist_overlay.tracks {
+                    LoadingState::Loaded(songs) => songs.len(),
+                    _ => 0,
+                };
+                if let Some(idx) = list_scroll::list_index_at_click(
+                    layout.tracks_col,
+                    x,
+                    y,
+                    app.playlist_overlay.tracks_scroll,
+                    track_len,
+                ) {
+                    let target = mouse_click::MouseClickTarget::PlaylistTrack(idx);
+                    if mouse_click::is_double_click(app, target) {
+                        app.double_click_playlist_overlay_track(idx);
+                    } else {
+                        app.click_playlist_overlay_track(idx);
+                    }
+                }
+            }
+            return true;
+        }
+    }
+
+    false
+}
+
+fn handle_browser_overlay_wheel(x: u16, y: u16, dir: Direction, app: &mut App, center: Rect) -> bool {
+    use crate::state::{FavoritesFocus, PlaylistFocus};
+    use crate::ui::{favorites_overlay, playlist_overlay};
+
+    // Render order: playlist overlay → picker → favorites (topmost last).
+    if app.favorites_overlay.visible {
+        let layout = favorites_overlay::panel_layout(center);
+        if rect_contains(layout.area, x, y) {
+            if list_row_at(layout.categories_col, x, y).is_some() {
+                app.favorites_overlay.focus = FavoritesFocus::Categories;
+            } else if list_row_at(layout.items_col, x, y).is_some() {
+                app.favorites_overlay.focus = FavoritesFocus::Items;
+            }
+            app.navigate_favorites_wheel(dir);
+            return true;
+        }
+    }
+
+    if app.playlist_picker.is_some() {
+        let popup = playlist_overlay::picker_rect(center);
+        if rect_contains(popup, x, y) {
+            app.navigate_playlist_picker_wheel(dir);
+            return true;
+        }
+    }
+
+    if app.playlist_overlay.visible {
+        let layout = playlist_overlay::panel_layout(center, &app.playlist_overlay.input_mode);
+        if rect_contains(layout.area, x, y) {
+            if list_row_at(layout.list_rows, x, y).is_some() {
+                app.playlist_overlay.focus = PlaylistFocus::List;
+            } else if list_row_at(layout.tracks_col, x, y).is_some() {
+                app.playlist_overlay.focus = PlaylistFocus::Tracks;
+            }
+            app.navigate_playlist_wheel(dir);
+            return true;
+        }
+    }
+
+    false
+}
+
 fn handle_mouse_wheel(x: u16, y: u16, dir: Direction, app: &mut App, terminal_size: Rect) {
     if app.active_tab != Tab::Browser {
         return;
     }
 
     let areas = ui::layout::build_layout(terminal_size, &ui::layout::layout_options_for_app(app));
+    if handle_browser_overlay_wheel(x, y, dir, app, areas.center) {
+        return;
+    }
+
     let Some(hit) = browser_column_hit(x, y, areas.center, app.browser_browse_mode) else {
         return;
     };
@@ -1943,26 +2116,25 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
             Action::None
         };
         app.dispatch(action);
+        mouse_click::clear_pending_click(app);
         return;
     }
 
+    if app.help_visible {
+        let popup = ui::popup::help_popup_rect(terminal_size, app.config.radio_enabled);
+        if rect_contains(popup, x, y) {
+            mouse_click::clear_pending_click(app);
+            return;
+        }
+    }
+
     if app.radio.picker_visible && app.radio.input_mode.is_normal() {
-        let area = terminal_size;
-        let w = (area.width * 4 / 5).clamp(40, area.width);
-        let h = (area.height * 7 / 10).clamp(8, area.height);
-        let popup = ratatui::layout::Rect {
-            x: area.x + (area.width.saturating_sub(w)) / 2,
-            y: area.y + (area.height.saturating_sub(h)) / 2,
-            width: w,
-            height: h,
-        };
-        if x >= popup.x
-            && x < popup.x + popup.width
-            && y >= popup.y + 1
-            && y < popup.y + popup.height.saturating_sub(1)
-        {
-            let visible_row = (y - popup.y - 1) as usize;
-            app.click_radio_row(visible_row);
+        let popup = ui::radio_popup::popup_rect(terminal_size);
+        if rect_contains(popup, x, y) {
+            if let Some(visible_row) = picker_list_row_at(popup, x, y) {
+                app.click_radio_row(visible_row);
+            }
+            mouse_click::clear_pending_click(app);
             return;
         }
     }
@@ -1975,6 +2147,7 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
             let row = ui::now_playing::controls_row_rect(controls_area);
             if y >= row.y && y < row.y + row.height {
                 app.dispatch(action);
+                mouse_click::clear_pending_click(app);
                 return;
             }
         }
@@ -2003,6 +2176,7 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                     app.dispatch(Action::SeekTo(std::time::Duration::from_secs(seek_secs)));
                 }
             }
+            mouse_click::clear_pending_click(app);
             return;
         }
     }
@@ -2017,6 +2191,9 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
             handle_home_click(x, y, app, center);
         }
         Tab::Browser => {
+            if handle_browser_overlay_click(x, y, app, center) {
+                return;
+            }
             let Some(hit) = browser_column_hit(x, y, center, app.browser_browse_mode) else {
                 return;
             };
@@ -2032,11 +2209,22 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                             let scroll = app.folders.dirs_scroll;
                             scroll + visible_row
                         };
-                        app.click_folder_dir(visible_pos);
+                        let target = mouse_click::MouseClickTarget::FolderDir(visible_pos);
+                        if mouse_click::is_double_click(app, target) {
+                            app.double_click_folder_dir(visible_pos);
+                        } else {
+                            app.click_folder_dir(visible_pos);
+                        }
                     }
                     _ => {
-                        app.click_folder_preview_row(visible_row);
-                        app.folder_activate_preview_selection();
+                        if let Some(row_ix) = app.folder_preview_row_index(visible_row) {
+                            let target = mouse_click::MouseClickTarget::FolderPreview(row_ix);
+                            if mouse_click::is_double_click(app, target) {
+                                app.double_click_folder_preview_row(visible_row);
+                            } else {
+                                app.click_folder_preview_row(visible_row);
+                            }
+                        }
                     }
                 }
                 return;
@@ -2065,7 +2253,12 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                         }
                     };
                     if let Some(idx) = orig_idx {
-                        app.click_browser_artist(idx);
+                        let target = mouse_click::MouseClickTarget::BrowserArtist(idx);
+                        if mouse_click::is_double_click(app, target) {
+                            app.double_click_browser_artist(idx);
+                        } else {
+                            app.click_browser_artist(idx);
+                        }
                     }
                 }
                 1 => {
@@ -2096,7 +2289,12 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                         }
                     };
                     if let Some(idx) = orig_idx {
-                        app.click_browser_album(idx);
+                        let target = mouse_click::MouseClickTarget::BrowserAlbum(idx);
+                        if mouse_click::is_double_click(app, target) {
+                            app.double_click_browser_album(idx);
+                        } else {
+                            app.click_browser_album(idx);
+                        }
                     }
                 }
                 _ => {
@@ -2126,7 +2324,12 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                         }
                     };
                     if let Some(idx) = orig_idx {
-                        app.click_browser_track(idx);
+                        let target = mouse_click::MouseClickTarget::BrowserTrack(idx);
+                        if mouse_click::is_double_click(app, target) {
+                            app.double_click_browser_track(idx);
+                        } else {
+                            app.click_browser_track(idx);
+                        }
                     }
                 }
             }
@@ -2265,7 +2468,12 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                 return;
             }
             let clicked_idx = app.queue.scroll + visible_row;
-            app.set_queue_cursor(clicked_idx);
+            let target = mouse_click::MouseClickTarget::QueueRow(clicked_idx);
+            if mouse_click::is_double_click(app, target) {
+                app.double_click_queue_row(clicked_idx);
+            } else {
+                app.click_queue_row(clicked_idx);
+            }
         }
     }
 }

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -13,8 +13,8 @@ mod keyring_init;
 mod library_index;
 mod lyrics;
 mod lyrics_cache;
-mod mpris;
 mod mouse_click;
+mod mpris;
 mod persist;
 mod scrobble;
 mod scrobble_queue;
@@ -1243,7 +1243,10 @@ fn home_click_panel(x: u16, y: u16, area: Rect, panel: HomePanel, app: &mut App)
             ) else {
                 return;
             };
-            if mouse_click::is_double_click(app, mouse_click::MouseClickTarget::HomeRecentAlbum(album_index)) {
+            if mouse_click::is_double_click(
+                app,
+                mouse_click::MouseClickTarget::HomeRecentAlbum(album_index),
+            ) {
                 app.dispatch(Action::HomeAlbumAddToQueue);
             } else {
                 app.home.active_section = app::HomeSection::RecentAlbums;
@@ -1259,7 +1262,10 @@ fn home_click_panel(x: u16, y: u16, area: Rect, panel: HomePanel, app: &mut App)
             }
             let row = (y - inner_y) as usize;
             if row < app.home.recent_tracks.len() {
-                if mouse_click::is_double_click(app, mouse_click::MouseClickTarget::HomeRecentTrack(row)) {
+                if mouse_click::is_double_click(
+                    app,
+                    mouse_click::MouseClickTarget::HomeRecentTrack(row),
+                ) {
                     app.append_home_recent_track(row);
                 } else {
                     app.home.active_section = app::HomeSection::RecentTracks;
@@ -1275,7 +1281,10 @@ fn home_click_panel(x: u16, y: u16, area: Rect, panel: HomePanel, app: &mut App)
             }
             let row = (y - inner_y) as usize;
             if row < app.home.rediscover.len() {
-                if mouse_click::is_double_click(app, mouse_click::MouseClickTarget::HomeRediscover(row)) {
+                if mouse_click::is_double_click(
+                    app,
+                    mouse_click::MouseClickTarget::HomeRediscover(row),
+                ) {
                     app.append_home_rediscover_artist(row);
                 } else {
                     app.home.active_section = app::HomeSection::Rediscover;
@@ -1945,8 +1954,7 @@ fn handle_browser_overlay_click(x: u16, y: u16, app: &mut App, center: Rect) -> 
         if rect_contains(popup, x, y) {
             if let Some(ref picker) = app.playlist_picker {
                 let len = picker.playlists.len();
-                if let Some(idx) =
-                    list_scroll::list_index_at_click(popup, x, y, picker.scroll, len)
+                if let Some(idx) = list_scroll::list_index_at_click(popup, x, y, picker.scroll, len)
                 {
                     app.click_playlist_picker_row(idx);
                 }
@@ -2002,7 +2010,13 @@ fn handle_browser_overlay_click(x: u16, y: u16, app: &mut App, center: Rect) -> 
     false
 }
 
-fn handle_browser_overlay_wheel(x: u16, y: u16, dir: Direction, app: &mut App, center: Rect) -> bool {
+fn handle_browser_overlay_wheel(
+    x: u16,
+    y: u16,
+    dir: Direction,
+    app: &mut App,
+    center: Rect,
+) -> bool {
     use crate::state::{FavoritesFocus, PlaylistFocus};
     use crate::ui::{favorites_overlay, playlist_overlay};
 

--- a/ratune/src/mouse_click.rs
+++ b/ratune/src/mouse_click.rs
@@ -28,9 +28,9 @@ pub enum MouseClickTarget {
 /// Returns `true` when this click is the second half of a double-click on `target`.
 pub fn is_double_click(app: &mut App, target: MouseClickTarget) -> bool {
     let now = Instant::now();
-    let is_double = app.last_mouse_click.is_some_and(|(t, prev)| {
-        prev == target && now.duration_since(t) <= DOUBLE_CLICK_INTERVAL
-    });
+    let is_double = app
+        .last_mouse_click
+        .is_some_and(|(t, prev)| prev == target && now.duration_since(t) <= DOUBLE_CLICK_INTERVAL);
     if is_double {
         app.last_mouse_click = None;
     } else {

--- a/ratune/src/mouse_click.rs
+++ b/ratune/src/mouse_click.rs
@@ -1,0 +1,45 @@
+//! Mouse double-click detection (two clicks on the same target within a short window).
+
+use std::time::{Duration, Instant};
+
+use crate::app::App;
+
+/// Maximum interval between two clicks that counts as a double-click.
+pub const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(450);
+
+/// Identifies a clickable list/item target for double-click pairing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseClickTarget {
+    BrowserArtist(usize),
+    BrowserAlbum(usize),
+    BrowserTrack(usize),
+    FolderDir(usize),
+    FolderPreview(usize),
+    HomeRecentAlbum(usize),
+    HomeRecentTrack(usize),
+    HomeRediscover(usize),
+    PlaylistList(usize),
+    PlaylistTrack(usize),
+    FavoritesCategory(usize),
+    FavoritesItem(usize),
+    QueueRow(usize),
+}
+
+/// Returns `true` when this click is the second half of a double-click on `target`.
+pub fn is_double_click(app: &mut App, target: MouseClickTarget) -> bool {
+    let now = Instant::now();
+    let is_double = app.last_mouse_click.is_some_and(|(t, prev)| {
+        prev == target && now.duration_since(t) <= DOUBLE_CLICK_INTERVAL
+    });
+    if is_double {
+        app.last_mouse_click = None;
+    } else {
+        app.last_mouse_click = Some((now, target));
+    }
+    is_double
+}
+
+/// Clear pending single-click state (e.g. after a non-list click).
+pub fn clear_pending_click(app: &mut App) {
+    app.last_mouse_click = None;
+}

--- a/ratune/src/state.rs
+++ b/ratune/src/state.rs
@@ -521,6 +521,10 @@ pub struct PlaylistOverlay {
     pub focus: PlaylistFocus,
     pub loaded_playlist_id: Option<String>,
     pub input_mode: PlaylistInputMode,
+    /// Cached `getPlaylist` results to avoid refetching while scrolling.
+    pub tracks_cache: std::collections::HashMap<String, Vec<ratune_subsonic::Song>>,
+    pub list_scroll: usize,
+    pub tracks_scroll: usize,
 }
 
 impl Default for PlaylistOverlay {
@@ -534,6 +538,9 @@ impl Default for PlaylistOverlay {
             focus: PlaylistFocus::List,
             loaded_playlist_id: None,
             input_mode: PlaylistInputMode::Normal,
+            tracks_cache: std::collections::HashMap::new(),
+            list_scroll: 0,
+            tracks_scroll: 0,
         }
     }
 }
@@ -579,6 +586,8 @@ pub struct FavoritesOverlay {
     pub focus: FavoritesFocus,
     pub selected_category_index: usize,
     pub selected_item_index: usize,
+    pub categories_scroll: usize,
+    pub items_scroll: usize,
     pub songs: Vec<ratune_subsonic::Song>,
     pub albums: Vec<ratune_subsonic::Album>,
     pub artists: Vec<ratune_subsonic::Artist>,
@@ -599,6 +608,7 @@ impl FavoritesOverlay {
         }
         let max = self.item_count().saturating_sub(1);
         self.selected_item_index = self.selected_item_index.min(max);
+        self.items_scroll = 0;
     }
 }
 

--- a/ratune/src/ui/browser.rs
+++ b/ratune/src/ui/browser.rs
@@ -29,13 +29,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
                 &theme,
             );
             if let Some(picker) = app.playlist_picker.as_mut() {
-                playlist_overlay::render_playlist_picker(
-                    frame,
-                    area,
-                    picker,
-                    accent,
-                    &theme,
-                );
+                playlist_overlay::render_playlist_picker(frame, area, picker, accent, &theme);
             }
             favorites_overlay::render_favorites_overlay(
                 frame,
@@ -69,13 +63,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
                 &theme,
             );
             if let Some(picker) = app.playlist_picker.as_mut() {
-                playlist_overlay::render_playlist_picker(
-                    frame,
-                    area,
-                    picker,
-                    accent,
-                    &theme,
-                );
+                playlist_overlay::render_playlist_picker(frame, area, picker, accent, &theme);
             }
             favorites_overlay::render_favorites_overlay(
                 frame,

--- a/ratune/src/ui/browser.rs
+++ b/ratune/src/ui/browser.rs
@@ -9,6 +9,8 @@ use crate::app::{App, BrowserColumn};
 use crate::config::BrowseMode;
 
 pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
+    let accent = app.accent();
+    let theme = app.theme.clone();
     match app.browser_browse_mode {
         BrowseMode::Genre => {
             frame.render_widget(
@@ -22,25 +24,25 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
             playlist_overlay::render_playlist_overlay(
                 frame,
                 area,
-                &app.playlist_overlay,
-                app.accent(),
-                &app.theme,
+                &mut app.playlist_overlay,
+                accent,
+                &theme,
             );
-            if let Some(picker) = &app.playlist_picker {
+            if let Some(picker) = app.playlist_picker.as_mut() {
                 playlist_overlay::render_playlist_picker(
                     frame,
                     area,
                     picker,
-                    app.accent(),
-                    &app.theme,
+                    accent,
+                    &theme,
                 );
             }
             favorites_overlay::render_favorites_overlay(
                 frame,
                 area,
-                &app.favorites_overlay,
-                app.accent(),
-                &app.theme,
+                &mut app.favorites_overlay,
+                accent,
+                &theme,
             );
             return;
         }
@@ -62,25 +64,25 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
             playlist_overlay::render_playlist_overlay(
                 frame,
                 area,
-                &app.playlist_overlay,
-                app.accent(),
-                &app.theme,
+                &mut app.playlist_overlay,
+                accent,
+                &theme,
             );
-            if let Some(picker) = &app.playlist_picker {
+            if let Some(picker) = app.playlist_picker.as_mut() {
                 playlist_overlay::render_playlist_picker(
                     frame,
                     area,
                     picker,
-                    app.accent(),
-                    &app.theme,
+                    accent,
+                    &theme,
                 );
             }
             favorites_overlay::render_favorites_overlay(
                 frame,
                 area,
-                &app.favorites_overlay,
-                app.accent(),
-                &app.theme,
+                &mut app.favorites_overlay,
+                accent,
+                &theme,
             );
             return;
         }
@@ -116,20 +118,20 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
     playlist_overlay::render_playlist_overlay(
         frame,
         area,
-        &app.playlist_overlay,
-        app.accent(),
-        &app.theme,
+        &mut app.playlist_overlay,
+        accent,
+        &theme,
     );
 
-    if let Some(picker) = &app.playlist_picker {
-        playlist_overlay::render_playlist_picker(frame, area, picker, app.accent(), &app.theme);
+    if let Some(picker) = app.playlist_picker.as_mut() {
+        playlist_overlay::render_playlist_picker(frame, area, picker, accent, &theme);
     }
 
     favorites_overlay::render_favorites_overlay(
         frame,
         area,
-        &app.favorites_overlay,
-        app.accent(),
-        &app.theme,
+        &mut app.favorites_overlay,
+        accent,
+        &theme,
     );
 }

--- a/ratune/src/ui/favorites_overlay.rs
+++ b/ratune/src/ui/favorites_overlay.rs
@@ -2,11 +2,29 @@
 
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem};
 use ratatui::Frame;
 
 use crate::state::{FavoritesCategory, FavoritesFocus, FavoritesOverlay};
 use crate::theme::{style_with_bg, Theme};
+
+pub struct PanelLayout {
+    pub area: Rect,
+    pub categories_col: Rect,
+    pub items_col: Rect,
+}
+
+pub fn panel_layout(parent: Rect) -> PanelLayout {
+    let area =
+        Layout::vertical([Constraint::Percentage(60), Constraint::Percentage(40)]).split(parent)[1];
+    let cols =
+        Layout::horizontal([Constraint::Percentage(30), Constraint::Percentage(70)]).split(area);
+    PanelLayout {
+        area,
+        categories_col: cols[0],
+        items_col: cols[1],
+    }
+}
 
 fn overlay_title(overlay: &FavoritesOverlay) -> String {
     if overlay.offline_snapshot {
@@ -46,7 +64,7 @@ fn fmt_duration_ms(secs: u32) -> String {
 pub fn render_favorites_overlay(
     frame: &mut Frame,
     area: Rect,
-    overlay: &FavoritesOverlay,
+    overlay: &mut FavoritesOverlay,
     accent: ratatui::style::Color,
     theme: &Theme,
 ) {
@@ -54,25 +72,20 @@ pub fn render_favorites_overlay(
         return;
     }
 
-    let split =
-        Layout::vertical([Constraint::Percentage(60), Constraint::Percentage(40)]).split(area);
-    let overlay_area = split[1];
-    frame.render_widget(Clear, overlay_area);
-
-    let cols = Layout::horizontal([Constraint::Percentage(30), Constraint::Percentage(70)])
-        .split(overlay_area);
+    let layout = panel_layout(area);
+    frame.render_widget(Clear, layout.area);
 
     let left_active = matches!(overlay.focus, FavoritesFocus::Categories);
     let right_active = !left_active;
 
-    render_categories(frame, cols[0], overlay, accent, theme, left_active);
-    render_items(frame, cols[1], overlay, accent, theme, right_active);
+    render_categories(frame, layout.categories_col, overlay, accent, theme, left_active);
+    render_items(frame, layout.items_col, overlay, accent, theme, right_active);
 }
 
 fn render_categories(
     frame: &mut Frame,
     area: Rect,
-    overlay: &FavoritesOverlay,
+    overlay: &mut FavoritesOverlay,
     accent: ratatui::style::Color,
     theme: &Theme,
     is_active: bool,
@@ -124,15 +137,23 @@ fn render_categories(
         .highlight_symbol("▶ ")
         .style(style_with_bg(theme.background));
 
-    let mut state = ListState::default();
-    state.select(Some(overlay.selected_category_index));
-    frame.render_stateful_widget(list, area, &mut state);
+    let len = FavoritesCategory::ALL.len();
+    frame.render_stateful_widget(
+        list,
+        area,
+        &mut super::list_scroll::list_state_for_selection(
+            area,
+            Some(overlay.selected_category_index),
+            len,
+            &mut overlay.categories_scroll,
+        ),
+    );
 }
 
 fn render_items(
     frame: &mut Frame,
     area: Rect,
-    overlay: &FavoritesOverlay,
+    overlay: &mut FavoritesOverlay,
     accent: ratatui::style::Color,
     theme: &Theme,
     is_active: bool,
@@ -246,6 +267,7 @@ fn render_items(
         items
     };
 
+    let len = items.len();
     let list = List::new(items)
         .block(block)
         .highlight_style(
@@ -257,13 +279,24 @@ fn render_items(
         .highlight_symbol("▶ ")
         .style(style_with_bg(theme.background));
 
-    let mut state = ListState::default();
-    if overlay.item_count() > 0 {
-        state.select(Some(
+    let item_count = overlay.item_count();
+    let sel = if item_count > 0 {
+        Some(
             overlay
                 .selected_item_index
-                .min(overlay.item_count().saturating_sub(1)),
-        ));
-    }
-    frame.render_stateful_widget(list, area, &mut state);
+                .min(item_count.saturating_sub(1)),
+        )
+    } else {
+        None
+    };
+    frame.render_stateful_widget(
+        list,
+        area,
+        &mut super::list_scroll::list_state_for_selection(
+            area,
+            sel,
+            len,
+            &mut overlay.items_scroll,
+        ),
+    );
 }

--- a/ratune/src/ui/favorites_overlay.rs
+++ b/ratune/src/ui/favorites_overlay.rs
@@ -78,8 +78,22 @@ pub fn render_favorites_overlay(
     let left_active = matches!(overlay.focus, FavoritesFocus::Categories);
     let right_active = !left_active;
 
-    render_categories(frame, layout.categories_col, overlay, accent, theme, left_active);
-    render_items(frame, layout.items_col, overlay, accent, theme, right_active);
+    render_categories(
+        frame,
+        layout.categories_col,
+        overlay,
+        accent,
+        theme,
+        left_active,
+    );
+    render_items(
+        frame,
+        layout.items_col,
+        overlay,
+        accent,
+        theme,
+        right_active,
+    );
 }
 
 fn render_categories(

--- a/ratune/src/ui/list_scroll.rs
+++ b/ratune/src/ui/list_scroll.rs
@@ -1,0 +1,48 @@
+//! Shared list scroll helpers for overlay panes.
+
+use ratatui::layout::Rect;
+use ratatui::widgets::ListState;
+
+use crate::state::LibraryState;
+
+pub fn list_state_for_selection(
+    area: Rect,
+    sel: Option<usize>,
+    len: usize,
+    scroll: &mut usize,
+) -> ListState {
+    let vh = area.height.saturating_sub(2).max(1) as usize;
+    let mut state = ListState::default();
+    if len == 0 {
+        *scroll = 0;
+        return state;
+    }
+    if let Some(sel) = sel {
+        if sel < len {
+            LibraryState::clamp_vertical_scroll(scroll, sel, len, vh);
+            state = ListState::default().with_offset(*scroll);
+            state.select(Some(sel));
+        }
+    } else {
+        let max_first = len.saturating_sub(vh);
+        *scroll = (*scroll).min(max_first);
+        state = ListState::default().with_offset(*scroll);
+    }
+    state
+}
+
+/// Map a click inside a bordered list column to an absolute row index.
+pub fn list_index_at_click(area: Rect, x: u16, y: u16, scroll: usize, len: usize) -> Option<usize> {
+    if x < area.x || x >= area.x + area.width {
+        return None;
+    }
+    if y <= area.y || y >= area.y + area.height.saturating_sub(1) {
+        return None;
+    }
+    if len == 0 {
+        return None;
+    }
+    let visible_row = (y - area.y - 1) as usize;
+    let idx = scroll + visible_row;
+    (idx < len).then_some(idx)
+}

--- a/ratune/src/ui/mod.rs
+++ b/ratune/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod folders;
 pub mod home_tab;
 pub mod kitty_art;
 pub mod layout;
+pub mod list_scroll;
 pub mod now_playing;
 pub mod now_playing_format;
 pub mod nowplaying_tab;

--- a/ratune/src/ui/playlist_overlay.rs
+++ b/ratune/src/ui/playlist_overlay.rs
@@ -111,7 +111,14 @@ pub fn render_playlist_overlay(
     let right_active = !left_active;
 
     render_playlist_list(frame, layout.list_col, overlay, accent, theme, left_active);
-    render_track_list(frame, layout.tracks_col, overlay, accent, theme, right_active);
+    render_track_list(
+        frame,
+        layout.tracks_col,
+        overlay,
+        accent,
+        theme,
+        right_active,
+    );
 
     // Confirm dialog renders on top of both columns when active.
     if let PlaylistInputMode::Confirming { action } = &overlay.input_mode {

--- a/ratune/src/ui/playlist_overlay.rs
+++ b/ratune/src/ui/playlist_overlay.rs
@@ -7,7 +7,7 @@
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style}; // Modifier used by highlight_style
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph};
 use ratatui::Frame;
 
 use crate::app::PlaylistPicker;
@@ -16,6 +16,53 @@ use crate::state::{
 };
 use crate::theme::style_with_bg;
 use crate::theme::Theme;
+
+/// Bottom 40% of the browser content area — matches overlay render geometry.
+pub fn overlay_area(parent: Rect) -> Rect {
+    Layout::vertical([Constraint::Percentage(60), Constraint::Percentage(40)]).split(parent)[1]
+}
+
+pub struct PanelLayout {
+    pub area: Rect,
+    pub list_col: Rect,
+    pub tracks_col: Rect,
+    /// List rows in the left column (excludes the text-input strip when shown).
+    pub list_rows: Rect,
+}
+
+pub fn panel_layout(parent: Rect, input_mode: &PlaylistInputMode) -> PanelLayout {
+    let area = overlay_area(parent);
+    let cols =
+        Layout::horizontal([Constraint::Percentage(35), Constraint::Percentage(65)]).split(area);
+    let list_rows = match input_mode {
+        PlaylistInputMode::Creating { .. } | PlaylistInputMode::Renaming { .. }
+            if cols[0].height > 3 =>
+        {
+            Layout::vertical([Constraint::Min(0), Constraint::Length(3)]).split(cols[0])[0]
+        }
+        _ => cols[0],
+    };
+    PanelLayout {
+        area,
+        list_col: cols[0],
+        tracks_col: cols[1],
+        list_rows,
+    }
+}
+
+/// Floating picker popup rect (opened via `BrowserAddToPlaylist`).
+pub fn picker_rect(parent: Rect) -> Rect {
+    let w = (parent.width / 2).max(30).min(parent.width);
+    let h = (parent.height * 6 / 10).max(5).min(parent.height);
+    let x = parent.x + (parent.width.saturating_sub(w)) / 2;
+    let y = parent.y + (parent.height.saturating_sub(h)) / 2;
+    Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    }
+}
 
 // ── Duration helpers ──────────────────────────────────────────────────────────
 
@@ -46,7 +93,7 @@ fn fmt_duration_ms(secs: u32) -> String {
 pub fn render_playlist_overlay(
     frame: &mut Frame,
     area: Rect,
-    overlay: &PlaylistOverlay,
+    overlay: &mut PlaylistOverlay,
     accent: Color,
     theme: &Theme,
 ) {
@@ -54,27 +101,17 @@ pub fn render_playlist_overlay(
         return;
     }
 
-    // ── Overlay occupies the bottom 40% of the browser content area ──────────
-
-    let split =
-        Layout::vertical([Constraint::Percentage(60), Constraint::Percentage(40)]).split(area);
-
-    let overlay_area = split[1];
+    let layout = panel_layout(area, &overlay.input_mode);
 
     // Clear all cells in the overlay region before drawing so browser content
     // beneath does not bleed through the Block widgets.
-    frame.render_widget(Clear, overlay_area);
-
-    // ── Horizontal split: left 35% (playlists), right 65% (tracks) ───────────
-
-    let cols = Layout::horizontal([Constraint::Percentage(35), Constraint::Percentage(65)])
-        .split(overlay_area);
+    frame.render_widget(Clear, layout.area);
 
     let left_active = matches!(overlay.focus, PlaylistFocus::List);
     let right_active = !left_active;
 
-    render_playlist_list(frame, cols[0], overlay, accent, theme, left_active);
-    render_track_list(frame, cols[1], overlay, accent, theme, right_active);
+    render_playlist_list(frame, layout.list_col, overlay, accent, theme, left_active);
+    render_track_list(frame, layout.tracks_col, overlay, accent, theme, right_active);
 
     // Confirm dialog renders on top of both columns when active.
     if let PlaylistInputMode::Confirming { action } = &overlay.input_mode {
@@ -83,7 +120,7 @@ pub fn render_playlist_overlay(
                 format!(" Delete \"{}\"? [y/n] ", name)
             }
         };
-        render_confirm_dialog(frame, overlay_area, &msg, accent, theme);
+        render_confirm_dialog(frame, layout.area, &msg, accent, theme);
     }
 }
 
@@ -92,7 +129,7 @@ pub fn render_playlist_overlay(
 fn render_playlist_list(
     frame: &mut Frame,
     area: Rect,
-    overlay: &PlaylistOverlay,
+    overlay: &mut PlaylistOverlay,
     accent: Color,
     theme: &Theme,
     is_active: bool,
@@ -177,9 +214,20 @@ fn render_playlist_list(
         .highlight_symbol("▶ ")
         .style(style_with_bg(theme.background));
 
-    let mut state = ListState::default();
-    state.select(sel);
-    frame.render_stateful_widget(list, list_area, &mut state);
+    let len = match &overlay.playlists {
+        LoadingState::Loaded(playlists) => playlists.len(),
+        _ => 0,
+    };
+    frame.render_stateful_widget(
+        list,
+        list_area,
+        &mut super::list_scroll::list_state_for_selection(
+            list_area,
+            sel,
+            len,
+            &mut overlay.list_scroll,
+        ),
+    );
 
     // Text-input box (create / rename).
     if let Some(input_rect) = input_area {
@@ -208,7 +256,7 @@ fn render_playlist_list(
 fn render_track_list(
     frame: &mut Frame,
     area: Rect,
-    overlay: &PlaylistOverlay,
+    overlay: &mut PlaylistOverlay,
     accent: Color,
     theme: &Theme,
     is_active: bool,
@@ -280,6 +328,7 @@ fn render_track_list(
         }
     };
 
+    let len = items.len();
     let list = List::new(items)
         .block(block)
         .highlight_style(
@@ -291,9 +340,16 @@ fn render_track_list(
         .highlight_symbol("▶ ")
         .style(style_with_bg(theme.background));
 
-    let mut state = ListState::default();
-    state.select(sel);
-    frame.render_stateful_widget(list, area, &mut state);
+    frame.render_stateful_widget(
+        list,
+        area,
+        &mut super::list_scroll::list_state_for_selection(
+            area,
+            sel,
+            len,
+            &mut overlay.tracks_scroll,
+        ),
+    );
 }
 
 // ── Confirm dialog ────────────────────────────────────────────────────────────
@@ -336,20 +392,11 @@ fn render_confirm_dialog(
 pub fn render_playlist_picker(
     frame: &mut Frame,
     area: Rect,
-    picker: &PlaylistPicker,
+    picker: &mut PlaylistPicker,
     accent: Color,
     theme: &Theme,
 ) {
-    let w = (area.width / 2).max(30).min(area.width);
-    let h = (area.height * 6 / 10).max(5).min(area.height);
-    let x = area.x + (area.width.saturating_sub(w)) / 2;
-    let y = area.y + (area.height.saturating_sub(h)) / 2;
-    let picker_area = Rect {
-        x,
-        y,
-        width: w,
-        height: h,
-    };
+    let picker_area = picker_rect(area);
 
     frame.render_widget(Clear, picker_area);
 
@@ -381,6 +428,7 @@ pub fn render_playlist_picker(
         .border_style(Style::default().fg(accent))
         .style(style_with_bg(theme.background));
 
+    let len = items.len();
     let list = List::new(items)
         .block(block)
         .highlight_style(
@@ -392,7 +440,14 @@ pub fn render_playlist_picker(
         .highlight_symbol("▶ ")
         .style(style_with_bg(theme.background));
 
-    let mut state = ListState::default();
-    state.select(sel);
-    frame.render_stateful_widget(list, picker_area, &mut state);
+    frame.render_stateful_widget(
+        list,
+        picker_area,
+        &mut super::list_scroll::list_state_for_selection(
+            picker_area,
+            sel,
+            len,
+            &mut picker.scroll,
+        ),
+    );
 }

--- a/ratune/src/ui/popup.rs
+++ b/ratune/src/ui/popup.rs
@@ -211,6 +211,28 @@ fn pack_blocks_into_two_columns(
     (left, right)
 }
 
+/// Popup bounds for the keybind help overlay (matches `render_help` sizing).
+pub fn help_popup_rect(area: Rect, radio_enabled: bool) -> Rect {
+    use ratatui::style::Color;
+
+    // Colors are only used for line content; lengths depend on section text alone.
+    let accent = Color::White;
+    let mut blocks = build_blocks(sections(radio_enabled), accent, accent, accent);
+    blocks.push(vec![Line::from("")]);
+    blocks.extend(build_blocks(playlist_sections(), accent, accent, accent));
+    let (left_all, right_all) = pack_blocks_into_two_columns(blocks);
+
+    let required_inner_h = left_all.len().max(right_all.len()).max(1) as u16;
+    let content_h = required_inner_h + 2;
+    let max_h = (area.height * 80 / 100).max(10);
+    let popup_h = content_h.min(max_h);
+    let popup_w = (area.width * 70 / 100).max(80).min(area.width);
+
+    let x = area.x + area.width.saturating_sub(popup_w) / 2;
+    let y = area.y + area.height.saturating_sub(popup_h) / 2;
+    Rect::new(x, y, popup_w, popup_h)
+}
+
 /// Render the keybind help popup centered over the current frame.
 ///
 /// Call this last in the render pass so it layers on top of all other widgets.
@@ -232,20 +254,7 @@ pub fn render_help(app: &mut App, frame: &mut Frame) {
     blocks.extend(build_blocks(playlist_sections(), accent, fg, dim));
     let (left_all, right_all) = pack_blocks_into_two_columns(blocks);
 
-    // ── Sizing & positioning ──────────────────────────────────────────────────
-
-    // Size to fit the taller column, but clamp to a percentage of the terminal.
-    let required_inner_h = left_all.len().max(right_all.len()).max(1) as u16;
-    let content_h = required_inner_h + 2; // +2 for border
-    let max_h = (area.height * 80 / 100).max(10);
-    let popup_h = content_h.min(max_h);
-
-    // Wide enough to comfortably hold two KEY_COL_W + desc columns side by side.
-    let popup_w = (area.width * 70 / 100).max(80).min(area.width);
-
-    let x = area.x + area.width.saturating_sub(popup_w) / 2;
-    let y = area.y + area.height.saturating_sub(popup_h) / 2;
-    let popup_area = Rect::new(x, y, popup_w, popup_h);
+    let popup_area = help_popup_rect(area, app.config.radio_enabled);
 
     // ── Render ────────────────────────────────────────────────────────────────
 

--- a/ratune/src/ui/radio_popup.rs
+++ b/ratune/src/ui/radio_popup.rs
@@ -10,20 +10,24 @@ use crate::app::App;
 use crate::state::{LoadingState, RadioField, RadioInputMode};
 use crate::theme::style_with_bg;
 
+pub fn popup_rect(area: Rect) -> Rect {
+    let w = (area.width * 4 / 5).clamp(40, area.width);
+    let h = (area.height * 7 / 10).clamp(8, area.height);
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}
+
 pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
     if !app.radio.input_mode.is_normal() {
         render_form(app, frame, area);
         return;
     }
 
-    let w = (area.width * 4 / 5).clamp(40, area.width);
-    let h = (area.height * 7 / 10).clamp(8, area.height);
-    let popup = Rect {
-        x: area.x + (area.width.saturating_sub(w)) / 2,
-        y: area.y + (area.height.saturating_sub(h)) / 2,
-        width: w,
-        height: h,
-    };
+    let popup = popup_rect(area);
     frame.render_widget(Clear, popup);
 
     let t = &app.theme;


### PR DESCRIPTION
Fixes mouse functionality for panes on browse tab. Mainly playlists and favorites. See #41 for part of the issue.