### PR TITLE
feat: subsonic ratings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,12 +264,11 @@ Ratune syncs favorites with your server through the Subsonic **star** / **unstar
 
 ### Ratings
 
-Ratune can sync per-user song ratings with your server through the Subsonic **`setRating`** API (1–5 stars, or 0 to clear). **Ratings are off by default** — enable them in config if you want the UI, keybinds, and MPRIS export.
+Ratune can sync per-user song ratings with your server through the Subsonic **`setRating`** API (1–5 stars, or 0 to clear). **Ratings are off by default**, enable them in config if you want the UI, keybinds, and MPRIS export.
 
 ```toml
 [ratings]
 enabled = true
-# Optional: use classic stars instead of the default small glyphs
 # star_filled = "★"
 # star_empty = "☆"
 # Optional: change or remove brackets around the rating ("" = none)
@@ -277,9 +276,9 @@ enabled = true
 # bracket_close = "]"
 ```
 
-When enabled, press **Shift+1** … **Shift+5** to rate (most US terminals deliver these as `!` `@` `#` `$` `%`; Shift+0 / `)` clears). You must be on a library song (Now Playing queue, Browse tracks, etc.) — not radio.
+When enabled, press **Shift+1** … **Shift+5** to rate (most US terminals deliver these as `!` `@` `#` `$` `%`; Shift+0 / `)` clears).
 
-- **Display:** rated items show `[⭑⭑⭑⭒⭒]` via `{rating}` in the queue template (after duration by default). Browse lists append the rating after the title. Favorites show **★** before the title in the queue (inside the title column width) and in browse lists.
+- **Display:** rated items show `[⭑⭑⭑⭒⭒]` via `{rating}` in the queue template (after duration by default). Browse lists append the rating after the title.
 - **Rate:** `Shift+1` … `Shift+5` on the focused song, album, or artist (`rate_song_1` … in `[keybinds]`)
 - **Clear rating:** `Shift+0` / `)` (`rate_song_clear`)
 - **MPRIS (Linux):** current track rating as `xesam:userRating` (0.0–1.0)

--- a/README.md
+++ b/README.md
@@ -262,6 +262,31 @@ Ratune syncs favorites with your server through the Subsonic **star** / **unstar
 - **Offline:** the favorites list is cached at `~/.cache/ratune/favorites.json`; open `F` without a connection to browse the last sync and play tracks already in the audio cache
 - **`[cache].cache_starred = true`:** while online, prefetch favorite **songs** into the offline cache (same `max_size_gb` pool as play-time caching)
 
+### Ratings
+
+Ratune can sync per-user song ratings with your server through the Subsonic **`setRating`** API (1–5 stars, or 0 to clear). **Ratings are off by default** — enable them in config if you want the UI, keybinds, and MPRIS export.
+
+```toml
+[ratings]
+enabled = true
+# Optional: use classic stars instead of the default small glyphs
+# star_filled = "★"
+# star_empty = "☆"
+# Optional: change or remove brackets around the rating ("" = none)
+# bracket_open = "["
+# bracket_close = "]"
+```
+
+When enabled, press **Shift+1** … **Shift+5** to rate (most US terminals deliver these as `!` `@` `#` `$` `%`; Shift+0 / `)` clears). You must be on a library song (Now Playing queue, Browse tracks, etc.) — not radio.
+
+- **Display:** rated items show `[⭑⭑⭑⭒⭒]` via `{rating}` in the queue template (after duration by default). Browse lists append the rating after the title. Favorites show **★** before the title in the queue (inside the title column width) and in browse lists.
+- **Rate:** `Shift+1` … `Shift+5` on the focused song, album, or artist (`rate_song_1` … in `[keybinds]`)
+- **Clear rating:** `Shift+0` / `)` (`rate_song_clear`)
+- **MPRIS (Linux):** current track rating as `xesam:userRating` (0.0–1.0)
+- Requires an online server connection (like favorites)
+
+Unrated tracks show nothing until you rate them.
+
 ### Internet radio
 
 Ratune plays internet radio stations configured on your Subsonic-compatible server — no separate stream proxy; the client connects directly to each station URL.

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -90,6 +90,27 @@ mpris = true
 queue_loop = true
 
 # -----------------------------------------------------------------------------
+# [ratings] — per-user song ratings (Subsonic setRating)
+# -----------------------------------------------------------------------------
+#
+# This section turns on ratings everywhere:
+# browse lists, Now Playing queue/bar, Shift+1…5 keybinds, and MPRIS UserRating.
+#
+# enabled      — Master switch. Default: false.
+# star_filled  — Glyph repeated for each filled star. Default: ⭑ (BLACK SMALL STAR).
+# star_empty   — Glyph repeated for each empty star. Default: ⭒ (WHITE SMALL STAR).
+#                Example for classic larger stars: star_filled = "★", star_empty = "☆".
+# bracket_open — Bracket before the star run. Default: `[` (`""` = none).
+# bracket_close — Bracket after the star run. Default: `]` (`""` = none).
+
+[ratings]
+# enabled = false
+# star_filled = "⭑"
+# star_empty = "⭒"
+# bracket_open = "["
+# bracket_close = "]"
+
+# -----------------------------------------------------------------------------
 # [keybinds] — optional overrides
 # -----------------------------------------------------------------------------
 #
@@ -104,7 +125,7 @@ queue_loop = true
 # column_right       = "l"
 # play_pause         = "p"
 # next_track          = "n"
-# prev_track          = "Shift+n"     # or "N" — same meaning
+# prev_track          = "Shift+n"     # or "N", same meaning
 # seek_forward        = "Right"
 # seek_backward       = "Left"
 # add_track           = "a"           # browser + playlist overlay (tracks pane): append to queue
@@ -145,6 +166,12 @@ queue_loop = true
 # home_refresh        = "r"          # home: refresh / re-roll where applicable
 # toggle_folder_browse = "Ctrl+b"   # browse: toggle folder view (needs [ui.browsetab] folder_navigation); "" disables
 # toggle_favorite     = "f"         # toggle favorite on focused song, album, or artist (Subsonic star)
+# rate_song_1         = "Shift+1"   # rate focused/playing song 1–5 stars (Subsonic setRating)
+# rate_song_2         = "Shift+2"
+# rate_song_3         = "Shift+3"
+# rate_song_4         = "Shift+4"
+# rate_song_5         = "Shift+5"
+# rate_song_clear     = "Shift+0"   # clear song rating
 # favorites_overlay   = "Shift+f"   # favorites panel on Browse tab (`F`)
 
 # -----------------------------------------------------------------------------
@@ -162,7 +189,7 @@ queue_loop = true
 # Each colour value may be:
 #   • Hex: `#rrggbb` or `rrggbb`
 #   • Terminal index (256-colour): `idx:0` … `idx:255` — also `indexed:`, `ansi:`, `color:`, or `i:`
-#     (e.g. list selection uses accent as background — `accent = "idx:2"` maps “primary” to ANSI green)
+#     (e.g. list selection uses accent as background: `accent = "idx:2"` maps “primary” to ANSI green)
 #   • `reset` / `inherit` / `default` / `unset` / `none` / `transparent` — do not paint a
 #     background (keeps terminal transparency; unlike `idx:0`, which paints ANSI black).
 #
@@ -226,7 +253,8 @@ tab_bar_position = "bottom"
 # lines — ncmpcpp-inspired `%` / `$` strings (one per strip row). Examples:
 #   %t title  %a artist  %b album  %y year  %n track#  %l track length
 #   %e elapsed  %E / %T total  %g genre  %f file  %D parent dir  %q quality
-#   %P queue total duration  %i %j queue index & length  %v volume  %K bitrate  %% literal %
+#   %P queue total duration  %i %j queue index & length  %v volume  %K bitrate
+#   %R user rating ([⭑⭑⭒⭒⭒], needs [ratings].enabled)  %% literal %
 #   $1–$8 colors, $9 reset, $b$/b bold, $u$/u underline, $r$/r reverse.
 
 [ui.row_now_playing]
@@ -296,9 +324,12 @@ mode = "artists"
 # Lyrics — `[ui.nptab.lyrics_pane]` (enabled / visible / location), same idea as visualizer_pane.
 #   Lyrics and visualizer can both be visible; set each pane's `location` to split them (e.g. left/right).
 # queue_template — Per-row queue format; prefer `[ui.nptab.queue].queue_template`.
-#   Placeholders: {n} track # (` 3. `, plus `★ ` when favorited), {title},
-#   {album}, {duration}, {suffix}, {favorite} (legacy prefix; prefer {n}).
-# show_fzf_hint  — Empty-queue hint mentioning library picker when enabled.
+#   Placeholders: {n} track # (` 3. `), {title} (prepends `★ ` when favorited, inside
+#   `{title:<N}` width so columns stay aligned), {artist}, {album}, {duration},
+#   {rating} ([⭑⭑⭒⭒⭒] when rated), {suffix}, {favorite} (standalone star prefix).
+#   Spacing is reflected in output e.g. add space before {rating}:
+#   `{n}{title:<40}  {artist:<25}  {duration:>5}    {rating}`
+# show_fzf_hint — Empty-queue hint mentioning library picker when enabled.
 
 [ui.nptab]
 queue_template = ""
@@ -327,7 +358,7 @@ left_width_percent = 50
 
 [ui.nptab.queue]
 position = "right"
-# queue_template = "{n}{title:<40}  {artist:<25}  {duration:>5}"
+# queue_template = "{n}{title:<40}  {artist:<25}  {duration:>5}    {rating}"
 
 # [ui.nptab.lyrics_pane]
 # enabled — If false, lyrics cannot be opened. Default: true.

--- a/ratune-subsonic/src/client.rs
+++ b/ratune-subsonic/src/client.rs
@@ -131,6 +131,7 @@ fn music_directory_from_library_indexes(music_folder_id: &str, data: &Artists) -
             path: None,
             suffix: None,
             content_type: None,
+            user_rating: None,
         })
         .collect();
     directories.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
@@ -777,6 +778,25 @@ impl SubsonicClient {
         self.set_starred(StarItemType::Song, id, false).await
     }
 
+    /// Set or clear the user rating for a song, album, or artist (`setRating`).
+    ///
+    /// `rating` must be 1–5 to set, or 0 to remove the rating. The server resolves
+    /// entity type from `id` (same as the star API).
+    pub async fn set_rating(&self, id: &str, rating: u8) -> Result<()> {
+        let mut params = self.auth_params();
+        params.push(("id", id.to_string()));
+        params.push(("rating", rating.to_string()));
+        let env: PingEnvelope = self
+            .http
+            .get(self.endpoint_url("setRating"))
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        check_status(&env.response.status, env.response.error.as_ref())
+    }
+
     /// Mark a song as played (scrobble).
     pub async fn scrobble(&self, id: &str) -> Result<()> {
         let mut params = self.auth_params();
@@ -1046,6 +1066,7 @@ mod tests {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         }
     }
 

--- a/ratune-subsonic/src/lib.rs
+++ b/ratune-subsonic/src/lib.rs
@@ -8,8 +8,10 @@ pub use client::{
 };
 pub use error::{is_auth_failure, SubsonicError, AUTH_ERROR_CODE};
 pub use models::{
-    music_library_root_cache_key, parse_music_library_root_folder_id, Album, Artist, ArtistIndex,
-    Artists, DirectoryChild, Indexes, InternetRadioStation, LyricLine, MusicDirectory, MusicFolder,
-    Playlist, PlaylistDetail, ScanStatus, SearchResult3, Song, Starred2, SubsonicLibrary,
-    MUSIC_FOLDER_ROOT_ID_PREFIX,
+    format_user_rating, format_user_rating_with_glyphs, format_user_rating_with_options,
+    music_library_root_cache_key, parse_music_library_root_folder_id, user_rating_mpris, Album,
+    Artist, ArtistIndex, Artists, DirectoryChild, Indexes, InternetRadioStation, LyricLine,
+    MusicDirectory, MusicFolder, Playlist, PlaylistDetail, ScanStatus, SearchResult3, Song,
+    Starred2, SubsonicLibrary, DEFAULT_RATING_BRACKET_CLOSE, DEFAULT_RATING_BRACKET_OPEN,
+    DEFAULT_RATING_STAR_EMPTY, DEFAULT_RATING_STAR_FILLED, MUSIC_FOLDER_ROOT_ID_PREFIX,
 };

--- a/ratune-subsonic/src/models.rs
+++ b/ratune-subsonic/src/models.rs
@@ -49,6 +49,9 @@ pub struct Artist {
     pub album_count: Option<u32>,
     pub cover_art: Option<String>,
     pub starred: Option<String>,
+    /// User rating 1–5 from Subsonic `userRating`.
+    #[serde(default)]
+    pub user_rating: Option<u8>,
     /// Album stubs — populated only by `getArtist`, empty from `getArtists`.
     #[serde(default)]
     pub album: Vec<Album>,
@@ -123,6 +126,76 @@ pub struct Song {
     pub size: Option<u64>,
     pub path: Option<String>,
     pub starred: Option<String>,
+    /// User rating 1–5 from Subsonic `userRating` (absent or 0 = unrated).
+    #[serde(default)]
+    pub user_rating: Option<u8>,
+}
+
+/// Glyphs for ratings: small stars sit closer to the text centerline than `★`/`☆`.
+pub const DEFAULT_RATING_STAR_FILLED: &str = "⭑";
+pub const DEFAULT_RATING_STAR_EMPTY: &str = "⭒";
+pub const DEFAULT_RATING_BRACKET_OPEN: &str = "[";
+pub const DEFAULT_RATING_BRACKET_CLOSE: &str = "]";
+
+/// Display a 1–5 user rating as bracketed stars (empty when unrated).
+#[must_use]
+pub fn format_user_rating(rating: Option<u8>) -> String {
+    format_user_rating_with_options(
+        rating,
+        DEFAULT_RATING_STAR_FILLED,
+        DEFAULT_RATING_STAR_EMPTY,
+        DEFAULT_RATING_BRACKET_OPEN,
+        DEFAULT_RATING_BRACKET_CLOSE,
+    )
+}
+
+/// Like [`format_user_rating`] but with custom filled/empty glyphs (one repeat = one star).
+#[must_use]
+pub fn format_user_rating_with_glyphs(rating: Option<u8>, filled: &str, empty: &str) -> String {
+    format_user_rating_with_options(
+        rating,
+        filled,
+        empty,
+        DEFAULT_RATING_BRACKET_OPEN,
+        DEFAULT_RATING_BRACKET_CLOSE,
+    )
+}
+
+/// Full control over rating display glyphs and optional brackets (`""` = no brackets).
+#[must_use]
+pub fn format_user_rating_with_options(
+    rating: Option<u8>,
+    filled: &str,
+    empty: &str,
+    bracket_open: &str,
+    bracket_close: &str,
+) -> String {
+    let filled = if filled.is_empty() {
+        DEFAULT_RATING_STAR_FILLED
+    } else {
+        filled
+    };
+    let empty = if empty.is_empty() {
+        DEFAULT_RATING_STAR_EMPTY
+    } else {
+        empty
+    };
+    match rating.filter(|&r| (1..=5).contains(&r)) {
+        Some(r) => {
+            let on = filled.repeat(r as usize);
+            let off = empty.repeat((5 - r) as usize);
+            format!("{bracket_open}{on}{off}{bracket_close}")
+        }
+        None => String::new(),
+    }
+}
+
+/// MPRIS `xesam:userRating` is 0.0–1.0; Subsonic uses 1–5.
+#[must_use]
+pub fn user_rating_mpris(rating: Option<u8>) -> Option<f64> {
+    rating
+        .filter(|&r| (1..=5).contains(&r))
+        .map(|r| f64::from(r) / 5.0)
 }
 
 /// An album as returned by `getAlbum` or `search3`.
@@ -143,6 +216,9 @@ pub struct Album {
     pub year: Option<u32>,
     pub genre: Option<String>,
     pub starred: Option<String>,
+    /// User rating 1–5 from Subsonic `userRating`.
+    #[serde(default)]
+    pub user_rating: Option<u8>,
     /// Tracks — populated only by `getAlbum`, empty for search results.
     #[serde(default)]
     pub song: Vec<Song>,
@@ -298,6 +374,9 @@ pub struct DirectoryChild {
     pub path: Option<String>,
     pub suffix: Option<String>,
     pub content_type: Option<String>,
+    /// User rating 1–5 when the server includes it on directory entries.
+    #[serde(default)]
+    pub user_rating: Option<u8>,
 }
 
 impl DirectoryChild {
@@ -322,6 +401,7 @@ impl DirectoryChild {
             size: None,
             path: self.path.clone(),
             starred: None,
+            user_rating: self.user_rating,
         }
     }
 }
@@ -1051,6 +1131,7 @@ mod tests {
                 album_count: None,
                 cover_art: None,
                 starred: None,
+                user_rating: None,
                 album: vec![],
             }],
         };
@@ -1104,5 +1185,30 @@ mod tests {
         let lines = structured_lyrics_to_lines(&entries);
         assert_eq!(lines.len(), 2);
         assert!(lines.iter().all(|l| l.time.is_none()));
+    }
+
+    #[test]
+    fn deserialize_song_user_rating() {
+        let j = r#"{"id":"1","title":"T","userRating":4}"#;
+        let song: Song = serde_json::from_str(j).unwrap();
+        assert_eq!(song.user_rating, Some(4));
+    }
+
+    #[test]
+    fn format_user_rating_and_mpris_scale() {
+        assert_eq!(format_user_rating(Some(3)), "[⭑⭑⭑⭒⭒]");
+        assert_eq!(format_user_rating(None), "");
+        assert_eq!(format_user_rating_with_glyphs(Some(4), "★", "☆"), "[★★★★☆]");
+        assert_eq!(
+            format_user_rating_with_options(Some(3), "★", "☆", "", ""),
+            "★★★☆☆"
+        );
+        assert_eq!(
+            format_user_rating_with_options(Some(2), "⭑", "⭒", "(", ")"),
+            "(⭑⭑⭒⭒⭒)"
+        );
+        assert_eq!(user_rating_mpris(Some(5)), Some(1.0));
+        assert_eq!(user_rating_mpris(Some(3)), Some(0.6));
+        assert_eq!(user_rating_mpris(None), None);
     }
 }

--- a/ratune/src/action.rs
+++ b/ratune/src/action.rs
@@ -76,6 +76,8 @@ pub enum Action {
     ToggleHelp,
     /// Toggle favorite (star) status for the focused or playing track.
     ToggleFavorite,
+    /// Set user rating (1–5) on the focused or playing song; 0 clears.
+    RateSong(u8),
     /// Toggle the favorites (starred) browser overlay.
     ToggleFavoritesOverlay,
     /// Favorites overlay: scroll up.

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -407,6 +407,13 @@ pub enum LibraryUpdate {
         was_starred: bool,
         error: Option<String>,
     },
+    /// Song, album, or artist rating update completed or failed (`setRating`).
+    RatingSet {
+        id: String,
+        kind: FavoriteKind,
+        rating: u8,
+        error: Option<String>,
+    },
     /// Starred tracks to prefetch into the offline cache (`song_id`, `album_id`).
     PrefetchStarredCache(Vec<(String, String)>),
     /// Starred library from `getStarred2` for the favorites overlay.
@@ -435,6 +442,11 @@ fn favorite_kind_to_star_item_type(kind: FavoriteKind) -> StarItemType {
         FavoriteKind::Album => StarItemType::Album,
         FavoriteKind::Artist => StarItemType::Artist,
     }
+}
+
+struct RatingTarget {
+    id: String,
+    kind: FavoriteKind,
 }
 
 struct FavoriteTarget {
@@ -3059,6 +3071,27 @@ impl App {
                     self.fetch_starred();
                 }
             }
+            LibraryUpdate::RatingSet {
+                id,
+                kind,
+                rating,
+                error,
+            } => {
+                if let Some(e) = error {
+                    self.flash_status_secs(format!("Rating failed: {e}"), 5);
+                } else {
+                    let stored = if rating == 0 { None } else { Some(rating) };
+                    self.set_item_rating(kind, &id, stored);
+                    self.flash_status(if rating == 0 {
+                        "Rating cleared"
+                    } else {
+                        "Rating updated"
+                    });
+                    if kind == FavoriteKind::Song {
+                        self.mpris_emit_props();
+                    }
+                }
+            }
             LibraryUpdate::PrefetchStarredCache(tracks) => {
                 let uncached: Vec<_> = tracks
                     .into_iter()
@@ -3681,7 +3714,12 @@ impl App {
 
     #[must_use]
     pub fn is_radio_song(song: &ratune_subsonic::Song) -> bool {
-        song.id.starts_with(RADIO_SONG_ID_PREFIX)
+        Self::is_radio_song_id(&song.id)
+    }
+
+    #[must_use]
+    fn is_radio_song_id(song_id: &str) -> bool {
+        song_id.starts_with(RADIO_SONG_ID_PREFIX)
     }
 
     fn song_from_radio_station(station: &InternetRadioStation) -> ratune_subsonic::Song {
@@ -3704,6 +3742,7 @@ impl App {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         }
     }
 
@@ -4370,6 +4409,97 @@ impl App {
             })
     }
 
+    /// Item targeted by rating keys (1–5 / clear): song, album, or artist.
+    fn rating_target(&self) -> Option<RatingTarget> {
+        if self.favorites_overlay.visible {
+            let idx = self.favorites_overlay.selected_item_index;
+            return match self.favorites_overlay.category {
+                FavoritesCategory::Songs => {
+                    self.favorites_overlay.songs.get(idx).map(|s| RatingTarget {
+                        id: s.id.clone(),
+                        kind: FavoriteKind::Song,
+                    })
+                }
+                FavoritesCategory::Albums => {
+                    self.favorites_overlay
+                        .albums
+                        .get(idx)
+                        .map(|a| RatingTarget {
+                            id: a.id.clone(),
+                            kind: FavoriteKind::Album,
+                        })
+                }
+                FavoritesCategory::Artists => {
+                    self.favorites_overlay
+                        .artists
+                        .get(idx)
+                        .map(|a| RatingTarget {
+                            id: a.id.clone(),
+                            kind: FavoriteKind::Artist,
+                        })
+                }
+            };
+        }
+        if self.active_tab == Tab::Browser && !self.browse_files() {
+            match self.browser_focus {
+                BrowserColumn::Artists => {
+                    return self.library.current_artist().map(|a| RatingTarget {
+                        id: a.id.clone(),
+                        kind: FavoriteKind::Artist,
+                    });
+                }
+                BrowserColumn::Albums => {
+                    return self.library.current_album().map(|a| RatingTarget {
+                        id: a.id.clone(),
+                        kind: FavoriteKind::Album,
+                    });
+                }
+                BrowserColumn::Tracks => {}
+            }
+            if let Some(song) = self.library.current_track() {
+                return Some(RatingTarget {
+                    id: song.id.clone(),
+                    kind: FavoriteKind::Song,
+                });
+            }
+            return None;
+        }
+        if self.active_tab == Tab::Browser && self.browse_files() {
+            if let Some(song) = self
+                .folders
+                .current_preview_track(self.browser_column_filter(BrowserColumn::Tracks))
+            {
+                return Some(RatingTarget {
+                    id: song.id.clone(),
+                    kind: FavoriteKind::Song,
+                });
+            }
+            return None;
+        }
+        if self.active_tab == Tab::NowPlaying {
+            if let Some(song) = self.queue.songs.get(self.queue.cursor) {
+                return Some(RatingTarget {
+                    id: song.id.clone(),
+                    kind: FavoriteKind::Song,
+                });
+            }
+            if let Some(song) = self.playback.current_song.as_ref() {
+                return Some(RatingTarget {
+                    id: song.id.clone(),
+                    kind: FavoriteKind::Song,
+                });
+            }
+            return None;
+        }
+        self.playback
+            .current_song
+            .as_ref()
+            .map(|song| RatingTarget {
+                id: song.id.clone(),
+                kind: FavoriteKind::Song,
+            })
+    }
+
     fn set_item_starred(&mut self, kind: FavoriteKind, item_id: &str, starred: Option<String>) {
         match kind {
             FavoriteKind::Song => self.set_song_starred(item_id, starred),
@@ -4464,6 +4594,93 @@ impl App {
             let max = self.favorites_overlay.item_count().saturating_sub(1);
             self.favorites_overlay.selected_item_index =
                 self.favorites_overlay.selected_item_index.min(max);
+        }
+    }
+
+    fn set_item_rating(&mut self, kind: FavoriteKind, item_id: &str, rating: Option<u8>) {
+        match kind {
+            FavoriteKind::Song => self.set_song_rating(item_id, rating),
+            FavoriteKind::Album => {
+                for state in self.library.albums.values_mut() {
+                    if let LoadingState::Loaded(albums) = state {
+                        for a in albums.iter_mut().filter(|a| a.id == item_id) {
+                            a.user_rating = rating;
+                        }
+                    }
+                }
+                for a in self
+                    .favorites_overlay
+                    .albums
+                    .iter_mut()
+                    .filter(|a| a.id == item_id)
+                {
+                    a.user_rating = rating;
+                }
+            }
+            FavoriteKind::Artist => {
+                if let LoadingState::Loaded(artists) = &mut self.library.artists {
+                    for a in artists.iter_mut().filter(|a| a.id == item_id) {
+                        a.user_rating = rating;
+                    }
+                }
+                for a in self
+                    .favorites_overlay
+                    .artists
+                    .iter_mut()
+                    .filter(|a| a.id == item_id)
+                {
+                    a.user_rating = rating;
+                }
+            }
+        }
+    }
+
+    /// Update `user_rating` everywhere a song appears in local state.
+    fn set_song_rating(&mut self, song_id: &str, rating: Option<u8>) {
+        for state in self.library.tracks.values_mut() {
+            if let LoadingState::Loaded(songs) = state {
+                for s in songs.iter_mut().filter(|s| s.id == song_id) {
+                    s.user_rating = rating;
+                }
+            }
+        }
+        for s in self.queue.songs.iter_mut().filter(|s| s.id == song_id) {
+            s.user_rating = rating;
+        }
+        if let Some(s) = self.playback.current_song.as_mut() {
+            if s.id == song_id {
+                s.user_rating = rating;
+            }
+        }
+        for state in self.folders.listings.values_mut() {
+            if let LoadingState::Loaded(li) = state {
+                for s in li.tracks.iter_mut().filter(|s| s.id == song_id) {
+                    s.user_rating = rating;
+                }
+            }
+        }
+        if let LoadingState::Loaded(tracks) = &mut self.playlist_overlay.tracks {
+            for s in tracks.iter_mut().filter(|s| s.id == song_id) {
+                s.user_rating = rating;
+            }
+        }
+        if let Some(s) = self.library_index_by_id.get_mut(song_id) {
+            s.user_rating = rating;
+        }
+        for s in self
+            .library_index_tracks
+            .iter_mut()
+            .filter(|s| s.id == song_id)
+        {
+            s.user_rating = rating;
+        }
+        for s in self
+            .favorites_overlay
+            .songs
+            .iter_mut()
+            .filter(|s| s.id == song_id)
+        {
+            s.user_rating = rating;
         }
     }
 
@@ -4597,6 +4814,26 @@ impl App {
                     id,
                     kind,
                     was_starred,
+                    error,
+                })
+                .await;
+        });
+    }
+
+    fn spawn_set_rating(&self, id: String, kind: FavoriteKind, rating: u8) {
+        if !self.remote_available() {
+            return;
+        }
+        let client = self.subsonic.clone();
+        let tx = self.library_tx.clone();
+        tokio::spawn(async move {
+            let result = client.set_rating(&id, rating).await;
+            let error = result.err().map(|e| e.to_string());
+            let _ = tx
+                .send(LibraryUpdate::RatingSet {
+                    id,
+                    kind,
+                    rating,
                     error,
                 })
                 .await;
@@ -4776,6 +5013,34 @@ impl App {
                 } else if let Some(target) = self.favorite_target() {
                     self.spawn_toggle_star(target.id.clone(), target.kind, target.was_starred);
                     self.flash_status("Updating favorite…");
+                } else {
+                    self.flash_status("No item selected");
+                }
+            }
+            Action::RateSong(rating) => {
+                if rating > 5 {
+                    return;
+                }
+                if !self.config.ratings_enabled {
+                    self.flash_status_secs("Ratings disabled — set [ratings].enabled = true", 5);
+                } else if !self.remote_available() {
+                    self.flash_status_secs("Server offline — cannot change rating", 4);
+                } else if let Some(target) = self.rating_target() {
+                    if target.kind == FavoriteKind::Song && Self::is_radio_song_id(&target.id) {
+                        self.flash_status("Ratings are not available for radio");
+                    } else {
+                        let stored = if rating == 0 { None } else { Some(rating) };
+                        self.set_item_rating(target.kind, &target.id, stored);
+                        if target.kind == FavoriteKind::Song {
+                            self.mpris_emit_props();
+                        }
+                        self.spawn_set_rating(target.id.clone(), target.kind, rating);
+                        self.flash_status(if rating == 0 {
+                            "Clearing rating…".to_string()
+                        } else {
+                            format!("Rated {rating} star(s)")
+                        });
+                    }
                 } else {
                     self.flash_status("No item selected");
                 }
@@ -6006,6 +6271,7 @@ impl App {
                         bit_rate: None,
                         size: None,
                         starred: None,
+                        user_rating: None,
                     };
                     let was_empty = self.queue.songs.is_empty();
                     self.queue.push(song);
@@ -6108,6 +6374,7 @@ impl App {
             bit_rate: None,
             size: None,
             starred: None,
+            user_rating: None,
         };
         let was_empty = self.queue.songs.is_empty();
         self.queue.push(song);

--- a/ratune/src/cache.rs
+++ b/ratune/src/cache.rs
@@ -311,6 +311,7 @@ mod tests {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         }
     }
 

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -40,6 +40,8 @@ struct FileConfig {
     pub scrobble: ScrobbleSection,
     #[serde(default)]
     pub radio: RadioSection,
+    #[serde(default)]
+    ratings: RatingsSection,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -141,6 +143,14 @@ pub struct KeybindsSection {
     pub toggle_favorite: Option<String>,
     /// Browse: open favorites overlay. Default: Shift+f (`F`)
     pub favorites_overlay: Option<String>,
+    /// Rate focused/playing song 1–5 (Subsonic setRating). Defaults: Shift+1 … Shift+5
+    pub rate_song_1: Option<String>,
+    pub rate_song_2: Option<String>,
+    pub rate_song_3: Option<String>,
+    pub rate_song_4: Option<String>,
+    pub rate_song_5: Option<String>,
+    /// Clear song rating. Default: Shift+0
+    pub rate_song_clear: Option<String>,
 }
 
 // ── [theme] ───────────────────────────────────────────────────────────────────
@@ -1042,6 +1052,37 @@ impl Default for PlayerSection {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct RatingsSection {
+    /// Show ratings in the UI, allow rating keybinds, and export MPRIS UserRating.
+    #[serde(default)]
+    enabled: bool,
+    /// Glyph repeated for each filled star in rating display. Default: ⭑
+    #[serde(default = "default_rating_star_filled")]
+    star_filled: String,
+    /// Glyph repeated for each empty star in rating display. Default: ⭒
+    #[serde(default = "default_rating_star_empty")]
+    star_empty: String,
+    /// Opening bracket around the rating star run. Default: `[` (`""` = none).
+    #[serde(default = "default_rating_bracket_open")]
+    bracket_open: String,
+    /// Closing bracket around the rating star run. Default: `]` (`""` = none).
+    #[serde(default = "default_rating_bracket_close")]
+    bracket_close: String,
+}
+
+impl Default for RatingsSection {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            star_filled: default_rating_star_filled(),
+            star_empty: default_rating_star_empty(),
+            bracket_open: default_rating_bracket_open(),
+            bracket_close: default_rating_bracket_close(),
+        }
+    }
+}
+
 fn default_volume() -> u8 {
     70
 }
@@ -1054,11 +1095,60 @@ fn default_queue_loop() -> bool {
     true
 }
 
+fn default_rating_star_filled() -> String {
+    ratune_subsonic::DEFAULT_RATING_STAR_FILLED.to_string()
+}
+
+fn default_rating_star_empty() -> String {
+    ratune_subsonic::DEFAULT_RATING_STAR_EMPTY.to_string()
+}
+
+fn default_rating_bracket_open() -> String {
+    ratune_subsonic::DEFAULT_RATING_BRACKET_OPEN.to_string()
+}
+
+fn default_rating_bracket_close() -> String {
+    ratune_subsonic::DEFAULT_RATING_BRACKET_CLOSE.to_string()
+}
+
 fn default_password_keyring() -> String {
     "keyutils".into()
 }
 
 // ── Runtime config ────────────────────────────────────────────────────────────
+
+/// Glyphs used when rendering a 1–5 user rating in the UI.
+#[derive(Debug, Clone)]
+pub struct RatingStarGlyphs {
+    pub filled: String,
+    pub empty: String,
+    pub bracket_open: String,
+    pub bracket_close: String,
+}
+
+impl Default for RatingStarGlyphs {
+    fn default() -> Self {
+        Self {
+            filled: default_rating_star_filled(),
+            empty: default_rating_star_empty(),
+            bracket_open: default_rating_bracket_open(),
+            bracket_close: default_rating_bracket_close(),
+        }
+    }
+}
+
+impl RatingStarGlyphs {
+    #[must_use]
+    pub fn format(&self, rating: Option<u8>) -> String {
+        ratune_subsonic::format_user_rating_with_options(
+            rating,
+            &self.filled,
+            &self.empty,
+            &self.bracket_open,
+            &self.bracket_close,
+        )
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -1075,6 +1165,10 @@ pub struct Config {
     pub mpris_enabled: bool,
     /// When true, playback wraps to the first queue track after the last one ends.
     pub queue_loop: bool,
+    /// When true, show ratings in the UI and allow rating keybinds / MPRIS UserRating (`[ratings].enabled`).
+    pub ratings_enabled: bool,
+    /// Star glyphs for rating display (`[ratings].star_filled` / `star_empty`).
+    pub rating_stars: RatingStarGlyphs,
     /// Internet Radio (picker, Now Playing pane, station management).
     pub radio_enabled: bool,
     /// When false, skip HTTP fetches to station homepages for Now Playing art.
@@ -1506,6 +1600,13 @@ impl Config {
             max_bit_rate: file_cfg.player.max_bit_rate,
             mpris_enabled: file_cfg.player.mpris,
             queue_loop: file_cfg.player.queue_loop,
+            ratings_enabled: file_cfg.ratings.enabled,
+            rating_stars: RatingStarGlyphs {
+                filled: file_cfg.ratings.star_filled,
+                empty: file_cfg.ratings.star_empty,
+                bracket_open: file_cfg.ratings.bracket_open,
+                bracket_close: file_cfg.ratings.bracket_close,
+            },
             radio_enabled,
             radio_fetch_station_icons,
             keybinds: file_cfg.keybinds,
@@ -1646,6 +1747,13 @@ max_bit_rate = 0   # 0 = unlimited; set e.g. 320 to cap streaming bitrate
 # mpris = true     # Linux: register on session D-Bus for media keys / playerctl (default: true)
 # queue_loop = true   # wrap to first track after the last queue item (default: true)
 
+[ratings]
+# enabled = false     # show ratings in UI, enable Shift+1…5 keybinds, export MPRIS UserRating
+# star_filled = "⭑"   # glyph per filled star in [⭑⭑⭒⭒⭒] display
+# star_empty = "⭒"    # glyph per empty star (try "★" / "☆" for larger stars)
+# bracket_open = "["  # bracket before stars ("" = none)
+# bracket_close = "]" # bracket after stars ("" = none)
+
 [keybinds]
 # Shift+letter: use "Shift+n" or "N" (same). Helps Ghostty/kitty vs. classic terminals.
 # scroll_up     = "k"
@@ -1691,6 +1799,14 @@ max_bit_rate = 0   # 0 = unlimited; set e.g. 320 to cap streaming bitrate
 # home_section_next = "Shift+j"
 # home_section_prev = "Shift+k"
 # home_refresh = "r"
+
+# toggle_favorite = "f"
+# rate_song_1 = "Shift+1"   # rate focused/playing song 1–5 (Subsonic setRating)
+# rate_song_2 = "Shift+2"
+# rate_song_3 = "Shift+3"
+# rate_song_4 = "Shift+4"
+# rate_song_5 = "Shift+5"
+# rate_song_clear = "Shift+0"
 
 [theme]
 # accent        = "#ff8c00"   # highlighted items, active borders, progress fill
@@ -2448,6 +2564,34 @@ cache_enabled = false
     fn parses_radio_enabled() {
         let fc: FileConfig = toml::from_str("[radio]\nenabled = false\n").expect("toml");
         assert_eq!(fc.radio.enabled, Some(false));
+    }
+
+    #[test]
+    fn ratings_defaults_disabled() {
+        let fc: FileConfig = toml::from_str("").expect("toml");
+        assert!(!fc.ratings.enabled);
+        assert_eq!(fc.ratings.star_filled, "⭑");
+        assert_eq!(fc.ratings.bracket_open, "[");
+    }
+
+    #[test]
+    fn parses_ratings_section() {
+        let fc: FileConfig = toml::from_str(
+            r#"
+[ratings]
+enabled = true
+star_filled = "★"
+star_empty = "☆"
+bracket_open = ""
+bracket_close = ""
+"#,
+        )
+        .expect("toml");
+        assert!(fc.ratings.enabled);
+        assert_eq!(fc.ratings.star_filled, "★");
+        assert_eq!(fc.ratings.star_empty, "☆");
+        assert_eq!(fc.ratings.bracket_open, "");
+        assert_eq!(fc.ratings.bracket_close, "");
     }
 
     #[test]

--- a/ratune/src/favorites_cache.rs
+++ b/ratune/src/favorites_cache.rs
@@ -103,6 +103,7 @@ mod tests {
             size: None,
             path: None,
             starred: Some("2024-01-01T00:00:00Z".into()),
+            user_rating: None,
         });
 
         let ts = save(&path, &starred).unwrap();

--- a/ratune/src/keybinds.rs
+++ b/ratune/src/keybinds.rs
@@ -27,6 +27,9 @@ impl KeySpec {
     ///
     /// Shift+letter chords are stored as lowercase `char` + [`SHIFT`]. Many terminals
     /// send an uppercase letter plus SHIFT instead; those are normalized here.
+    ///
+    /// Shift+digit defaults bind the shifted symbol (`!` for Shift+1 on US layouts) because
+    /// most terminals never deliver `Char('1')` + SHIFT.
     pub fn matches(&self, code: KeyCode, mods: KeyModifiers) -> bool {
         if self.code == KeyCode::BackTab {
             return code == KeyCode::BackTab;
@@ -40,6 +43,17 @@ impl KeySpec {
                 && kc.to_ascii_lowercase() == sc
             {
                 return true;
+            }
+            // Shift+digit configured as `Shift+1`: accept digit+SHIFT or US shifted symbol.
+            if self.modifiers == KeyModifiers::SHIFT && sc.is_ascii_digit() {
+                if kc == sc && mods.contains(KeyModifiers::SHIFT) {
+                    return true;
+                }
+                if let Some(ch) = shift_digit_symbol(sc) {
+                    if kc == ch && !mods.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+                        return true;
+                    }
+                }
             }
         }
         let (code, mods) = match code {
@@ -66,6 +80,25 @@ impl KeySpec {
         }
         mods.contains(self.modifiers)
     }
+}
+
+/// US-keyboard shifted symbol for a digit (Shift+1 → `!`, etc.).
+fn shift_digit_symbol(digit: char) -> Option<char> {
+    Some(match digit {
+        '1' => '!',
+        '2' => '@',
+        '3' => '#',
+        '4' => '$',
+        '5' => '%',
+        '0' => ')',
+        _ => return None,
+    })
+}
+
+/// Default rating key: the character most terminals emit for Shift+digit (US layout).
+fn rate_default(digit: char) -> KeySpec {
+    let ch = shift_digit_symbol(digit).unwrap_or(digit);
+    KeySpec::new(KeyCode::Char(ch))
 }
 
 /// Human-readable key chord (e.g. `Ctrl+Shift+r`, `N`, `` ` ``).
@@ -192,6 +225,14 @@ pub struct Keybinds {
     pub toggle_favorite: KeySpec,
     /// Browser: favorites overlay. Default: Shift+f (`F`)
     pub favorites_overlay: KeySpec,
+    /// Rate focused/playing song 1–5 via Subsonic `setRating`.
+    pub rate_song_1: KeySpec,
+    pub rate_song_2: KeySpec,
+    pub rate_song_3: KeySpec,
+    pub rate_song_4: KeySpec,
+    pub rate_song_5: KeySpec,
+    /// Clear song rating (`setRating` with 0).
+    pub rate_song_clear: KeySpec,
 }
 
 impl Keybinds {
@@ -289,7 +330,6 @@ impl Keybinds {
                 modifiers: KeyModifiers::CONTROL,
             }),
         );
-
         Self {
             scroll_up: resolve(sec.scroll_up.as_deref(), KeySpec::new(KeyCode::Char('k'))),
             scroll_down: resolve(sec.scroll_down.as_deref(), KeySpec::new(KeyCode::Char('j'))),
@@ -440,6 +480,12 @@ impl Keybinds {
                     modifiers: KeyModifiers::SHIFT,
                 },
             ),
+            rate_song_1: resolve(sec.rate_song_1.as_deref(), rate_default('1')),
+            rate_song_2: resolve(sec.rate_song_2.as_deref(), rate_default('2')),
+            rate_song_3: resolve(sec.rate_song_3.as_deref(), rate_default('3')),
+            rate_song_4: resolve(sec.rate_song_4.as_deref(), rate_default('4')),
+            rate_song_5: resolve(sec.rate_song_5.as_deref(), rate_default('5')),
+            rate_song_clear: resolve(sec.rate_song_clear.as_deref(), rate_default('0')),
         }
     }
 }
@@ -536,6 +582,35 @@ mod tests {
     use crossterm::event::{KeyCode, KeyModifiers};
 
     use crate::config::KeybindsSection;
+
+    #[test]
+    fn rate_defaults_match_us_shift_digit_symbols() {
+        let kb = Keybinds::from_section(&KeybindsSection::default());
+        assert!(kb
+            .rate_song_1
+            .matches(KeyCode::Char('!'), KeyModifiers::empty()));
+        assert!(kb
+            .rate_song_3
+            .matches(KeyCode::Char('#'), KeyModifiers::empty()));
+        assert!(kb
+            .rate_song_clear
+            .matches(KeyCode::Char(')'), KeyModifiers::empty()));
+    }
+
+    #[test]
+    fn shift_digit_config_matches_digit_with_shift_or_symbol() {
+        let sec = KeybindsSection {
+            rate_song_1: Some("Shift+1".into()),
+            ..Default::default()
+        };
+        let kb = Keybinds::from_section(&sec);
+        assert!(kb
+            .rate_song_1
+            .matches(KeyCode::Char('1'), KeyModifiers::SHIFT));
+        assert!(kb
+            .rate_song_1
+            .matches(KeyCode::Char('!'), KeyModifiers::empty()));
+    }
 
     #[test]
     fn single_uppercase_letter_in_config_is_shift_plus_lowercase() {

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -792,6 +792,7 @@ async fn run_loop(
                                             app.active_tab,
                                             &app.keybinds,
                                             &mut app.pending_gg,
+                                            app.config.ratings_enabled,
                                         );
                                         app.dispatch(action);
                                     } else if is_quit_in_normal {
@@ -802,6 +803,7 @@ async fn run_loop(
                                             key.modifiers,
                                             &app.favorites_overlay.focus,
                                             &app.keybinds,
+                                            app.config.ratings_enabled,
                                         );
                                         app.dispatch(action);
                                     }
@@ -835,6 +837,7 @@ async fn run_loop(
                                             app.active_tab,
                                             &app.keybinds,
                                             &mut app.pending_gg,
+                                            app.config.ratings_enabled,
                                         );
                                         app.dispatch(action);
                                     } else if is_quit_in_normal {
@@ -847,6 +850,7 @@ async fn run_loop(
                                             &app.playlist_overlay.focus,
                                             &app.playlist_overlay.input_mode,
                                             &app.keybinds,
+                                            app.config.ratings_enabled,
                                         );
                                         app.dispatch(action);
                                     }
@@ -902,6 +906,7 @@ async fn run_loop(
                                             app.active_tab,
                                             &app.keybinds,
                                             &mut app.pending_gg,
+                                            app.config.ratings_enabled,
                                         )
                                     };
                                     match action {
@@ -1310,7 +1315,11 @@ fn map_favorites_key(
     modifiers: KeyModifiers,
     _focus: &FavoritesFocus,
     kb: &Keybinds,
+    ratings_enabled: bool,
 ) -> Action {
+    if let Some(action) = map_rate_key(code, modifiers, kb, ratings_enabled) {
+        return action;
+    }
     let shift = modifiers.intersects(KeyModifiers::SHIFT);
     match code {
         KeyCode::Esc => Action::ToggleFavoritesOverlay,
@@ -1395,6 +1404,7 @@ fn map_playlist_key(
     focus: &PlaylistFocus,
     input_mode: &PlaylistInputMode,
     kb: &Keybinds,
+    ratings_enabled: bool,
 ) -> Action {
     match input_mode {
         // ── Text-input modes: feed characters into the buffer ──────────────
@@ -1473,7 +1483,7 @@ fn map_playlist_key(
                 {
                     Action::PlaylistAppendAll
                 }
-                _ => Action::None,
+                _ => map_rate_key(code, modifiers, kb, ratings_enabled).unwrap_or(Action::None),
             }
         }
     }
@@ -1490,12 +1500,43 @@ fn map_picker_key(code: KeyCode, _modifiers: KeyModifiers) -> Action {
     }
 }
 
+fn map_rate_key(
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    kb: &Keybinds,
+    ratings_enabled: bool,
+) -> Option<Action> {
+    if !ratings_enabled {
+        return None;
+    }
+    if kb.rate_song_1.matches(code, modifiers) {
+        return Some(Action::RateSong(1));
+    }
+    if kb.rate_song_2.matches(code, modifiers) {
+        return Some(Action::RateSong(2));
+    }
+    if kb.rate_song_3.matches(code, modifiers) {
+        return Some(Action::RateSong(3));
+    }
+    if kb.rate_song_4.matches(code, modifiers) {
+        return Some(Action::RateSong(4));
+    }
+    if kb.rate_song_5.matches(code, modifiers) {
+        return Some(Action::RateSong(5));
+    }
+    if kb.rate_song_clear.matches(code, modifiers) {
+        return Some(Action::RateSong(0));
+    }
+    None
+}
+
 fn map_key(
     code: KeyCode,
     modifiers: KeyModifiers,
     active_tab: Tab,
     kb: &Keybinds,
     pending_gg: &mut bool,
+    ratings_enabled: bool,
 ) -> Action {
     // Second `g` after a lone `g`: vim-style `gg` → top.
     if *pending_gg {
@@ -1587,6 +1628,9 @@ fn map_key(
     }
     if kb.toggle_favorite.matches(code, modifiers) {
         return Action::ToggleFavorite;
+    }
+    if let Some(action) = map_rate_key(code, modifiers, kb, ratings_enabled) {
+        return action;
     }
     if kb.toggle_dynamic_theme.matches(code, modifiers) {
         return Action::ToggleDynamicTheme;
@@ -2144,7 +2188,11 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
     }
 
     if app.help_visible {
-        let popup = ui::popup::help_popup_rect(terminal_size, app.config.radio_enabled);
+        let popup = ui::popup::help_popup_rect(
+            terminal_size,
+            app.config.radio_enabled,
+            app.config.ratings_enabled,
+        );
         if rect_contains(popup, x, y) {
             mouse_click::clear_pending_click(app);
             return;

--- a/ratune/src/library_index.rs
+++ b/ratune/src/library_index.rs
@@ -345,6 +345,7 @@ pub fn build_browse_snapshot(tracks: &[Song]) -> BrowseSnapshot {
                 .flat_map(|a| a.songs.first())
                 .find_map(|s| s.cover_art.clone()),
             starred: None,
+            user_rating: None,
             album: Vec::new(),
         })
         .collect();
@@ -380,6 +381,7 @@ pub fn build_browse_snapshot(tracks: &[Song]) -> BrowseSnapshot {
                     year,
                     genre,
                     starred: None,
+                    user_rating: None,
                     song: Vec::new(),
                 }
             })
@@ -422,6 +424,7 @@ mod tests {
                 size: None,
                 path: None,
                 starred: None,
+                user_rating: None,
             }
         }
 
@@ -513,6 +516,7 @@ mod tests {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         };
         let cols = FzfColumns {
             title: 0,
@@ -544,6 +548,7 @@ mod tests {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         };
         let line = fzf_input_lines(std::slice::from_ref(&s), FzfColumns::default());
         assert_eq!(

--- a/ratune/src/mpris.rs
+++ b/ratune/src/mpris.rs
@@ -85,6 +85,9 @@ mod linux {
         if let Some(ref u) = s.art_url {
             b = b.art_url(u.as_str());
         }
+        if let Some(r) = s.user_rating_mpris {
+            b = b.user_rating(r);
+        }
         b.build()
     }
 
@@ -387,6 +390,8 @@ pub struct MprisSnapshot {
     pub can_pause: bool,
     pub can_seek: bool,
     pub has_track: bool,
+    /// MPRIS `xesam:userRating` (0.0–1.0); unset when the track is unrated.
+    pub user_rating_mpris: Option<f64>,
 }
 
 impl Default for MprisSnapshot {
@@ -410,6 +415,7 @@ impl Default for MprisSnapshot {
             can_pause: false,
             can_seek: false,
             has_track: false,
+            user_rating_mpris: None,
         }
     }
 }
@@ -589,6 +595,11 @@ pub fn write_snapshot(app: &crate::app::App, snap: &RwLock<MprisSnapshot>) {
             .duration
             .map(|d| i64::from(d) * 1_000_000)
             .unwrap_or(0);
+        s.user_rating_mpris = if app.config.ratings_enabled {
+            ratune_subsonic::user_rating_mpris(track.user_rating)
+        } else {
+            None
+        };
     }
     s.position_micros = app.playback.elapsed.as_micros() as i64;
     s.volume = app.config.default_volume as f64 / 100.0;

--- a/ratune/src/state.rs
+++ b/ratune/src/state.rs
@@ -650,6 +650,7 @@ mod queue_tests {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         }
     }
 

--- a/ratune/src/ui/albums.rs
+++ b/ratune/src/ui/albums.rs
@@ -59,9 +59,19 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         Some(LoadingState::Loaded(albums)) => {
             let make_label = |a: &Album| {
                 let star = if a.starred.is_some() { "★ " } else { "" };
+                let rating_suffix = if app.config.ratings_enabled {
+                    let rating = app.config.rating_stars.format(a.user_rating);
+                    if rating.is_empty() {
+                        String::new()
+                    } else {
+                        format!("  {rating}")
+                    }
+                } else {
+                    String::new()
+                };
                 match a.year {
-                    Some(y) => format!("{}{} ({})", star, a.name, y),
-                    None => format!("{}{}", star, a.name),
+                    Some(y) => format!("{}{} ({}){}", star, a.name, y, rating_suffix),
+                    None => format!("{}{}{}", star, a.name, rating_suffix),
                 }
             };
 

--- a/ratune/src/ui/artists.rs
+++ b/ratune/src/ui/artists.rs
@@ -74,7 +74,17 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                     .map(|(i, _)| {
                         let a = &artists[*i];
                         let star = if a.starred.is_some() { "★ " } else { "" };
-                        let label = format!("{}{}", star, a.name);
+                        let rating_suffix = if app.config.ratings_enabled {
+                            let rating = app.config.rating_stars.format(a.user_rating);
+                            if rating.is_empty() {
+                                String::new()
+                            } else {
+                                format!("  {rating}")
+                            }
+                        } else {
+                            String::new()
+                        };
+                        let label = format!("{}{}{}", star, a.name, rating_suffix);
                         ListItem::new(label).style(Style::default().fg(t.foreground))
                     })
                     .collect()

--- a/ratune/src/ui/folder_tracks.rs
+++ b/ratune/src/ui/folder_tracks.rs
@@ -82,6 +82,16 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         Some(LoadingState::Loaded(listing)) => {
             let make_track_label = |s: &ratune_subsonic::Song| {
                 let star = if s.starred.is_some() { "★ " } else { "" };
+                let rating_suffix = if app.config.ratings_enabled {
+                    let rating = app.config.rating_stars.format(s.user_rating);
+                    if rating.is_empty() {
+                        String::new()
+                    } else {
+                        format!("  {rating}")
+                    }
+                } else {
+                    String::new()
+                };
                 let dur = s
                     .duration
                     .map(|d| {
@@ -90,7 +100,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                         format!("  {m}:{sec:02}")
                     })
                     .unwrap_or_default();
-                format!("{}{}{}", star, s.title, dur)
+                format!("{}{}{}{}", star, s.title, dur, rating_suffix)
             };
 
             let rows =

--- a/ratune/src/ui/now_playing.rs
+++ b/ratune/src/ui/now_playing.rs
@@ -553,14 +553,18 @@ fn split_row_columns(area: Rect, show_c: bool, show_p: bool) -> RowColumns {
     }
 }
 
-fn builtin_lines() -> Vec<String> {
-    vec!["$b%t$/b".into(), "%a".into(), "%b".into()]
+fn builtin_lines(ratings_enabled: bool) -> Vec<String> {
+    if ratings_enabled {
+        vec!["$b%t$/b  %R".into(), "%a".into(), "%b".into()]
+    } else {
+        vec!["$b%t$/b".into(), "%a".into(), "%b".into()]
+    }
 }
 
 fn template_lines_row(app: &App) -> Vec<String> {
     let v = &app.config.now_playing_lines_row;
     if v.is_empty() {
-        builtin_lines()
+        builtin_lines(app.config.ratings_enabled)
     } else {
         v.clone()
     }
@@ -569,7 +573,7 @@ fn template_lines_row(app: &App) -> Vec<String> {
 fn template_lines_boxed(app: &App) -> Vec<String> {
     let v = &app.config.now_playing_lines_boxed;
     if v.is_empty() {
-        builtin_lines()
+        builtin_lines(app.config.ratings_enabled)
     } else {
         v.clone()
     }
@@ -628,6 +632,8 @@ fn np_context(app: &App) -> NowPlayingContext<'_> {
         } else {
             queue_position_now_playing(app)
         },
+        ratings_enabled: app.config.ratings_enabled,
+        rating_stars: &app.config.rating_stars,
     }
 }
 

--- a/ratune/src/ui/now_playing_format.rs
+++ b/ratune/src/ui/now_playing_format.rs
@@ -21,6 +21,9 @@ pub struct NowPlayingContext<'a> {
     pub queue_total_duration_secs: Option<u64>,
     /// 1-based index of the current track in the queue, and total track count.
     pub queue_position: Option<(usize, usize)>,
+    /// When false, `%R` and other rating placeholders render empty.
+    pub ratings_enabled: bool,
+    pub rating_stars: &'a crate::config::RatingStarGlyphs,
 }
 
 fn palette(theme: &Theme, accent: Color) -> [Color; 8] {
@@ -121,6 +124,13 @@ fn placeholder_value(key: char, ctx: &NowPlayingContext<'_>) -> String {
             .and_then(|x| x.bit_rate)
             .map(|br| format!("{br}"))
             .unwrap_or_default(),
+        'R' => {
+            if !ctx.ratings_enabled {
+                String::new()
+            } else {
+                ctx.rating_stars.format(s.and_then(|x| x.user_rating))
+            }
+        }
         _ => String::new(),
     }
 }
@@ -255,7 +265,9 @@ mod tests {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         };
+        let stars = crate::config::RatingStarGlyphs::default();
         let ctx = NowPlayingContext {
             song: Some(&song),
             elapsed: Duration::ZERO,
@@ -264,6 +276,8 @@ mod tests {
             volume_percent: 70,
             queue_total_duration_secs: None,
             queue_position: None,
+            ratings_enabled: false,
+            rating_stars: &stars,
         };
         let line = format_now_playing_line("%t", &ctx, &theme, theme.accent);
         let s: String = line.iter().map(|s| s.content.as_ref()).collect();
@@ -292,7 +306,9 @@ mod tests {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         };
+        let stars = crate::config::RatingStarGlyphs::default();
         let ctx = NowPlayingContext {
             song: Some(&song),
             elapsed: Duration::ZERO,
@@ -301,6 +317,8 @@ mod tests {
             volume_percent: 42,
             queue_total_duration_secs: Some(125),
             queue_position: Some((2, 5)),
+            ratings_enabled: false,
+            rating_stars: &stars,
         };
         let line = format_now_playing_line("%K vol %v %P %i/%j", &ctx, &theme, theme.accent);
         let s: String = line.iter().map(|s| s.content.as_ref()).collect();
@@ -332,7 +350,9 @@ mod tests {
             size: None,
             path: None,
             starred: None,
+            user_rating: None,
         };
+        let stars = crate::config::RatingStarGlyphs::default();
         let ctx = NowPlayingContext {
             song: Some(&song),
             elapsed: Duration::ZERO,
@@ -341,6 +361,8 @@ mod tests {
             volume_percent: 0,
             queue_total_duration_secs: None,
             queue_position: None,
+            ratings_enabled: false,
+            rating_stars: &stars,
         };
         let line = format_now_playing_line("%K", &ctx, &theme, theme.accent);
         let s: String = line.iter().map(|s| s.content.as_ref()).collect();

--- a/ratune/src/ui/popup.rs
+++ b/ratune/src/ui/popup.rs
@@ -12,7 +12,10 @@ use crate::theme::style_with_bg;
 /// Width reserved for the key column (padded with spaces to align descriptions).
 const KEY_COL_W: usize = 12;
 
-fn sections(radio_enabled: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+fn sections(
+    radio_enabled: bool,
+    ratings_enabled: bool,
+) -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
     let mut playback = vec![
         ("p / Space", "Play / pause"),
         ("n / N", "Next / previous track"),
@@ -21,6 +24,12 @@ fn sections(radio_enabled: bool) -> Vec<(&'static str, Vec<(&'static str, &'stat
         ("x / Z", "Shuffle / unshuffle"),
         ("Q", "Toggle queue loop"),
     ];
+    if ratings_enabled {
+        playback.insert(
+            3,
+            ("Shift+1 … Shift+5", "Rate song 1–5 stars (Shift+0 clears)"),
+        );
+    }
     if radio_enabled {
         playback.push(("Shift+R", "Open / close internet radio picker"));
     }
@@ -123,20 +132,24 @@ fn sections(radio_enabled: bool) -> Vec<(&'static str, Vec<(&'static str, &'stat
     out
 }
 
-fn playlist_sections() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+fn playlist_sections(
+    ratings_enabled: bool,
+) -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+    let mut favorites = vec![
+        ("F", "Open / close favorites panel (Browse)"),
+        ("j / k", "Scroll category / item list"),
+        ("h / l", "Switch between lists"),
+        ("Enter / Ctrl+r", "Replace queue and play"),
+        ("Shift+A", "Append to queue"),
+        ("f", "Toggle favorite"),
+    ];
+    if ratings_enabled {
+        favorites.push(("Shift+1 … Shift+5", "Rate song (Shift+0 clears)"));
+    }
+    favorites.push(("Escape / q", "Close panel"));
+
     vec![
-        (
-            "Favorites",
-            vec![
-                ("F", "Open / close favorites panel (Browse)"),
-                ("j / k", "Scroll category / item list"),
-                ("h / l", "Switch between lists"),
-                ("Enter / Ctrl+r", "Replace queue and play"),
-                ("Shift+A", "Append to queue"),
-                ("f", "Toggle favorite"),
-                ("Escape / q", "Close panel"),
-            ],
-        ),
+        ("Favorites", favorites),
         (
             "Playlists",
             vec![
@@ -212,14 +225,24 @@ fn pack_blocks_into_two_columns(
 }
 
 /// Popup bounds for the keybind help overlay (matches `render_help` sizing).
-pub fn help_popup_rect(area: Rect, radio_enabled: bool) -> Rect {
+pub fn help_popup_rect(area: Rect, radio_enabled: bool, ratings_enabled: bool) -> Rect {
     use ratatui::style::Color;
 
     // Colors are only used for line content; lengths depend on section text alone.
     let accent = Color::White;
-    let mut blocks = build_blocks(sections(radio_enabled), accent, accent, accent);
+    let mut blocks = build_blocks(
+        sections(radio_enabled, ratings_enabled),
+        accent,
+        accent,
+        accent,
+    );
     blocks.push(vec![Line::from("")]);
-    blocks.extend(build_blocks(playlist_sections(), accent, accent, accent));
+    blocks.extend(build_blocks(
+        playlist_sections(ratings_enabled),
+        accent,
+        accent,
+        accent,
+    ));
     let (left_all, right_all) = pack_blocks_into_two_columns(blocks);
 
     let required_inner_h = left_all.len().max(right_all.len()).max(1) as u16;
@@ -249,12 +272,22 @@ pub fn render_help(app: &mut App, frame: &mut Frame) {
     // Keep each category within one column where possible, while aiming for
     // roughly equal column heights.
 
-    let mut blocks = build_blocks(sections(app.config.radio_enabled), accent, fg, dim);
+    let mut blocks = build_blocks(
+        sections(app.config.radio_enabled, app.config.ratings_enabled),
+        accent,
+        fg,
+        dim,
+    );
     blocks.push(vec![Line::from("")]);
-    blocks.extend(build_blocks(playlist_sections(), accent, fg, dim));
+    blocks.extend(build_blocks(
+        playlist_sections(app.config.ratings_enabled),
+        accent,
+        fg,
+        dim,
+    ));
     let (left_all, right_all) = pack_blocks_into_two_columns(blocks);
 
-    let popup_area = help_popup_rect(area, app.config.radio_enabled);
+    let popup_area = help_popup_rect(area, app.config.radio_enabled, app.config.ratings_enabled);
 
     // ── Render ────────────────────────────────────────────────────────────────
 

--- a/ratune/src/ui/queue.rs
+++ b/ratune/src/ui/queue.rs
@@ -7,7 +7,7 @@ use crate::app::App;
 use crate::text_width;
 use crate::theme::style_with_bg;
 
-const DEFAULT_QUEUE_TEMPLATE: &str = "{n}{title:<40}  {artist:<25}  {duration:>5}";
+const DEFAULT_QUEUE_TEMPLATE: &str = "{n}{title:<40}  {artist:<25}  {duration:>5}  {rating}";
 
 pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
     let visible = area.height.saturating_sub(2) as usize;
@@ -77,7 +77,12 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         .enumerate()
         .map(|(offset, s)| {
             let idx = start + offset;
-            let label = format_queue_line(template, s);
+            let label = format_queue_line(
+                template,
+                s,
+                app.config.ratings_enabled,
+                &app.config.rating_stars,
+            );
 
             let style = if idx == app.queue.cursor {
                 Style::default()
@@ -106,11 +111,21 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
     frame.render_stateful_widget(list, area, &mut state);
 }
 
-fn format_queue_line(template: &str, s: &ratune_subsonic::Song) -> String {
+fn format_queue_line(
+    template: &str,
+    s: &ratune_subsonic::Song,
+    ratings_enabled: bool,
+    stars: &crate::config::RatingStarGlyphs,
+) -> String {
     let num = s.track.map(|n| format!("{n:>2}. ")).unwrap_or_default();
-    let star = if s.starred.is_some() { "★ " } else { "" };
-    let n = format!("{num}{star}");
-    let title = s.title.as_str();
+    let title = {
+        let mut t = String::new();
+        if s.starred.is_some() {
+            t.push_str("★ ");
+        }
+        t.push_str(&s.title);
+        t
+    };
     let artist = s.artist.as_deref().unwrap_or("");
     let album = s.album.as_deref().unwrap_or("");
     let duration = s
@@ -119,13 +134,18 @@ fn format_queue_line(template: &str, s: &ratune_subsonic::Song) -> String {
         .unwrap_or_default();
 
     render_template(template, |name| match name {
-        "n" => Some(n.clone()),
-        "title" => Some(title.to_string()),
+        "n" => Some(num.clone()),
+        "title" => Some(title.clone()),
         "artist" => Some(artist.to_string()),
         "album" => Some(album.to_string()),
         "duration" => Some(duration.clone()),
         "favorite" => Some(if s.starred.is_some() {
             "★ ".to_string()
+        } else {
+            String::new()
+        }),
+        "rating" => Some(if ratings_enabled {
+            stars.format(s.user_rating)
         } else {
             String::new()
         }),

--- a/ratune/src/ui/tracks.rs
+++ b/ratune/src/ui/tracks.rs
@@ -65,6 +65,16 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
             let make_label = |s: &ratune_subsonic::Song| {
                 let num = s.track.map(|n| format!("{n:>2}. ")).unwrap_or_default();
                 let star = if s.starred.is_some() { "★ " } else { "" };
+                let rating_suffix = if app.config.ratings_enabled {
+                    let rating = app.config.rating_stars.format(s.user_rating);
+                    if rating.is_empty() {
+                        String::new()
+                    } else {
+                        format!("  {rating}")
+                    }
+                } else {
+                    String::new()
+                };
                 let dur = s
                     .duration
                     .map(|d| {
@@ -73,7 +83,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                         format!("  {m}:{sec:02}")
                     })
                     .unwrap_or_default();
-                format!("{}{}{}{}", num, star, s.title, dur)
+                format!("{}{}{}{}{}", num, star, s.title, dur, rating_suffix)
             };
 
             let visible: Vec<(usize, String)> =


### PR DESCRIPTION
Adds support for subsonic ratings. See #49.

Includes:
- syncing of ratings with subsonic server
- ability to rate songs/albums/artists
- UI display of ratings in browser and queue
- MPRIS rating support
- configurable rating display

Ratings needs to be enabled in config to work:
```toml
[ratings]
enabled = false
```

and everything visual can be configured:
```toml
[ratings]
star_filled = "⭑"
star_empty = "⭒"
bracket_open = "["
bracket_close = "]"
```
