### PR TITLE
fix: allow non-truncating of columns in config

### DIFF
--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -407,21 +407,27 @@ colors = ["#00aaff", "#00ff99", "#ffee55", "#ff3355"]
 # enabled — Build/use index for Ctrl+f picker. Default: true.
 # index_path — JSON index file. Empty → ~/.cache/ratune/library_index.json (see code).
 # max_age_secs — Staleness threshold; background refresh when older. 0 = always stale at startup.
-# fzf_binary   — Executable name or path ("fzf", "sk", …). For `sk` (skim), ratune appends
-#                `--bind=ctrl-r:accept(ctrl-r)` so Ctrl+R replaces the queue; skim's default
-#                Ctrl+R is rotate mode, so `--expect=ctrl-r` alone would not fire.
-# fzf_args     — Extra argv merged with app defaults (delimiter/columns). The app may add
-#                its own headers unless you pass a custom --header=…
 # fetch_*_parallelism — Tunables for full index refresh (minimum 1 enforced at runtime).
 # navidrome_skip_unchanged_scan — Navidrome: skip full walk when lastScan unchanged.
 # notify_on_forced_index_refresh — Desktop notification when forced refresh completes.
+#
+# [library.fzf] — fuzzy picker (legacy: fzf_binary / fzf_args under [library])
+# binary — Executable ("fzf", "sk", …). For skim, ratune appends --bind=ctrl-r:accept(ctrl-r).
+# args   — Picker argv (delimiter, columns, …). App adds --header unless you pass --header=…
+# [library.fzf.columns] — max TSV field width (Unicode chars); 0 = no truncation.
 
 [library]
 enabled = true
 index_path = ""
 max_age_secs = 86400
-fzf_binary = "fzf"
-fzf_args = [
+fetch_album_parallelism = 12
+fetch_artist_parallelism = 4
+navidrome_skip_unchanged_scan = false
+notify_on_forced_index_refresh = true
+
+[library.fzf]
+binary = "fzf"
+args = [
   "--delimiter=\t",
   "--with-nth=2,3,4,5",
   "--nth=1,2,3",
@@ -429,10 +435,12 @@ fzf_args = [
   "--expect=ctrl-r",
   "--border=rounded",
 ]
-fetch_album_parallelism = 12
-fetch_artist_parallelism = 4
-navidrome_skip_unchanged_scan = false
-notify_on_forced_index_refresh = true
+
+# [library.fzf.columns]
+# artist = 26
+# album = 28
+# title = 36
+# duration = 6
 
 # -----------------------------------------------------------------------------
 # [cache] — offline streamed audio cache

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -265,6 +265,30 @@ impl LyricsSource {
 
 // ── [library] — metadata index + fzf picker ───────────────────────────────────
 
+/// Fuzzy picker settings under `[library.fzf]`.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct LibraryFzfSection {
+    /// Executable name or path. Default: `fzf` (also works with `sk`).
+    #[serde(default = "default_fzf_binary")]
+    pub binary: String,
+    /// Arguments passed to the picker (delimiter, columns, key bindings, …).
+    #[serde(default = "default_fzf_args")]
+    pub args: Vec<String>,
+    /// Max width per TSV field (Unicode chars). `0` = no truncation.
+    #[serde(default)]
+    pub columns: crate::library_index::FzfColumns,
+}
+
+impl Default for LibraryFzfSection {
+    fn default() -> Self {
+        Self {
+            binary: default_fzf_binary(),
+            args: default_fzf_args(),
+            columns: crate::library_index::FzfColumns::default(),
+        }
+    }
+}
+
 /// Local library metadata index and fuzzy picker (Milestone 2).
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LibrarySection {
@@ -278,12 +302,15 @@ pub struct LibrarySection {
     /// Default: 86400 (24 h). Set to 0 to always refresh at startup.
     #[serde(default = "default_library_max_age_secs")]
     pub max_age_secs: u64,
-    /// Executable name or path for the fuzzy finder. Default: `fzf` (also works with `sk`).
-    #[serde(default = "default_fzf_binary")]
-    pub fzf_binary: String,
-    /// Extra arguments passed to fzf after defaults (delimiter, columns).
-    #[serde(default = "default_fzf_args")]
-    pub fzf_args: Vec<String>,
+    /// Fuzzy picker (`[library.fzf]`). Legacy flat keys under `[library]` are still read.
+    #[serde(default)]
+    pub fzf: LibraryFzfSection,
+    /// Legacy: `fzf_binary` under `[library]`. Prefer `[library.fzf].binary`.
+    #[serde(default, rename = "fzf_binary", skip_serializing)]
+    legacy_fzf_binary: Option<String>,
+    /// Legacy: `fzf_args` under `[library]`. Prefer `[library.fzf].args`.
+    #[serde(default, rename = "fzf_args", skip_serializing)]
+    legacy_fzf_args: Option<Vec<String>>,
     /// Concurrent `getAlbum` calls per artist during a full index refresh. Default: 12.
     #[serde(default = "default_library_fetch_album_parallelism")]
     pub fetch_album_parallelism: usize,
@@ -298,6 +325,32 @@ pub struct LibrarySection {
     /// `notify-send` protocol). Default: true.
     #[serde(default = "default_library_notify_on_forced_refresh")]
     pub notify_on_forced_index_refresh: bool,
+}
+
+impl LibrarySection {
+    /// Merge `[library.fzf]` with legacy flat `fzf_*` keys. Non-default nested values win;
+    /// legacy fills fields left at defaults.
+    pub fn resolve_fzf(&self) -> LibraryFzfSection {
+        let nested = &self.fzf;
+        let defaults = LibraryFzfSection::default();
+        LibraryFzfSection {
+            binary: if nested.binary != defaults.binary {
+                nested.binary.clone()
+            } else {
+                self.legacy_fzf_binary
+                    .clone()
+                    .unwrap_or_else(default_fzf_binary)
+            },
+            args: if nested.args != defaults.args {
+                nested.args.clone()
+            } else {
+                self.legacy_fzf_args
+                    .clone()
+                    .unwrap_or_else(default_fzf_args)
+            },
+            columns: nested.columns,
+        }
+    }
 }
 
 fn default_library_enabled() -> bool {
@@ -345,8 +398,9 @@ impl Default for LibrarySection {
             enabled: default_library_enabled(),
             index_path: String::new(),
             max_age_secs: default_library_max_age_secs(),
-            fzf_binary: default_fzf_binary(),
-            fzf_args: default_fzf_args(),
+            fzf: LibraryFzfSection::default(),
+            legacy_fzf_binary: None,
+            legacy_fzf_args: None,
             fetch_album_parallelism: default_library_fetch_album_parallelism(),
             fetch_artist_parallelism: default_library_fetch_artist_parallelism(),
             navidrome_skip_unchanged_scan: false,
@@ -1110,8 +1164,7 @@ pub struct Config {
     pub library_index_enabled: bool,
     pub library_index_path: String,
     pub library_index_max_age_secs: u64,
-    pub fzf_binary: String,
-    pub fzf_args: Vec<String>,
+    pub fzf: LibraryFzfSection,
     pub library_fetch_album_parallelism: usize,
     pub library_fetch_artist_parallelism: usize,
     pub library_navidrome_skip_unchanged_scan: bool,
@@ -1440,6 +1493,9 @@ impl Config {
             .fetch_station_icons
             .unwrap_or_else(default_radio_fetch_station_icons);
 
+        let library = file_cfg.library;
+        let library_fzf = library.resolve_fzf();
+
         Ok(Config {
             subsonic_url: file_cfg.server.url,
             subsonic_user: file_cfg.server.username,
@@ -1495,15 +1551,14 @@ impl Config {
                 .unwrap_or(LyricsSource::LrcLib),
             lyrics_lrclib_url: file_cfg.lyrics.lrclib_url,
             lyrics_cache_enabled: file_cfg.lyrics.cache_enabled,
-            library_index_enabled: file_cfg.library.enabled,
-            library_index_path: file_cfg.library.index_path,
-            library_index_max_age_secs: file_cfg.library.max_age_secs,
-            fzf_binary: file_cfg.library.fzf_binary,
-            fzf_args: file_cfg.library.fzf_args,
-            library_fetch_album_parallelism: file_cfg.library.fetch_album_parallelism.max(1),
-            library_fetch_artist_parallelism: file_cfg.library.fetch_artist_parallelism.max(1),
-            library_navidrome_skip_unchanged_scan: file_cfg.library.navidrome_skip_unchanged_scan,
-            library_notify_on_forced_index_refresh: file_cfg.library.notify_on_forced_index_refresh,
+            library_index_enabled: library.enabled,
+            library_index_path: library.index_path,
+            library_index_max_age_secs: library.max_age_secs,
+            fzf: library_fzf,
+            library_fetch_album_parallelism: library.fetch_album_parallelism.max(1),
+            library_fetch_artist_parallelism: library.fetch_artist_parallelism.max(1),
+            library_navidrome_skip_unchanged_scan: library.navidrome_skip_unchanged_scan,
+            library_notify_on_forced_index_refresh: library.notify_on_forced_index_refresh,
             home_recent_albums_show_art,
             home_cover_fetch_max_px,
             home_top_height_percent,
@@ -1715,9 +1770,15 @@ location = "right"
 # enabled = true
 # index_path = ""          # empty = ~/.cache/ratune/library_index.json
 # max_age_secs = 86400     # refresh in background when older (0 = always stale)
-# fzf_binary = "fzf"       # or "sk" (skim gets --bind=ctrl-r:accept(ctrl-r) for replace-queue)
-# fzf_args = ["--delimiter=\\t", "--with-nth=2,3,4,5", "--nth=1,2,3", "--multi", "--expect=ctrl-r", "--border=rounded"]
+# [library.fzf]            # fuzzy picker (legacy: fzf_binary / fzf_args under [library])
+# binary = "fzf"           # or "sk" (skim gets --bind=ctrl-r:accept(ctrl-r) for replace-queue)
+# args = ["--delimiter=\\t", "--with-nth=2,3,4,5", "--nth=1,2,3", "--multi", "--expect=ctrl-r", "--border=rounded"]
 # aligned --header is added automatically unless you pass your own --header=…
+# [library.fzf.columns]    # max TSV field width (Unicode chars); 0 = no truncation
+# artist = 26
+# album = 28
+# title = 36               # set to 0 to search long track names
+# duration = 6
 # fetch_album_parallelism = 12    # concurrent getAlbum per artist during index refresh
 # fetch_artist_parallelism = 4    # concurrent artists during index refresh
 # navidrome_skip_unchanged_scan = false   # Navidrome: skip full walk when lastScan unchanged
@@ -2387,5 +2448,44 @@ cache_enabled = false
     fn parses_radio_enabled() {
         let fc: FileConfig = toml::from_str("[radio]\nenabled = false\n").expect("toml");
         assert_eq!(fc.radio.enabled, Some(false));
+    }
+
+    #[test]
+    fn parses_library_fzf_nested() {
+        let text = r#"
+[library.fzf]
+binary = "sk"
+
+[library.fzf.columns]
+title = 0
+"#;
+        let fc: FileConfig = toml::from_str(text).expect("toml");
+        let fzf = fc.library.resolve_fzf();
+        assert_eq!(fzf.binary, "sk");
+        assert_eq!(fzf.columns.title, 0);
+        assert_eq!(fzf.args, default_fzf_args());
+    }
+
+    #[test]
+    fn library_fzf_nested_overrides_legacy() {
+        let text = r#"
+[library]
+fzf_binary = "legacy-sk"
+
+[library.fzf]
+binary = "sk"
+"#;
+        let fc: FileConfig = toml::from_str(text).expect("toml");
+        assert_eq!(fc.library.resolve_fzf().binary, "sk");
+    }
+
+    #[test]
+    fn library_fzf_legacy_flat_keys() {
+        let text = r#"
+[library]
+fzf_binary = "sk"
+"#;
+        let fc: FileConfig = toml::from_str(text).expect("toml");
+        assert_eq!(fc.library.resolve_fzf().binary, "sk");
     }
 }

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -327,13 +327,14 @@ fn run_library_fzf_picker(
     }
 
     fzf_picker::suspend_tui(terminal, app.in_tmux)?;
-    let input = library_index::fzf_input_lines(&tracks);
-    let mut fzf_args = app.config.fzf_args.clone();
+    let cols = app.config.fzf.columns;
+    let input = library_index::fzf_input_lines(&tracks, cols);
+    let mut fzf_args = app.config.fzf.args.clone();
     if !fzf_args.iter().any(|a| a.starts_with("--header")) {
-        fzf_args.insert(0, format!("--header={}", library_index::fzf_header_line()));
+        fzf_args.insert(0, format!("--header={}", library_index::fzf_header_line(cols)));
     }
-    let fzf_args = fzf_picker::prepare_library_fuzzy_picker_args(&app.config.fzf_binary, fzf_args);
-    let res = fzf_picker::run_fzf(&app.config.fzf_binary, &fzf_args, &input);
+    let fzf_args = fzf_picker::prepare_library_fuzzy_picker_args(&app.config.fzf.binary, fzf_args);
+    let res = fzf_picker::run_fzf(&app.config.fzf.binary, &fzf_args, &input);
     if let Err(e) = fzf_picker::resume_tui(terminal, app.in_tmux) {
         eprintln!("resume terminal after fzf: {e}");
     }

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -331,7 +331,10 @@ fn run_library_fzf_picker(
     let input = library_index::fzf_input_lines(&tracks, cols);
     let mut fzf_args = app.config.fzf.args.clone();
     if !fzf_args.iter().any(|a| a.starts_with("--header")) {
-        fzf_args.insert(0, format!("--header={}", library_index::fzf_header_line(cols)));
+        fzf_args.insert(
+            0,
+            format!("--header={}", library_index::fzf_header_line(cols)),
+        );
     }
     let fzf_args = fzf_picker::prepare_library_fuzzy_picker_args(&app.config.fzf.binary, fzf_args);
     let res = fzf_picker::run_fzf(&app.config.fzf.binary, &fzf_args, &input);

--- a/ratune/src/library_index.rs
+++ b/ratune/src/library_index.rs
@@ -12,6 +12,43 @@ use anyhow::{Context, Result};
 use ratune_subsonic::Song;
 use serde::{Deserialize, Serialize};
 
+/// Display width per TSV column fed to fzf (Unicode scalars). `0` = no truncation or padding.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FzfColumns {
+    #[serde(default = "default_fzf_col_artist")]
+    pub artist: usize,
+    #[serde(default = "default_fzf_col_album")]
+    pub album: usize,
+    #[serde(default = "default_fzf_col_title")]
+    pub title: usize,
+    #[serde(default = "default_fzf_col_duration")]
+    pub duration: usize,
+}
+
+impl Default for FzfColumns {
+    fn default() -> Self {
+        Self {
+            artist: default_fzf_col_artist(),
+            album: default_fzf_col_album(),
+            title: default_fzf_col_title(),
+            duration: default_fzf_col_duration(),
+        }
+    }
+}
+
+fn default_fzf_col_artist() -> usize {
+    26
+}
+fn default_fzf_col_album() -> usize {
+    28
+}
+fn default_fzf_col_title() -> usize {
+    36
+}
+fn default_fzf_col_duration() -> usize {
+    6
+}
+
 const FORMAT_VERSION: u32 = 1;
 
 /// Serialized snapshot written to disk.
@@ -91,13 +128,6 @@ pub fn save(
     Ok(())
 }
 
-/// Max display width (Unicode scalars) per column after truncation. Keeps fzf rows
-/// readable; full metadata stays in the index for enqueue.
-const FZF_COL_ARTIST: usize = 26;
-const FZF_COL_ALBUM: usize = 28;
-const FZF_COL_TITLE: usize = 36;
-const FZF_COL_DUR: usize = 6;
-
 fn sanitize_field(s: &str) -> String {
     s.replace(['\t', '\n'], " ")
 }
@@ -119,7 +149,11 @@ fn truncate_display(s: &str, max_chars: usize) -> String {
 }
 
 /// Truncate then pad with spaces so columns line up in a monospace terminal.
+/// When `width` is 0, pass through unchanged (full text for fzf search and display).
 fn format_fzf_column(s: &str, width: usize) -> String {
+    if width == 0 {
+        return s.to_string();
+    }
     let t = truncate_display(s, width);
     let n = t.chars().count();
     if n < width {
@@ -131,19 +165,20 @@ fn format_fzf_column(s: &str, width: usize) -> String {
 
 /// Tab-separated header labels padded to match [`fzf_input_lines`] columns (artist–time;
 /// song id is not shown). Pass as `fzf --header=…` so labels line up with data.
-pub fn fzf_header_line() -> String {
-    let artist = format_fzf_column("Artist", FZF_COL_ARTIST);
-    let album = format_fzf_column("Album", FZF_COL_ALBUM);
-    let title = format_fzf_column("Title", FZF_COL_TITLE);
-    let time = format_fzf_column("Time", FZF_COL_DUR);
+pub fn fzf_header_line(cols: FzfColumns) -> String {
+    let artist = format_fzf_column("Artist", cols.artist);
+    let album = format_fzf_column("Album", cols.album);
+    let title = format_fzf_column("Title", cols.title);
+    let time = format_fzf_column("Time", cols.duration);
     format!("{artist}\t{album}\t{title}\t{time}")
 }
 
 /// One TSV line per track for fzf: id, artist, album, title, duration.
 /// Field 1 is the song id (hidden in the fzf *list* via `--with-nth=2,3,4,5`).
-/// Default `[library] fzf_args` uses `--nth=1,2,3` (artist, album, title; duration is
-/// shown but excluded from fuzzy search). Long strings are truncated for display only.
-pub fn fzf_input_lines(tracks: &[Song]) -> String {
+/// Default `[library.fzf].args` uses `--nth=1,2,3` (artist, album, title; duration is
+/// shown but excluded from fuzzy search). Column widths come from [`FzfColumns`]; set a
+/// width to `0` to send the full field (needed for searching long titles).
+pub fn fzf_input_lines(tracks: &[Song], cols: FzfColumns) -> String {
     let mut out = String::new();
     for s in tracks {
         let artist = s.artist.as_deref().unwrap_or("—");
@@ -154,10 +189,10 @@ pub fn fzf_input_lines(tracks: &[Song]) -> String {
             .map(fmt_duration_ms)
             .unwrap_or_else(|| "—".to_string());
         let id = sanitize_field(&s.id);
-        let artist = format_fzf_column(&sanitize_field(artist), FZF_COL_ARTIST);
-        let album = format_fzf_column(&sanitize_field(album), FZF_COL_ALBUM);
-        let title = format_fzf_column(&sanitize_field(title), FZF_COL_TITLE);
-        let dur = format_fzf_column(&sanitize_field(&dur), FZF_COL_DUR);
+        let artist = format_fzf_column(&sanitize_field(artist), cols.artist);
+        let album = format_fzf_column(&sanitize_field(album), cols.album);
+        let title = format_fzf_column(&sanitize_field(title), cols.title);
+        let dur = format_fzf_column(&sanitize_field(&dur), cols.duration);
         out.push_str(&format!("{id}\t{artist}\t{album}\t{title}\t{dur}\n"));
     }
     out
@@ -392,18 +427,50 @@ mod tests {
 
     #[test]
     fn fzf_header_matches_column_widths() {
-        let h = fzf_header_line();
+        let cols = FzfColumns::default();
+        let h = fzf_header_line(cols);
         assert_eq!(
             h.matches('\t').count(),
             3,
             "four columns: Artist | Album | Title | Time"
         );
-        let cols: Vec<&str> = h.split('\t').collect();
-        assert_eq!(cols.len(), 4);
-        assert_eq!(cols[0].chars().count(), 26);
-        assert_eq!(cols[1].chars().count(), 28);
-        assert_eq!(cols[2].chars().count(), 36);
-        assert_eq!(cols[3].chars().count(), 6);
+        let parts: Vec<&str> = h.split('\t').collect();
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0].chars().count(), cols.artist);
+        assert_eq!(parts[1].chars().count(), cols.album);
+        assert_eq!(parts[2].chars().count(), cols.title);
+        assert_eq!(parts[3].chars().count(), cols.duration);
+    }
+
+    #[test]
+    fn fzf_column_width_zero_passes_full_title() {
+        let s = Song {
+            id: "id".into(),
+            title: "a".repeat(50),
+            album: None,
+            artist: None,
+            album_id: None,
+            artist_id: None,
+            track: None,
+            disc_number: None,
+            year: None,
+            genre: None,
+            cover_art: None,
+            duration: None,
+            bit_rate: None,
+            content_type: None,
+            suffix: None,
+            size: None,
+            path: None,
+            starred: None,
+        };
+        let cols = FzfColumns {
+            title: 0,
+            ..FzfColumns::default()
+        };
+        let line = fzf_input_lines(std::slice::from_ref(&s), cols);
+        let title_field = line.split('\t').nth(3).unwrap();
+        assert_eq!(title_field, "a".repeat(50));
     }
 
     #[test]
@@ -428,7 +495,7 @@ mod tests {
             path: None,
             starred: None,
         };
-        let line = fzf_input_lines(std::slice::from_ref(&s));
+        let line = fzf_input_lines(std::slice::from_ref(&s), FzfColumns::default());
         assert_eq!(
             line.matches('\t').count(),
             4,


### PR DESCRIPTION
Allows customization of field truncation for what is passed to fuzzy finding. Users with very long names in their library can now use fuzzy finding properly. See #47 

Also, with additional fzf customization, this reorganizes the configuration a bit for clarity. Legacy fzf fields still supported.

Example config:
```toml
[library.fzf.columns]
title = 0    # disables truncation entirely
# artist = 26
# album = 28
# duration = 6
```