### PR TITLE
fix: align non-latin chars and fzf header alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "unicode-width 0.2.0",
  "url",
  "windows-native-keyring-store",
 ]

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -413,8 +413,9 @@ colors = ["#00aaff", "#00ff99", "#ffee55", "#ff3355"]
 #
 # [library.fzf] — fuzzy picker (legacy: fzf_binary / fzf_args under [library])
 # binary — Executable ("fzf", "sk", …). For skim, ratune appends --bind=ctrl-r:accept(ctrl-r).
-# args   — Picker argv (delimiter, columns, …). App adds --header unless you pass --header=…
-# [library.fzf.columns] — max TSV field width (Unicode chars); 0 = no truncation.
+# args   — Picker argv (delimiter, columns, …). Auto --header follows --with-nth unless
+#          you pass your own --header=…
+# [library.fzf.columns] — max TSV field width (terminal columns); 0 = no truncation.
 
 [library]
 enabled = true

--- a/ratune/Cargo.toml
+++ b/ratune/Cargo.toml
@@ -42,6 +42,7 @@ ratatui-image = { version = "9.0", default-features = false, features = ["image-
 inquire = "0.7"
 keyring-core = "1"
 libc = "0.2"
+unicode-width = "0.2"
 
 # Platform credential stores for keyring-core — see https://crates.io/crates/keyring-core
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -274,7 +274,7 @@ pub struct LibraryFzfSection {
     /// Arguments passed to the picker (delimiter, columns, key bindings, …).
     #[serde(default = "default_fzf_args")]
     pub args: Vec<String>,
-    /// Max width per TSV field (Unicode chars). `0` = no truncation.
+    /// Max width per TSV field (terminal columns). `0` = no truncation.
     #[serde(default)]
     pub columns: crate::library_index::FzfColumns,
 }
@@ -1773,8 +1773,8 @@ location = "right"
 # [library.fzf]            # fuzzy picker (legacy: fzf_binary / fzf_args under [library])
 # binary = "fzf"           # or "sk" (skim gets --bind=ctrl-r:accept(ctrl-r) for replace-queue)
 # args = ["--delimiter=\\t", "--with-nth=2,3,4,5", "--nth=1,2,3", "--multi", "--expect=ctrl-r", "--border=rounded"]
-# aligned --header is added automatically unless you pass your own --header=…
-# [library.fzf.columns]    # max TSV field width (Unicode chars); 0 = no truncation
+# aligned --header follows --with-nth unless you pass your own --header=…
+# [library.fzf.columns]    # max TSV field width (terminal columns); 0 = no truncation
 # artist = 26
 # album = 28
 # title = 36               # set to 0 to search long track names

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -19,6 +19,7 @@ mod persist;
 mod scrobble;
 mod scrobble_queue;
 mod state;
+mod text_width;
 mod theme;
 mod tty;
 mod ui;
@@ -331,9 +332,13 @@ fn run_library_fzf_picker(
     let input = library_index::fzf_input_lines(&tracks, cols);
     let mut fzf_args = app.config.fzf.args.clone();
     if !fzf_args.iter().any(|a| a.starts_with("--header")) {
+        let with_nth = library_index::parse_fzf_with_nth(&fzf_args);
         fzf_args.insert(
             0,
-            format!("--header={}", library_index::fzf_header_line(cols)),
+            format!(
+                "--header={}",
+                library_index::fzf_header_line(cols, &with_nth)
+            ),
         );
     }
     let fzf_args = fzf_picker::prepare_library_fuzzy_picker_args(&app.config.fzf.binary, fzf_args);

--- a/ratune/src/library_index.rs
+++ b/ratune/src/library_index.rs
@@ -12,7 +12,9 @@ use anyhow::{Context, Result};
 use ratune_subsonic::Song;
 use serde::{Deserialize, Serialize};
 
-/// Display width per TSV column fed to fzf (Unicode scalars). `0` = no truncation or padding.
+use crate::text_width::{self, Align};
+
+/// Display width per TSV column fed to fzf (terminal columns). `0` = no truncation or padding.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FzfColumns {
     #[serde(default = "default_fzf_col_artist")]
@@ -132,45 +134,68 @@ fn sanitize_field(s: &str) -> String {
     s.replace(['\t', '\n'], " ")
 }
 
-/// Truncate with ellipsis; never wider than `max_chars` scalars.
-fn truncate_display(s: &str, max_chars: usize) -> String {
-    let t = s.trim();
-    let count = t.chars().count();
-    if count <= max_chars {
-        return t.to_string();
-    }
-    if max_chars <= 1 {
-        return "…".to_string();
-    }
-    t.chars()
-        .take(max_chars.saturating_sub(1))
-        .chain(Some('…'))
-        .collect()
-}
-
 /// Truncate then pad with spaces so columns line up in a monospace terminal.
 /// When `width` is 0, pass through unchanged (full text for fzf search and display).
 fn format_fzf_column(s: &str, width: usize) -> String {
     if width == 0 {
         return s.to_string();
     }
-    let t = truncate_display(s, width);
-    let n = t.chars().count();
-    if n < width {
-        format!("{t}{}", " ".repeat(width - n))
-    } else {
-        t
-    }
+    text_width::fit_to_width(s, width, Align::Left)
 }
 
-/// Tab-separated header labels padded to match [`fzf_input_lines`] columns (artist–time;
-/// song id is not shown). Pass as `fzf --header=…` so labels line up with data.
-pub fn fzf_header_line(cols: FzfColumns) -> String {
-    let artist = format_fzf_column("Artist", cols.artist);
-    let album = format_fzf_column("Album", cols.album);
-    let title = format_fzf_column("Title", cols.title);
-    let time = format_fzf_column("Time", cols.duration);
-    format!("{artist}\t{album}\t{title}\t{time}")
+/// Default `--with-nth` when omitted from fzf argv (hide song id, show artist–duration).
+pub const FZF_DEFAULT_WITH_NTH: &[usize] = &[2, 3, 4, 5];
+
+/// Parse `--with-nth=2,3,4,5` (or `--with-nth 2,3,4,5`) from fzf argv.
+pub fn parse_fzf_with_nth(args: &[String]) -> Vec<usize> {
+    parse_fzf_flag_value(args, "--with-nth")
+        .map(|s| parse_fzf_field_indices(&s))
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| FZF_DEFAULT_WITH_NTH.to_vec())
+}
+
+fn parse_fzf_flag_value(args: &[String], flag: &str) -> Option<String> {
+    let eq = format!("{flag}=");
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if let Some(v) = a.strip_prefix(&eq) {
+            return Some(v.to_string());
+        }
+        if a == flag {
+            return args.get(i + 1).cloned();
+        }
+        i += 1;
+    }
+    None
+}
+
+fn parse_fzf_field_indices(s: &str) -> Vec<usize> {
+    s.split(',')
+        .filter_map(|part| part.trim().parse::<usize>().ok().filter(|&n| n > 0))
+        .collect()
+}
+
+fn fzf_field_header(field: usize, cols: FzfColumns) -> Option<String> {
+    let (label, width) = match field {
+        2 => ("Artist", cols.artist),
+        3 => ("Album", cols.album),
+        4 => ("Title", cols.title),
+        5 => ("Time", cols.duration),
+        _ => return None,
+    };
+    Some(format_fzf_column(label, width))
+}
+
+/// Tab-separated header labels padded to match [`fzf_input_lines`] columns in the order
+/// given by fzf's `--with-nth` (defaults to artist, album, title, time). Pass as
+/// `fzf --header=…` so labels line up with data rows.
+pub fn fzf_header_line(cols: FzfColumns, with_nth: &[usize]) -> String {
+    with_nth
+        .iter()
+        .filter_map(|&field| fzf_field_header(field, cols))
+        .collect::<Vec<_>>()
+        .join("\t")
 }
 
 /// One TSV line per track for fzf: id, artist, album, title, duration.
@@ -428,7 +453,7 @@ mod tests {
     #[test]
     fn fzf_header_matches_column_widths() {
         let cols = FzfColumns::default();
-        let h = fzf_header_line(cols);
+        let h = fzf_header_line(cols, FZF_DEFAULT_WITH_NTH);
         assert_eq!(
             h.matches('\t').count(),
             3,
@@ -436,10 +461,35 @@ mod tests {
         );
         let parts: Vec<&str> = h.split('\t').collect();
         assert_eq!(parts.len(), 4);
-        assert_eq!(parts[0].chars().count(), cols.artist);
-        assert_eq!(parts[1].chars().count(), cols.album);
-        assert_eq!(parts[2].chars().count(), cols.title);
-        assert_eq!(parts[3].chars().count(), cols.duration);
+        assert_eq!(text_width::str_width(parts[0]), cols.artist);
+        assert_eq!(text_width::str_width(parts[1]), cols.album);
+        assert_eq!(text_width::str_width(parts[2]), cols.title);
+        assert_eq!(text_width::str_width(parts[3]), cols.duration);
+    }
+
+    #[test]
+    fn fzf_header_follows_with_nth_order() {
+        let cols = FzfColumns::default();
+        let h = fzf_header_line(cols, &[2, 3, 5, 4]);
+        let parts: Vec<&str> = h.split('\t').collect();
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0].trim(), "Artist");
+        assert_eq!(parts[1].trim(), "Album");
+        assert_eq!(parts[2].trim(), "Time");
+        assert_eq!(parts[3].trim(), "Title");
+    }
+
+    #[test]
+    fn parse_fzf_with_nth_from_args() {
+        let args = vec![
+            "--delimiter=\t".into(),
+            "--with-nth=2,3,5,4".into(),
+            "--nth=1,2,3".into(),
+        ];
+        assert_eq!(parse_fzf_with_nth(&args), vec![2, 3, 5, 4]);
+        assert_eq!(parse_fzf_with_nth(&[]), vec![2, 3, 4, 5]);
+        let spaced = vec!["--with-nth".into(), "2,3,5,4".into()];
+        assert_eq!(parse_fzf_with_nth(&spaced), vec![2, 3, 5, 4]);
     }
 
     #[test]
@@ -501,5 +551,15 @@ mod tests {
             4,
             "exactly 4 tabs as delimiters"
         );
+    }
+
+    #[test]
+    fn fzf_column_cjk_uses_display_width() {
+        let cols = FzfColumns {
+            title: 6,
+            ..FzfColumns::default()
+        };
+        let field = format_fzf_column("日本語", cols.title);
+        assert_eq!(text_width::str_width(&field), cols.title);
     }
 }

--- a/ratune/src/text_width.rs
+++ b/ratune/src/text_width.rs
@@ -1,0 +1,106 @@
+//! Terminal display width (wcwidth-style), for column alignment in monospace UIs.
+//!
+//! CJK and many other scripts occupy two columns; Rust's `format!("{:<n$}")` counts
+//! Unicode scalars instead, which misaligns padded columns.
+
+use unicode_width::UnicodeWidthChar;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Align {
+    Left,
+    Right,
+}
+
+/// Sum of terminal column widths for printable characters in `s`.
+pub fn str_width(s: &str) -> usize {
+    s.chars()
+        .map(|c| UnicodeWidthChar::width(c).unwrap_or(0))
+        .sum()
+}
+
+/// Truncate `s` to at most `max_cols` terminal columns, appending `…` when cut.
+pub fn truncate_to_width(s: &str, max_cols: usize) -> String {
+    if max_cols == 0 {
+        return String::new();
+    }
+    if str_width(s) <= max_cols {
+        return s.to_string();
+    }
+    if max_cols == 1 {
+        return "…".to_string();
+    }
+    let budget = max_cols - 1;
+    let mut out = String::new();
+    let mut used = 0;
+    for ch in s.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > budget {
+            out.push('…');
+            return out;
+        }
+        used += w;
+        out.push(ch);
+    }
+    out
+}
+
+/// Pad `s` to exactly `cols` terminal columns (no truncation).
+pub fn pad_to_width(s: &str, cols: usize, align: Align) -> String {
+    if cols == 0 {
+        return String::new();
+    }
+    let w = str_width(s);
+    if w >= cols {
+        return s.to_string();
+    }
+    let pad = cols - w;
+    match align {
+        Align::Left => format!("{s}{}", " ".repeat(pad)),
+        Align::Right => format!("{}{s}", " ".repeat(pad)),
+    }
+}
+
+/// Truncate then pad so the result occupies exactly `cols` terminal columns.
+pub fn fit_to_width(s: &str, cols: usize, align: Align) -> String {
+    if cols == 0 {
+        return String::new();
+    }
+    pad_to_width(&truncate_to_width(s, cols), cols, align)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_width_matches_len() {
+        assert_eq!(str_width("hello"), 5);
+        assert_eq!(fit_to_width("hi", 5, Align::Left), "hi   ");
+        assert_eq!(fit_to_width("hi", 5, Align::Right), "   hi");
+    }
+
+    #[test]
+    fn cjk_counts_as_two_columns() {
+        assert_eq!(str_width("日本"), 4);
+        let padded = fit_to_width("日本", 6, Align::Left);
+        assert_eq!(str_width(&padded), 6);
+        assert_eq!(padded, "日本  ");
+        let truncated = fit_to_width("日本語の歌", 6, Align::Left);
+        assert_eq!(str_width(&truncated), 6);
+        assert_eq!(truncated, "日本… ");
+    }
+
+    #[test]
+    fn mixed_ascii_and_cjk_aligns() {
+        let title = fit_to_width("Hello 世界", 12, Align::Left);
+        assert_eq!(str_width(&title), 12);
+        let artist = fit_to_width("Artist", 8, Align::Left);
+        assert_eq!(str_width(&artist), 8);
+    }
+
+    #[test]
+    fn truncate_reserves_ellipsis_column() {
+        assert_eq!(truncate_to_width("abcdef", 4), "abc…");
+        assert_eq!(str_width(&truncate_to_width("abcdef", 4)), 4);
+    }
+}

--- a/ratune/src/ui/home_tab.rs
+++ b/ratune/src/ui/home_tab.rs
@@ -11,6 +11,7 @@ use ratatui_image::StatefulImage;
 
 use crate::app::{App, HomeSection, HomeState, RecentAlbum};
 use crate::config::{Config, HomePanel};
+use crate::text_width::{self, Align};
 use crate::theme::{style_with_bg, Theme};
 use crate::ui::kitty_art::{
     art_strip_layout, art_strip_slot_thumb_rect, art_strip_thumb_hit, KITTY_STRIP_MAX_SLOTS,
@@ -473,8 +474,9 @@ fn render_art_strip_labels(
             let is_selected = is_active && album_index == home.album_selected_index;
 
             let label_width = thumb_cols as usize;
-            let name_label = pad_or_truncate(&album.album_name, label_width);
-            let artist_label = pad_or_truncate(&album.artist_name, label_width);
+            let name_label = text_width::fit_to_width(&album.album_name, label_width, Align::Left);
+            let artist_label =
+                text_width::fit_to_width(&album.artist_name, label_width, Align::Left);
 
             let (name_style, artist_style) = if is_selected {
                 (
@@ -624,13 +626,11 @@ fn render_recent_tracks_block(
             let track_w = ((inner.width as usize).saturating_sub(8) * 40 / 100).max(10);
             let artist_w = ((inner.width as usize).saturating_sub(8) * 30 / 100).max(8);
             let text = format!(
-                " {:>2}. {:<track_w$} {:<artist_w$} {}",
+                " {:>2}. {} {} {}",
                 i + 1,
-                truncate(&record.track_name, track_w),
-                truncate(&record.artist_name, artist_w),
+                text_width::fit_to_width(&record.track_name, track_w, Align::Left),
+                text_width::fit_to_width(&record.artist_name, artist_w, Align::Left),
                 rel,
-                track_w = track_w,
-                artist_w = artist_w,
             );
             let selected = is_active && home.selected_index == i;
             let style = if selected {
@@ -676,7 +676,7 @@ fn render_rediscover_block(
             let text = format!(
                 " {:>2}. {}",
                 i + 1,
-                truncate(name, inner.width as usize - 6)
+                text_width::truncate_to_width(name, inner.width as usize - 6)
             );
             let selected = is_active && home.selected_index == i;
             let style = if selected {
@@ -705,35 +705,7 @@ fn render_rediscover_block(
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Truncate `s` to at most `max` characters, adding `…` if truncated.
+/// Truncate `s` to at most `max` terminal columns, adding `…` if truncated.
 fn truncate(s: &str, max: usize) -> String {
-    if max == 0 {
-        return String::new();
-    }
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
-        out.push('\u{2026}'); // …
-        out
-    }
-}
-
-/// Pad `s` to exactly `width` chars, or truncate with `…` if longer.
-fn pad_or_truncate(s: &str, width: usize) -> String {
-    if width == 0 {
-        return String::new();
-    }
-    let count = s.chars().count();
-    if count == width {
-        s.to_string()
-    } else if count < width {
-        let mut out = s.to_string();
-        for _ in 0..(width - count) {
-            out.push(' ');
-        }
-        out
-    } else {
-        truncate(s, width)
-    }
+    text_width::truncate_to_width(s, max)
 }

--- a/ratune/src/ui/queue.rs
+++ b/ratune/src/ui/queue.rs
@@ -4,6 +4,7 @@ use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
 use ratatui::Frame;
 
 use crate::app::App;
+use crate::text_width;
 use crate::theme::style_with_bg;
 
 const DEFAULT_QUEUE_TEMPLATE: &str = "{n}{title:<40}  {artist:<25}  {duration:>5}";
@@ -180,11 +181,11 @@ where
 
     let (align, width) = parse_spec(spec);
     if let Some(w) = width {
-        let truncated = trunc(&raw, w);
-        match align {
-            Align::Right => format!("{:>width$}", truncated, width = w),
-            Align::Left => format!("{:<width$}", truncated, width = w),
-        }
+        let align = match align {
+            Align::Right => text_width::Align::Right,
+            Align::Left => text_width::Align::Left,
+        };
+        text_width::fit_to_width(&raw, w, align)
     } else {
         raw
     }
@@ -212,26 +213,4 @@ fn parse_spec(spec: Option<&str>) -> (Align, Option<usize>) {
     };
     let width = rest.trim().parse::<usize>().ok().filter(|w| *w > 0);
     (align, width)
-}
-
-/// Truncate `s` to at most `max` Unicode characters, appending `…` if cut.
-fn trunc(s: &str, max: usize) -> String {
-    if max == 0 {
-        return String::new();
-    }
-    let mut chars = s.chars();
-    let mut result = String::with_capacity(max);
-    for (count, ch) in chars.by_ref().enumerate() {
-        if count >= max - 1 {
-            // Check if there are more characters coming.
-            if chars.next().is_some() {
-                result.push('…');
-            } else {
-                result.push(ch);
-            }
-            return result;
-        }
-        result.push(ch);
-    }
-    result
 }


### PR DESCRIPTION
Fixes alignment of characters for non-latin characters. See #50 

Also auto-aligns header in fzf with order of nth items stated so users do not need to do it manually. An update related to discussion in #47 