### PR TITLE
task: allow all icons and borders to be configurable

### DIFF
--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -96,19 +96,19 @@ queue_loop = true
 # This section turns on ratings everywhere:
 # browse lists, Now Playing queue/bar, Shift+1…5 keybinds, and MPRIS UserRating.
 #
-# enabled      — Master switch. Default: false.
-# star_filled  — Glyph repeated for each filled star. Default: ⭑ (BLACK SMALL STAR).
-# star_empty   — Glyph repeated for each empty star. Default: ⭒ (WHITE SMALL STAR).
-#                Example for classic larger stars: star_filled = "★", star_empty = "☆".
-# bracket_open — Bracket before the star run. Default: `[` (`""` = none).
-# bracket_close — Bracket after the star run. Default: `]` (`""` = none).
+# enabled — Master switch. Default: false.
+#
+# Rating display glyphs live under `[theme.icon]` (`rating_filled`, `rating_empty`,
+# `rating_bracket_open`, `rating_bracket_close`). Legacy keys below still work if
+# the theme.icon equivalents are unset:
+#   star_filled / star_empty / bracket_open / bracket_close
 
 [ratings]
 # enabled = false
-# star_filled = "⭑"
-# star_empty = "⭒"
-# bracket_open = "["
-# bracket_close = "]"
+# star_filled = "⭑"      # legacy — prefer [theme.icon].rating_filled
+# star_empty = "⭒"       # legacy — prefer [theme.icon].rating_empty
+# bracket_open = "["     # legacy — prefer [theme.icon].rating_bracket_open
+# bracket_close = "]"    # legacy — prefer [theme.icon].rating_bracket_close
 
 # -----------------------------------------------------------------------------
 # [keybinds] — optional overrides
@@ -203,6 +203,13 @@ queue_loop = true
 #   dimmed        — Secondary / muted text.
 #   border        — Inactive borders (some panes still use accent when focused).
 #   border_active — Reserved for themes; many panes now use accent for active frames.
+#
+# Pane outlines: optional `[theme.border_lines]` (`type` = plain|rounded|double|thick|ascii,
+# plus optional edge glyphs). Does not clash with the `border` colour key.
+#
+# Glyphs (optional `[theme.icon]`): transport, favorite marker, rating stars/brackets,
+# tab separator, status online/offline / radio live.
+# Progress bar: `[ui.row_now_playing].progress_style` (not under theme.icon).
 
 [theme]
 preset = "dynamic"
@@ -218,6 +225,60 @@ preset = "dynamic"
 # dimmed = "#5a5858"
 # border = "#252525"
 # border_active = "#3a3a3a"
+
+# -----------------------------------------------------------------------------
+# [theme.border_lines] — pane box-drawing (style + optional edge glyphs)
+# -----------------------------------------------------------------------------
+#
+# type — "plain" (default), "rounded", "double", "thick", or "ascii" (+ - |).
+# Edge overrides (any set builds a custom border): top_left, top_right,
+# bottom_left, bottom_right, vertical, horizontal.
+#
+# Legacy still accepted: flat `[theme].border_type` / `border_top_left` / … and the
+# same keys under `[theme.icon]`.
+
+# [theme.border_lines]
+# type = "ascii"
+# top_left = "+"
+# top_right = "+"
+# bottom_left = "+"
+# bottom_right = "+"
+# vertical = "|"
+# horizontal = "-"
+
+# -----------------------------------------------------------------------------
+# [theme.icon] — optional glyph overrides (fonts without media / specialty chars)
+# -----------------------------------------------------------------------------
+#
+# Omit any key to keep the built-in default. Transport labels are full strings as
+# shown in the controls row (including parentheses when you want them).
+#
+# playing / paused / stopped — shown for those playback states (defaults match the
+#   prior Unicode controls: pause while playing, play while paused, bare play idle).
+# favorite — starred marker in lists / queue (default ★).
+# rating_* — 1–5 user-rating display (defaults ⭑ / ⭒ with [ ]). Legacy: [ratings].star_*.
+# Progress bar glyphs are not here — use `[ui.row_now_playing].progress_style`
+#   (or `[ui.nptab.now_playing].progress_style`), e.g. progress_style = "=>-".
+#
+# Box outlines: prefer `[theme.border_lines]` (legacy: flat theme / theme.icon border_*).
+
+# [theme.icon]
+# playing = "( || )"
+# paused = "( > )"
+# stopped = ">"
+# next_song = ">>"
+# previous_song = "<<"
+# mode_shuffle = "><"
+# mode_loop = "o"
+# favorite = "*"
+# rating_filled = "*"
+# rating_empty = "-"
+# rating_bracket_open = "["
+# rating_bracket_close = "]"
+# tab_separator = " | "
+# online = "*"
+# offline = "o"
+# live = "*"
 
 # Example: mostly terminal colours, but a fixed hex for selection/highlight accent:
 # preset = "terminal"
@@ -254,7 +315,7 @@ tab_bar_position = "bottom"
 #   %t title  %a artist  %b album  %y year  %n track#  %l track length
 #   %e elapsed  %E / %T total  %g genre  %f file  %D parent dir  %q quality
 #   %P queue total duration  %i %j queue index & length  %v volume  %K bitrate
-#   %R user rating ([⭑⭑⭒⭒⭒], needs [ratings].enabled)  %% literal %
+#   %R user rating ([⭑⭑⭒⭒⭒], needs [ratings].enabled; glyphs: [theme.icon].rating_*)  %% literal %
 #   $1–$8 colors, $9 reset, $b$/b bold, $u$/u underline, $r$/r reverse.
 
 [ui.row_now_playing]

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -992,8 +992,169 @@ pub struct ThemeSection {
     pub surface: Option<String>,
     pub foreground: Option<String>,
     pub dimmed: Option<String>,
+    /// Inactive border colour.
     pub border: Option<String>,
     pub border_active: Option<String>,
+    /// Pane outline style + optional edge glyphs. See [`ThemeBorderLinesSection`].
+    #[serde(default)]
+    pub border_lines: ThemeBorderLinesSection,
+    /// Legacy — prefer `[theme.border_lines].type`.
+    pub border_type: Option<String>,
+    /// Legacy — prefer `[theme.border_lines].top_left` (etc.).
+    pub border_top_left: Option<String>,
+    pub border_top_right: Option<String>,
+    pub border_bottom_left: Option<String>,
+    pub border_bottom_right: Option<String>,
+    pub border_vertical: Option<String>,
+    pub border_horizontal: Option<String>,
+    /// Optional glyph overrides (transport, favorite, ratings stars, tab/status chrome).
+    /// See [`ThemeIconSection`]. Progress bar glyphs stay under `[ui.*.progress_style]`.
+    #[serde(default)]
+    pub icon: ThemeIconSection,
+}
+
+/// Pane box-drawing under `[theme.border_lines]` (avoids clashing with the `border` colour key).
+///
+/// ```toml
+/// [theme.border_lines]
+/// type = "ascii"          # plain | rounded | double | thick | ascii
+/// top_left = "+"
+/// top_right = "+"
+/// bottom_left = "+"
+/// bottom_right = "+"
+/// vertical = "|"
+/// horizontal = "-"
+/// ```
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct ThemeBorderLinesSection {
+    /// Outline style: `plain`, `rounded`, `double`, `thick`, or `ascii`.
+    /// TOML key: `type` (also accepts `border_type`).
+    #[serde(default, rename = "type", alias = "border_type")]
+    pub style: Option<String>,
+    #[serde(default, alias = "border_top_left")]
+    pub top_left: Option<String>,
+    #[serde(default, alias = "border_top_right")]
+    pub top_right: Option<String>,
+    #[serde(default, alias = "border_bottom_left")]
+    pub bottom_left: Option<String>,
+    #[serde(default, alias = "border_bottom_right")]
+    pub bottom_right: Option<String>,
+    #[serde(default, alias = "border_vertical")]
+    pub vertical: Option<String>,
+    #[serde(default, alias = "border_horizontal")]
+    pub horizontal: Option<String>,
+}
+
+/// Optional UI glyph overrides under `[theme.icon]`.
+///
+/// Omit any field to keep the built-in default. Useful when the terminal font lacks
+/// media-control or specialty characters.
+///
+/// Box outlines live under `[theme.border_lines]`. Flat `[theme].border_type` / edge keys
+/// and the same keys under `[theme.icon]` are still accepted as legacy fallbacks.
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct ThemeIconSection {
+    /// Label while a track is playing (default: `( ⏸ )`).
+    pub playing: Option<String>,
+    /// Label while paused (default: `( ▶ )`).
+    pub paused: Option<String>,
+    /// Label when nothing is loaded (default: `▶`).
+    pub stopped: Option<String>,
+    /// Next-track control (default: `⏭`).
+    pub next_song: Option<String>,
+    /// Previous-track control (default: `⏮`).
+    pub previous_song: Option<String>,
+    /// Shuffle control (default: `⇄`).
+    pub mode_shuffle: Option<String>,
+    /// Queue-loop control (default: `↻`).
+    pub mode_loop: Option<String>,
+    /// Starred / favorite marker (default: `★`).
+    pub favorite: Option<String>,
+    /// Glyph repeated for each filled rating star (default: `⭑`).
+    /// Legacy fallback: `[ratings].star_filled`.
+    pub rating_filled: Option<String>,
+    /// Glyph repeated for each empty rating star (default: `⭒`).
+    /// Legacy fallback: `[ratings].star_empty`.
+    pub rating_empty: Option<String>,
+    /// Opening bracket around the rating star run (default: `[`).
+    /// Legacy fallback: `[ratings].bracket_open`.
+    pub rating_bracket_open: Option<String>,
+    /// Closing bracket around the rating star run (default: `]`).
+    /// Legacy fallback: `[ratings].bracket_close`.
+    pub rating_bracket_close: Option<String>,
+    /// Tab bar separator including surrounding spaces (default: ` │ `).
+    pub tab_separator: Option<String>,
+    /// Status-bar online indicator (default: `●`).
+    pub online: Option<String>,
+    /// Status-bar offline indicator (default: `○`).
+    pub offline: Option<String>,
+    /// Radio live prefix glyph (default: `●`).
+    pub live: Option<String>,
+    /// Legacy — prefer `[theme.border_lines].type`.
+    pub border_type: Option<String>,
+    /// Legacy — prefer `[theme.border_lines]` edge keys.
+    pub border_top_left: Option<String>,
+    pub border_top_right: Option<String>,
+    pub border_bottom_left: Option<String>,
+    pub border_bottom_right: Option<String>,
+    pub border_vertical: Option<String>,
+    pub border_horizontal: Option<String>,
+}
+
+/// Resolved border glyph sources (canonical → flat theme → icon legacy).
+#[derive(Debug, Default, Clone)]
+pub struct ThemeBorderSource<'a> {
+    pub border_type: Option<&'a str>,
+    pub top_left: Option<&'a str>,
+    pub top_right: Option<&'a str>,
+    pub bottom_left: Option<&'a str>,
+    pub bottom_right: Option<&'a str>,
+    pub vertical: Option<&'a str>,
+    pub horizontal: Option<&'a str>,
+}
+
+impl ThemeSection {
+    /// Border style/glyphs: `[theme.border_lines]` → flat `[theme].border_*` → `[theme.icon]`.
+    pub fn border_source(&self) -> ThemeBorderSource<'_> {
+        let lines = &self.border_lines;
+        ThemeBorderSource {
+            border_type: lines
+                .style
+                .as_deref()
+                .or(self.border_type.as_deref())
+                .or(self.icon.border_type.as_deref()),
+            top_left: lines
+                .top_left
+                .as_deref()
+                .or(self.border_top_left.as_deref())
+                .or(self.icon.border_top_left.as_deref()),
+            top_right: lines
+                .top_right
+                .as_deref()
+                .or(self.border_top_right.as_deref())
+                .or(self.icon.border_top_right.as_deref()),
+            bottom_left: lines
+                .bottom_left
+                .as_deref()
+                .or(self.border_bottom_left.as_deref())
+                .or(self.icon.border_bottom_left.as_deref()),
+            bottom_right: lines
+                .bottom_right
+                .as_deref()
+                .or(self.border_bottom_right.as_deref())
+                .or(self.icon.border_bottom_right.as_deref()),
+            vertical: lines
+                .vertical
+                .as_deref()
+                .or(self.border_vertical.as_deref())
+                .or(self.icon.border_vertical.as_deref()),
+            horizontal: lines
+                .horizontal
+                .as_deref()
+                .or(self.border_horizontal.as_deref())
+                .or(self.icon.border_horizontal.as_deref()),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -1053,20 +1214,20 @@ impl Default for PlayerSection {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct RatingsSection {
+pub(crate) struct RatingsSection {
     /// Show ratings in the UI, allow rating keybinds, and export MPRIS UserRating.
     #[serde(default)]
     enabled: bool,
-    /// Glyph repeated for each filled star in rating display. Default: ⭑
+    /// Legacy glyph — prefer `[theme.icon].rating_filled`. Default: ⭑
     #[serde(default = "default_rating_star_filled")]
     star_filled: String,
-    /// Glyph repeated for each empty star in rating display. Default: ⭒
+    /// Legacy glyph — prefer `[theme.icon].rating_empty`. Default: ⭒
     #[serde(default = "default_rating_star_empty")]
     star_empty: String,
-    /// Opening bracket around the rating star run. Default: `[` (`""` = none).
+    /// Legacy — prefer `[theme.icon].rating_bracket_open`. Default: `[`
     #[serde(default = "default_rating_bracket_open")]
     bracket_open: String,
-    /// Closing bracket around the rating star run. Default: `]` (`""` = none).
+    /// Legacy — prefer `[theme.icon].rating_bracket_close`. Default: `]`
     #[serde(default = "default_rating_bracket_close")]
     bracket_close: String,
 }
@@ -1137,6 +1298,31 @@ impl Default for RatingStarGlyphs {
     }
 }
 
+/// Resolve rating display glyphs: `[theme.icon]` wins over legacy `[ratings]` keys.
+pub(crate) fn resolve_rating_stars(
+    icon: &ThemeIconSection,
+    ratings: &RatingsSection,
+) -> RatingStarGlyphs {
+    RatingStarGlyphs {
+        filled: icon
+            .rating_filled
+            .clone()
+            .unwrap_or_else(|| ratings.star_filled.clone()),
+        empty: icon
+            .rating_empty
+            .clone()
+            .unwrap_or_else(|| ratings.star_empty.clone()),
+        bracket_open: icon
+            .rating_bracket_open
+            .clone()
+            .unwrap_or_else(|| ratings.bracket_open.clone()),
+        bracket_close: icon
+            .rating_bracket_close
+            .clone()
+            .unwrap_or_else(|| ratings.bracket_close.clone()),
+    }
+}
+
 impl RatingStarGlyphs {
     #[must_use]
     pub fn format(&self, rating: Option<u8>) -> String {
@@ -1167,7 +1353,7 @@ pub struct Config {
     pub queue_loop: bool,
     /// When true, show ratings in the UI and allow rating keybinds / MPRIS UserRating (`[ratings].enabled`).
     pub ratings_enabled: bool,
-    /// Star glyphs for rating display (`[ratings].star_filled` / `star_empty`).
+    /// Star glyphs for rating display (`[theme.icon].rating_*`, legacy `[ratings].star_*`).
     pub rating_stars: RatingStarGlyphs,
     /// Internet Radio (picker, Now Playing pane, station management).
     pub radio_enabled: bool,
@@ -1601,12 +1787,7 @@ impl Config {
             mpris_enabled: file_cfg.player.mpris,
             queue_loop: file_cfg.player.queue_loop,
             ratings_enabled: file_cfg.ratings.enabled,
-            rating_stars: RatingStarGlyphs {
-                filled: file_cfg.ratings.star_filled,
-                empty: file_cfg.ratings.star_empty,
-                bracket_open: file_cfg.ratings.bracket_open,
-                bracket_close: file_cfg.ratings.bracket_close,
-            },
+            rating_stars: resolve_rating_stars(&file_cfg.theme.icon, &file_cfg.ratings),
             radio_enabled,
             radio_fetch_station_icons,
             keybinds: file_cfg.keybinds,
@@ -1749,10 +1930,8 @@ max_bit_rate = 0   # 0 = unlimited; set e.g. 320 to cap streaming bitrate
 
 [ratings]
 # enabled = false     # show ratings in UI, enable Shift+1…5 keybinds, export MPRIS UserRating
-# star_filled = "⭑"   # glyph per filled star in [⭑⭑⭒⭒⭒] display
-# star_empty = "⭒"    # glyph per empty star (try "★" / "☆" for larger stars)
-# bracket_open = "["  # bracket before stars ("" = none)
-# bracket_close = "]" # bracket after stars ("" = none)
+# Glyphs moved to [theme.icon] (rating_filled / rating_empty / …).
+# Legacy still works: star_filled, star_empty, bracket_open, bracket_close.
 
 [keybinds]
 # Shift+letter: use "Shift+n" or "N" (same). Helps Ghostty/kitty vs. classic terminals.
@@ -1820,6 +1999,8 @@ max_bit_rate = 0   # 0 = unlimited; set e.g. 320 to cap streaming bitrate
 # border        = "#252525"   # inactive pane borders
 # border_active = "#3a3a3a"   # active pane borders
 # preset = "dynamic"          # static | dynamic (default) | terminal | os
+# Glyphs: [theme.icon] — see docs/sample-config.toml (transport, favorite, rating_*)
+# Outlines: [theme.border_lines] type = "ascii" | plain | rounded | …
 
 [ui]
 # album_art_backend = "kitty-apc"   # default: ratatui-image
@@ -2592,6 +2773,123 @@ bracket_close = ""
         assert_eq!(fc.ratings.star_empty, "☆");
         assert_eq!(fc.ratings.bracket_open, "");
         assert_eq!(fc.ratings.bracket_close, "");
+    }
+
+    #[test]
+    fn parses_theme_icon_section() {
+        let fc: FileConfig = toml::from_str(
+            r#"
+[theme.border_lines]
+type = "ascii"
+
+[theme.icon]
+playing = "||"
+paused = "( > )"
+stopped = ">"
+next_song = ">>"
+previous_song = "<<"
+mode_shuffle = "><"
+mode_loop = "o"
+favorite = "*"
+rating_filled = "+"
+rating_empty = "-"
+tab_separator = " | "
+"#,
+        )
+        .expect("toml");
+        assert_eq!(fc.theme.border_lines.style.as_deref(), Some("ascii"));
+        assert_eq!(fc.theme.icon.playing.as_deref(), Some("||"));
+        assert_eq!(fc.theme.icon.paused.as_deref(), Some("( > )"));
+        assert_eq!(fc.theme.icon.stopped.as_deref(), Some(">"));
+        assert_eq!(fc.theme.icon.next_song.as_deref(), Some(">>"));
+        assert_eq!(fc.theme.icon.previous_song.as_deref(), Some("<<"));
+        assert_eq!(fc.theme.icon.mode_shuffle.as_deref(), Some("><"));
+        assert_eq!(fc.theme.icon.mode_loop.as_deref(), Some("o"));
+        assert_eq!(fc.theme.icon.favorite.as_deref(), Some("*"));
+        assert_eq!(fc.theme.icon.rating_filled.as_deref(), Some("+"));
+        assert_eq!(fc.theme.icon.rating_empty.as_deref(), Some("-"));
+        assert_eq!(fc.theme.icon.tab_separator.as_deref(), Some(" | "));
+    }
+
+    #[test]
+    fn rating_glyphs_prefer_theme_icon_over_legacy_ratings() {
+        let fc: FileConfig = toml::from_str(
+            r#"
+[ratings]
+star_filled = "★"
+star_empty = "☆"
+
+[theme.icon]
+rating_filled = "*"
+rating_empty = "-"
+rating_bracket_open = "<"
+rating_bracket_close = ">"
+"#,
+        )
+        .expect("toml");
+        let stars = resolve_rating_stars(&fc.theme.icon, &fc.ratings);
+        assert_eq!(stars.filled, "*");
+        assert_eq!(stars.empty, "-");
+        assert_eq!(stars.bracket_open, "<");
+        assert_eq!(stars.bracket_close, ">");
+    }
+
+    #[test]
+    fn rating_glyphs_legacy_ratings_section_still_works() {
+        let fc: FileConfig = toml::from_str(
+            r#"
+[ratings]
+star_filled = "★"
+star_empty = "☆"
+bracket_open = ""
+bracket_close = ""
+"#,
+        )
+        .expect("toml");
+        let stars = resolve_rating_stars(&fc.theme.icon, &fc.ratings);
+        assert_eq!(stars.filled, "★");
+        assert_eq!(stars.empty, "☆");
+        assert_eq!(stars.bracket_open, "");
+        assert_eq!(stars.bracket_close, "");
+    }
+
+    #[test]
+    fn theme_border_prefers_border_lines_over_legacy() {
+        let fc: FileConfig = toml::from_str(
+            r#"
+[theme]
+border_type = "double"
+
+[theme.border_lines]
+type = "ascii"
+
+[theme.icon]
+border_type = "thick"
+"#,
+        )
+        .expect("toml");
+        assert_eq!(fc.theme.border_source().border_type, Some("ascii"));
+    }
+
+    #[test]
+    fn theme_border_legacy_flat_and_icon_keys_still_work() {
+        let flat: FileConfig = toml::from_str(
+            r#"
+[theme]
+border_type = "ascii"
+"#,
+        )
+        .expect("toml");
+        assert_eq!(flat.theme.border_source().border_type, Some("ascii"));
+
+        let icon: FileConfig = toml::from_str(
+            r#"
+[theme.icon]
+border_type = "ascii"
+"#,
+        )
+        .expect("toml");
+        assert_eq!(icon.theme.border_source().border_type, Some("ascii"));
     }
 
     #[test]

--- a/ratune/src/theme.rs
+++ b/ratune/src/theme.rs
@@ -10,8 +10,93 @@
 ///   background (terminal transparency / default bg).
 use image::Rgba;
 use ratatui::style::{Color, Style};
+use ratatui::symbols::border;
+use ratatui::widgets::BorderType;
 
-use crate::config::{ThemePreset, ThemeSection};
+use crate::config::{ThemeBorderSource, ThemeIconSection, ThemePreset, ThemeSection};
+
+/// ASCII-friendly box borders (`+`, `-`, `|`) for fonts without box-drawing glyphs.
+pub const ASCII_BORDER_SET: border::Set = border::Set {
+    top_left: "+",
+    top_right: "+",
+    bottom_left: "+",
+    bottom_right: "+",
+    vertical_left: "|",
+    vertical_right: "|",
+    horizontal_top: "-",
+    horizontal_bottom: "-",
+};
+
+/// Resolved UI glyphs from `[theme.icon]` (owned strings; defaults match prior hardcoding).
+#[derive(Debug, Clone)]
+pub struct ThemeIcons {
+    /// Shown while a track is playing.
+    pub playing: String,
+    /// Shown while paused.
+    pub paused: String,
+    /// Shown when nothing is loaded.
+    pub stopped: String,
+    pub next_song: String,
+    pub previous_song: String,
+    pub mode_shuffle: String,
+    pub mode_loop: String,
+    /// Favorite / starred marker (without trailing space).
+    pub favorite: String,
+    /// Full tab separator including spaces (e.g. `" │ "`).
+    pub tab_separator: String,
+    pub online: String,
+    pub offline: String,
+    /// Radio live indicator glyph (without the ` LIVE` suffix).
+    pub live: String,
+}
+
+impl Default for ThemeIcons {
+    fn default() -> Self {
+        Self {
+            playing: "( ⏸ )".into(),
+            paused: "( ▶ )".into(),
+            stopped: "▶".into(),
+            next_song: "⏭".into(),
+            previous_song: "⏮".into(),
+            mode_shuffle: "⇄".into(),
+            mode_loop: "↻".into(),
+            favorite: "★".into(),
+            tab_separator: " │ ".into(),
+            online: "●".into(),
+            offline: "○".into(),
+            live: "●".into(),
+        }
+    }
+}
+
+impl ThemeIcons {
+    pub fn from_section(sec: &ThemeIconSection) -> Self {
+        let d = Self::default();
+        Self {
+            playing: sec.playing.clone().unwrap_or(d.playing),
+            paused: sec.paused.clone().unwrap_or(d.paused),
+            stopped: sec.stopped.clone().unwrap_or(d.stopped),
+            next_song: sec.next_song.clone().unwrap_or(d.next_song),
+            previous_song: sec.previous_song.clone().unwrap_or(d.previous_song),
+            mode_shuffle: sec.mode_shuffle.clone().unwrap_or(d.mode_shuffle),
+            mode_loop: sec.mode_loop.clone().unwrap_or(d.mode_loop),
+            favorite: sec.favorite.clone().unwrap_or(d.favorite),
+            tab_separator: sec.tab_separator.clone().unwrap_or(d.tab_separator),
+            online: sec.online.clone().unwrap_or(d.online),
+            offline: sec.offline.clone().unwrap_or(d.offline),
+            live: sec.live.clone().unwrap_or(d.live),
+        }
+    }
+
+    /// `"★ "` when favorite is non-empty, else `""`.
+    pub fn favorite_prefix(&self) -> String {
+        if self.favorite.is_empty() {
+            String::new()
+        } else {
+            format!("{} ", self.favorite)
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Theme {
@@ -36,6 +121,11 @@ pub struct Theme {
     pub border_active: Color,
     /// Whether to use the dynamic accent extracted from album art.
     pub dynamic: bool,
+    /// Transport / chrome glyphs from `[theme.icon]`.
+    pub icons: ThemeIcons,
+    /// Pane box-drawing set from `[theme.border_lines]`
+    /// (legacy: flat `[theme].border_*` / `[theme.icon].border_*`).
+    pub border_set: border::Set,
 }
 
 impl Theme {
@@ -68,6 +158,8 @@ impl Theme {
                     border: Color::Indexed(8),
                     border_active: Color::Indexed(4),
                     dynamic: false,
+                    icons: ThemeIcons::default(),
+                    border_set: BorderType::Plain.to_border_set(),
                 }
             }
             ThemePreset::Static => {
@@ -84,6 +176,8 @@ impl Theme {
                     border: Color::Rgb(37, 37, 37),
                     border_active: Color::Rgb(58, 58, 58),
                     dynamic: false,
+                    icons: ThemeIcons::default(),
+                    border_set: BorderType::Plain.to_border_set(),
                 }
             }
             ThemePreset::Dynamic => {
@@ -100,9 +194,14 @@ impl Theme {
                     border: Color::Rgb(37, 37, 37),
                     border_active: Color::Rgb(58, 58, 58),
                     dynamic: true,
+                    icons: ThemeIcons::default(),
+                    border_set: BorderType::Plain.to_border_set(),
                 }
             }
         };
+
+        theme.icons = ThemeIcons::from_section(&sec.icon);
+        theme.border_set = resolve_border_set(&sec.border_source());
 
         let chrome_default = theme.background;
 
@@ -132,6 +231,62 @@ impl Theme {
         } else {
             self.accent
         }
+    }
+}
+
+fn border_type_preset(name: &str) -> Option<border::Set> {
+    match name.trim().to_ascii_lowercase().as_str() {
+        "plain" | "normal" | "single" => Some(BorderType::Plain.to_border_set()),
+        "rounded" | "round" => Some(BorderType::Rounded.to_border_set()),
+        "double" => Some(BorderType::Double.to_border_set()),
+        "thick" | "bold" => Some(BorderType::Thick.to_border_set()),
+        "ascii" | "plus" => Some(ASCII_BORDER_SET),
+        _ => None,
+    }
+}
+
+fn leak_glyph(s: &str) -> &'static str {
+    Box::leak(s.to_owned().into_boxed_str())
+}
+
+fn resolve_border_set(sec: &ThemeBorderSource<'_>) -> border::Set {
+    let base = sec
+        .border_type
+        .and_then(border_type_preset)
+        .unwrap_or_else(|| BorderType::Plain.to_border_set());
+
+    let has_override = sec.top_left.is_some()
+        || sec.top_right.is_some()
+        || sec.bottom_left.is_some()
+        || sec.bottom_right.is_some()
+        || sec.vertical.is_some()
+        || sec.horizontal.is_some();
+
+    if !has_override {
+        return base;
+    }
+
+    let vert = sec.vertical.map(leak_glyph).unwrap_or(base.vertical_left);
+    let horiz = sec
+        .horizontal
+        .map(leak_glyph)
+        .unwrap_or(base.horizontal_top);
+
+    border::Set {
+        top_left: sec.top_left.map(leak_glyph).unwrap_or(base.top_left),
+        top_right: sec.top_right.map(leak_glyph).unwrap_or(base.top_right),
+        bottom_left: sec.bottom_left.map(leak_glyph).unwrap_or(base.bottom_left),
+        bottom_right: sec
+            .bottom_right
+            .map(leak_glyph)
+            .unwrap_or(base.bottom_right),
+        vertical_left: vert,
+        vertical_right: sec.vertical.map(leak_glyph).unwrap_or(base.vertical_right),
+        horizontal_top: horiz,
+        horizontal_bottom: sec
+            .horizontal
+            .map(leak_glyph)
+            .unwrap_or(base.horizontal_bottom),
     }
 }
 
@@ -294,6 +449,90 @@ mod tests {
         assert_eq!(t.background, Color::Rgb(0, 0, 0));
         assert_eq!(t.tab_bar, Color::Reset);
         assert_eq!(t.status_bar, Color::Rgb(0x11, 0x11, 0x11));
+    }
+
+    #[test]
+    fn theme_icons_from_section_override() {
+        let sec = crate::config::ThemeSection {
+            icon: crate::config::ThemeIconSection {
+                playing: Some("||".into()),
+                paused: Some("( > )".into()),
+                stopped: Some(">".into()),
+                next_song: Some(">>".into()),
+                previous_song: Some("<<".into()),
+                mode_shuffle: Some("><".into()),
+                mode_loop: Some("o".into()),
+                favorite: Some("*".into()),
+                tab_separator: Some(" | ".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let t = Theme::from_section(&sec);
+        assert_eq!(t.icons.playing, "||");
+        assert_eq!(t.icons.paused, "( > )");
+        assert_eq!(t.icons.stopped, ">");
+        assert_eq!(t.icons.next_song, ">>");
+        assert_eq!(t.icons.previous_song, "<<");
+        assert_eq!(t.icons.mode_shuffle, "><");
+        assert_eq!(t.icons.mode_loop, "o");
+        assert_eq!(t.icons.favorite, "*");
+        assert_eq!(t.icons.tab_separator, " | ");
+        assert_eq!(t.icons.favorite_prefix(), "* ");
+    }
+
+    #[test]
+    fn theme_border_type_on_theme_section() {
+        let sec = crate::config::ThemeSection {
+            border_lines: crate::config::ThemeBorderLinesSection {
+                style: Some("ascii".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let t = Theme::from_section(&sec);
+        assert_eq!(t.border_set, ASCII_BORDER_SET);
+    }
+
+    #[test]
+    fn theme_border_type_legacy_flat_theme_fallback() {
+        let sec = crate::config::ThemeSection {
+            border_type: Some("ascii".into()),
+            ..Default::default()
+        };
+        let t = Theme::from_section(&sec);
+        assert_eq!(t.border_set, ASCII_BORDER_SET);
+    }
+
+    #[test]
+    fn theme_border_type_legacy_icon_fallback() {
+        let sec = crate::config::ThemeSection {
+            icon: crate::config::ThemeIconSection {
+                border_type: Some("ascii".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let t = Theme::from_section(&sec);
+        assert_eq!(t.border_set, ASCII_BORDER_SET);
+    }
+
+    #[test]
+    fn theme_border_lines_prefers_over_legacy() {
+        let sec = crate::config::ThemeSection {
+            border_lines: crate::config::ThemeBorderLinesSection {
+                style: Some("ascii".into()),
+                ..Default::default()
+            },
+            border_type: Some("double".into()),
+            icon: crate::config::ThemeIconSection {
+                border_type: Some("thick".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let t = Theme::from_section(&sec);
+        assert_eq!(t.border_set, ASCII_BORDER_SET);
     }
 
     #[test]

--- a/ratune/src/ui/albums.rs
+++ b/ratune/src/ui/albums.rs
@@ -1,6 +1,6 @@
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 use ratatui::Frame;
 
 use crate::app::{App, BrowserColumn};
@@ -28,7 +28,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(border_style)
         .style(style_with_bg(t.surface));
 
@@ -58,7 +58,11 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         }
         Some(LoadingState::Loaded(albums)) => {
             let make_label = |a: &Album| {
-                let star = if a.starred.is_some() { "★ " } else { "" };
+                let star = if a.starred.is_some() {
+                    app.theme.icons.favorite_prefix()
+                } else {
+                    String::new()
+                };
                 let rating_suffix = if app.config.ratings_enabled {
                     let rating = app.config.rating_stars.format(a.user_rating);
                     if rating.is_empty() {

--- a/ratune/src/ui/artists.rs
+++ b/ratune/src/ui/artists.rs
@@ -1,6 +1,6 @@
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 use ratatui::Frame;
 
 use crate::app::{App, BrowserColumn};
@@ -28,7 +28,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(border_style)
         .style(style_with_bg(t.surface));
 
@@ -73,7 +73,11 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                     .iter()
                     .map(|(i, _)| {
                         let a = &artists[*i];
-                        let star = if a.starred.is_some() { "★ " } else { "" };
+                        let star = if a.starred.is_some() {
+                            app.theme.icons.favorite_prefix()
+                        } else {
+                            String::new()
+                        };
                         let rating_suffix = if app.config.ratings_enabled {
                             let rating = app.config.rating_stars.format(a.user_rating);
                             if rating.is_empty() {

--- a/ratune/src/ui/favorites_overlay.rs
+++ b/ratune/src/ui/favorites_overlay.rs
@@ -2,7 +2,7 @@
 
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem};
 use ratatui::Frame;
 
 use crate::state::{FavoritesCategory, FavoritesFocus, FavoritesOverlay};
@@ -122,7 +122,7 @@ fn render_categories(
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(theme.border_set)
         .border_style(list_border)
         .style(style_with_bg(theme.background));
 
@@ -135,7 +135,12 @@ fn render_categories(
         .iter()
         .enumerate()
         .map(|(i, cat)| {
-            let label = format!("★ {} ({})", cat.label(), counts[i]);
+            let label = format!(
+                "{}{} ({})",
+                theme.icons.favorite_prefix(),
+                cat.label(),
+                counts[i]
+            );
             ListItem::new(label).style(Style::default().fg(theme.foreground))
         })
         .collect();
@@ -191,7 +196,7 @@ fn render_items(
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(theme.border_set)
         .border_style(list_border)
         .style(style_with_bg(theme.background));
 

--- a/ratune/src/ui/folder_tracks.rs
+++ b/ratune/src/ui/folder_tracks.rs
@@ -1,6 +1,6 @@
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 use ratatui::Frame;
 
 use crate::app::{App, BrowserColumn};
@@ -44,7 +44,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(border_style)
         .style(style_with_bg(t.surface));
 
@@ -81,7 +81,11 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         }
         Some(LoadingState::Loaded(listing)) => {
             let make_track_label = |s: &ratune_subsonic::Song| {
-                let star = if s.starred.is_some() { "★ " } else { "" };
+                let star = if s.starred.is_some() {
+                    app.theme.icons.favorite_prefix()
+                } else {
+                    String::new()
+                };
                 let rating_suffix = if app.config.ratings_enabled {
                     let rating = app.config.rating_stars.format(s.user_rating);
                     if rating.is_empty() {

--- a/ratune/src/ui/folders.rs
+++ b/ratune/src/ui/folders.rs
@@ -1,6 +1,6 @@
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 use ratatui::Frame;
 
 use crate::app::{App, BrowserColumn};
@@ -42,7 +42,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(border_style)
         .style(style_with_bg(t.surface));
 

--- a/ratune/src/ui/home_tab.rs
+++ b/ratune/src/ui/home_tab.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Frame;
 use ratatui_image::picker::ProtocolType;
 use ratatui_image::StatefulImage;
@@ -56,7 +56,7 @@ fn titled_block<'a>(title: &'a str, is_active: bool, accent: Color, theme: &Them
     Block::default()
         .style(style_with_bg(theme.surface))
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(theme.border_set)
         .border_style(border_style)
         .title(Span::styled(title, title_style))
 }

--- a/ratune/src/ui/kitty_art.rs
+++ b/ratune/src/ui/kitty_art.rs
@@ -12,7 +12,8 @@ use std::io::{self, Write};
 use anyhow::Result;
 use image::Rgba;
 use ratatui::layout::Rect;
-use ratatui::widgets::{Block, BorderType, Borders};
+use ratatui::symbols::border;
+use ratatui::widgets::{Block, Borders};
 
 // ── Detection ──────────────────────────────────────────────────────────────────
 
@@ -432,15 +433,18 @@ fn placeholder_row(cols: u16, image_id: u32, row_index: usize) -> String {
 // ── Rendering ─────────────────────────────────────────────────────────────────
 
 /// Bordered shell for the Now Playing art column (no title — set at render time).
-pub fn album_art_block() -> Block<'static> {
+pub fn album_art_block(border_set: border::Set) -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(border_set)
 }
 
 /// Content rectangle inside the album-art bordered box (matches ratatui’s [`Block::inner`]).
 pub fn album_art_placeholder_inner(outer: Rect) -> Rect {
-    album_art_block().title(" Album Art ").inner(outer)
+    // Border thickness is always one cell for every supported set; glyphs don't change layout.
+    album_art_block(border::PLAIN)
+        .title(" Album Art ")
+        .inner(outer)
 }
 
 /// Cached resize + zlib for Now Playing Kitty APC (image id 1).

--- a/ratune/src/ui/now_playing.rs
+++ b/ratune/src/ui/now_playing.rs
@@ -1,14 +1,14 @@
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Frame;
 
 use super::now_playing_format::{format_now_playing_line, NowPlayingContext};
 
 use crate::action::Action;
 use crate::app::{App, Tab};
-use crate::theme::style_with_bg;
+use crate::theme::{style_with_bg, ThemeIcons};
 
 /// Spacing between transport glyphs in the controls row (must match `render_controls_widget`).
 const CONTROLS_GAP: &str = "      ";
@@ -47,7 +47,7 @@ fn slot_for_span_index(i: usize) -> Option<ControlSlot> {
 }
 
 /// Layout derived from the same `Line` ratatui renders (width + per-span columns).
-fn control_segments(ctx: ControlsClickCtx) -> (u16, Vec<ControlSegment>) {
+fn control_segments(ctx: &ControlsClickCtx) -> (u16, Vec<ControlSegment>) {
     let line = controls_line_plain(ctx);
     let total = line.width() as u16;
     let mut pos = 0u16;
@@ -66,22 +66,22 @@ fn control_segments(ctx: ControlsClickCtx) -> (u16, Vec<ControlSegment>) {
     (total, segments)
 }
 
-fn controls_line_plain(ctx: ControlsClickCtx) -> Line<'static> {
-    let play_label = play_label_for(ctx);
+fn controls_line_plain(ctx: &ControlsClickCtx) -> Line<'static> {
+    let play_label = play_label_for(ctx).to_owned();
     Line::from(vec![
-        Span::raw("⇄"),
+        Span::raw(ctx.icons.mode_shuffle.clone()),
         Span::raw(CONTROLS_GAP),
-        Span::raw("⏮"),
+        Span::raw(ctx.icons.previous_song.clone()),
         Span::raw(CONTROLS_GAP),
         Span::raw(play_label),
         Span::raw(CONTROLS_GAP),
-        Span::raw("⏭"),
+        Span::raw(ctx.icons.next_song.clone()),
         Span::raw(CONTROLS_GAP),
-        Span::raw("↻"),
+        Span::raw(ctx.icons.mode_loop.clone()),
     ])
 }
 
-fn action_for_slot(slot: ControlSlot, ctx: ControlsClickCtx) -> Action {
+fn action_for_slot(slot: ControlSlot, ctx: &ControlsClickCtx) -> Action {
     match slot {
         ControlSlot::Shuffle => {
             if ctx.shuffled {
@@ -98,11 +98,12 @@ fn action_for_slot(slot: ControlSlot, ctx: ControlsClickCtx) -> Action {
 }
 
 /// Context for control-line layout / hit-testing without a full `App`.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ControlsClickCtx {
     pub has_current_song: bool,
     pub paused: bool,
     pub shuffled: bool,
+    pub icons: ThemeIcons,
 }
 
 impl ControlsClickCtx {
@@ -111,23 +112,24 @@ impl ControlsClickCtx {
             has_current_song: app.playback.current_song.is_some(),
             paused: app.playback.paused,
             shuffled: app.queue.is_shuffled(),
+            icons: app.theme.icons.clone(),
         }
     }
 }
 
-fn play_label_for(ctx: ControlsClickCtx) -> &'static str {
+fn play_label_for(ctx: &ControlsClickCtx) -> &str {
     if !ctx.has_current_song {
-        "▶"
+        &ctx.icons.stopped
     } else if ctx.paused {
-        "( ▶ )"
+        &ctx.icons.paused
     } else {
-        "( ⏸ )"
+        &ctx.icons.playing
     }
 }
 
 /// Total display width of the centered controls line (used by click tests).
 #[cfg(test)]
-fn controls_line_width(ctx: ControlsClickCtx) -> u16 {
+fn controls_line_width(ctx: &ControlsClickCtx) -> u16 {
     controls_line_plain(ctx).width() as u16
 }
 
@@ -139,11 +141,11 @@ pub fn controls_row_rect(area: Rect) -> Rect {
 
 /// Map a terminal column inside `controls_area` to a transport action, if any.
 pub fn controls_click_action(app: &App, controls_area: Rect, x: u16) -> Option<Action> {
-    controls_click_action_for(ControlsClickCtx::from_app(app), controls_area, x)
+    controls_click_action_for(&ControlsClickCtx::from_app(app), controls_area, x)
 }
 
 pub fn controls_click_action_for(
-    ctx: ControlsClickCtx,
+    ctx: &ControlsClickCtx,
     controls_area: Rect,
     x: u16,
 ) -> Option<Action> {
@@ -239,7 +241,7 @@ pub fn interaction_rects_pane(app: &App, pane: Rect) -> NowPlayingChromeRects {
         .title(" Now Playing ")
         .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(Style::default().fg(accent))
         .style(style_with_bg(t.surface));
 
@@ -393,7 +395,7 @@ pub fn render_boxed_pane(app: &App, frame: &mut Frame, pane: Rect) {
         .title(" Now Playing ")
         .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(Style::default().fg(accent))
         .style(style_with_bg(t.surface));
 
@@ -696,17 +698,17 @@ fn render_controls_widget(app: &App, frame: &mut Frame, area: Rect) {
     let t = &app.theme;
     let ctx = ControlsClickCtx::from_app(app);
     let (play_label, play_style) = if !ctx.has_current_song {
-        ("▶", Style::default().fg(t.dimmed))
+        (ctx.icons.stopped.as_str(), Style::default().fg(t.dimmed))
     } else if ctx.paused {
         (
-            "( ▶ )",
+            ctx.icons.paused.as_str(),
             Style::default()
                 .fg(app.accent())
                 .add_modifier(Modifier::BOLD),
         )
     } else {
         (
-            "( ⏸ )",
+            ctx.icons.playing.as_str(),
             Style::default()
                 .fg(app.accent())
                 .add_modifier(Modifier::BOLD),
@@ -725,15 +727,15 @@ fn render_controls_widget(app: &App, frame: &mut Frame, area: Rect) {
     };
 
     let controls = Line::from(vec![
-        Span::styled("⇄", shuffle_style),
+        Span::styled(ctx.icons.mode_shuffle.clone(), shuffle_style),
         Span::raw(CONTROLS_GAP),
-        Span::styled("⏮", inactive),
+        Span::styled(ctx.icons.previous_song.clone(), inactive),
         Span::raw(CONTROLS_GAP),
-        Span::styled(play_label, play_style),
+        Span::styled(play_label.to_owned(), play_style),
         Span::raw(CONTROLS_GAP),
-        Span::styled("⏭", inactive),
+        Span::styled(ctx.icons.next_song.clone(), inactive),
         Span::raw(CONTROLS_GAP),
-        Span::styled("↻", loop_style),
+        Span::styled(ctx.icons.mode_loop.clone(), loop_style),
     ]);
 
     if area.height <= 1 {
@@ -902,7 +904,7 @@ fn render_progress_widget(app: &App, frame: &mut Frame, area: Rect) {
             area,
             t,
             accent_color,
-            "● LIVE",
+            &format!("{} LIVE", app.theme.icons.live),
             elapsed_str,
             true,
         );
@@ -1029,6 +1031,7 @@ mod controls_click_tests {
         controls_line_width, controls_row_rect, segment_center, ControlSlot, ControlsClickCtx,
     };
     use crate::action::Action;
+    use crate::theme::ThemeIcons;
     use ratatui::layout::Rect;
 
     fn playing() -> ControlsClickCtx {
@@ -1036,6 +1039,7 @@ mod controls_click_tests {
             has_current_song: true,
             paused: false,
             shuffled: false,
+            icons: ThemeIcons::default(),
         }
     }
 
@@ -1044,14 +1048,15 @@ mod controls_click_tests {
             has_current_song: true,
             paused: false,
             shuffled: true,
+            icons: ThemeIcons::default(),
         }
     }
 
-    fn line_start(area: Rect, ctx: ControlsClickCtx) -> u16 {
+    fn line_start(area: Rect, ctx: &ControlsClickCtx) -> u16 {
         centered_line_x(area.x, area.width, controls_line_width(ctx))
     }
 
-    fn click_at_slot(ctx: ControlsClickCtx, area: Rect, slot: ControlSlot) -> Option<Action> {
+    fn click_at_slot(ctx: &ControlsClickCtx, area: Rect, slot: ControlSlot) -> Option<Action> {
         let (_, segments) = control_segments(ctx);
         let x = line_start(area, ctx) + segment_center(&segments, slot);
         controls_click_action_for(ctx, area, x)
@@ -1063,11 +1068,12 @@ mod controls_click_tests {
             has_current_song: false,
             paused: false,
             shuffled: false,
+            icons: ThemeIcons::default(),
         };
-        let total = controls_line_width(ctx);
+        let total = controls_line_width(&ctx);
         let area = Rect::new(5, 0, 40, 1);
         let legacy = area.x + (area.width.saturating_sub(total)) / 2;
-        let aligned = line_start(area, ctx);
+        let aligned = line_start(area, &ctx);
         assert_eq!(aligned, area.x + (area.width / 2).saturating_sub(total / 2));
         assert_ne!(
             legacy, aligned,
@@ -1081,12 +1087,13 @@ mod controls_click_tests {
             has_current_song: false,
             paused: false,
             shuffled: false,
+            icons: ThemeIcons::default(),
         };
         assert_eq!(
-            controls_line_width(idle),
-            controls_line_plain(idle).width() as u16
+            controls_line_width(&idle),
+            controls_line_plain(&idle).width() as u16
         );
-        assert!(controls_line_width(playing()) >= controls_line_width(idle));
+        assert!(controls_line_width(&playing()) >= controls_line_width(&idle));
     }
 
     #[test]
@@ -1109,23 +1116,23 @@ mod controls_click_tests {
         let ctx = playing();
 
         assert!(matches!(
-            click_at_slot(ctx, area, ControlSlot::Shuffle),
+            click_at_slot(&ctx, area, ControlSlot::Shuffle),
             Some(Action::Shuffle)
         ));
         assert!(matches!(
-            click_at_slot(ctx, area, ControlSlot::Prev),
+            click_at_slot(&ctx, area, ControlSlot::Prev),
             Some(Action::PrevTrack)
         ));
         assert!(matches!(
-            click_at_slot(ctx, area, ControlSlot::PlayPause),
+            click_at_slot(&ctx, area, ControlSlot::PlayPause),
             Some(Action::PlayPause)
         ));
         assert!(matches!(
-            click_at_slot(ctx, area, ControlSlot::Next),
+            click_at_slot(&ctx, area, ControlSlot::Next),
             Some(Action::NextTrack)
         ));
         assert!(matches!(
-            click_at_slot(ctx, area, ControlSlot::Loop),
+            click_at_slot(&ctx, area, ControlSlot::Loop),
             Some(Action::ToggleQueueLoop)
         ));
     }
@@ -1135,7 +1142,7 @@ mod controls_click_tests {
         let area = Rect::new(0, 0, 80, 1);
         let ctx = shuffled();
         assert!(matches!(
-            click_at_slot(ctx, area, ControlSlot::Shuffle),
+            click_at_slot(&ctx, area, ControlSlot::Shuffle),
             Some(Action::Unshuffle)
         ));
     }
@@ -1144,18 +1151,18 @@ mod controls_click_tests {
     fn clicks_outside_centered_strip_are_ignored() {
         let area = Rect::new(0, 0, 80, 1);
         let ctx = playing();
-        assert!(controls_click_action_for(ctx, area, 0).is_none());
-        assert!(controls_click_action_for(ctx, area, 79).is_none());
+        assert!(controls_click_action_for(&ctx, area, 0).is_none());
+        assert!(controls_click_action_for(&ctx, area, 79).is_none());
     }
 
     #[test]
     fn gap_clicks_do_not_hit_buttons() {
         let area = Rect::new(0, 0, 80, 1);
         let ctx = playing();
-        let (total, segments) = control_segments(ctx);
-        let base = line_start(area, ctx);
+        let (total, segments) = control_segments(&ctx);
+        let base = line_start(area, &ctx);
         let gap_x = base + segments[0].start + segments[0].width + 3;
         assert!(gap_x < base + total);
-        assert!(controls_click_action_for(ctx, area, gap_x).is_none());
+        assert!(controls_click_action_for(&ctx, area, gap_x).is_none());
     }
 }

--- a/ratune/src/ui/nowplaying_tab.rs
+++ b/ratune/src/ui/nowplaying_tab.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Frame;
 use ratatui_image::thread::ThreadProtocol;
 use ratatui_image::StatefulImage;
@@ -157,7 +157,7 @@ fn render_art_placeholder(app: &mut App, frame: &mut Frame, area: Rect) {
         .filter(|s| App::is_radio_song(s))
         .map(|s| format!(" {} ", s.title))
         .unwrap_or_else(|| " Album Art ".to_string());
-    let block = crate::ui::kitty_art::album_art_block()
+    let block = crate::ui::kitty_art::album_art_block(t.border_set)
         .title(art_title)
         .title_style(Style::default().fg(t.dimmed).add_modifier(Modifier::BOLD))
         .border_style(Style::default().fg(t.border));
@@ -193,7 +193,7 @@ fn render_visualizer_pane(app: &App, frame: &mut Frame, area: Rect) {
         .title(" Visualizer ")
         .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(Style::default().fg(accent))
         .style(style_with_bg(t.surface));
 
@@ -228,7 +228,7 @@ fn render_lyrics_pane(app: &App, frame: &mut Frame, area: Rect) {
         .title(" Lyrics ")
         .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(Style::default().fg(accent))
         .style(style_with_bg(t.surface));
 

--- a/ratune/src/ui/playlist_overlay.rs
+++ b/ratune/src/ui/playlist_overlay.rs
@@ -7,7 +7,7 @@
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style}; // Modifier used by highlight_style
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
 use ratatui::Frame;
 
 use crate::app::PlaylistPicker;
@@ -170,7 +170,7 @@ fn render_playlist_list(
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(theme.border_set)
         .border_style(list_border)
         .style(style_with_bg(theme.background));
 
@@ -247,7 +247,7 @@ fn render_playlist_list(
             .title(label)
             .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
             .borders(Borders::ALL)
-            .border_type(BorderType::Plain)
+            .border_set(theme.border_set)
             .border_style(Style::default().fg(accent))
             .style(style_with_bg(theme.background));
         let input_line = Line::from(vec![
@@ -295,7 +295,7 @@ fn render_track_list(
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(theme.border_set)
         .border_style(list_border)
         .style(style_with_bg(theme.background));
 
@@ -382,7 +382,7 @@ fn render_confirm_dialog(
     frame.render_widget(Clear, dialog_area);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(theme.border_set)
         .border_style(Style::default().fg(accent))
         .style(style_with_bg(theme.background));
     let para = Paragraph::new(Line::from(Span::styled(
@@ -431,7 +431,7 @@ pub fn render_playlist_picker(
         .title(" Add to playlist  Enter: add  Esc: cancel ")
         .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(theme.border_set)
         .border_style(Style::default().fg(accent))
         .style(style_with_bg(theme.background));
 

--- a/ratune/src/ui/popup.rs
+++ b/ratune/src/ui/popup.rs
@@ -322,6 +322,7 @@ pub fn render_help(app: &mut App, frame: &mut Frame) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(app.theme.border_set)
         .border_style(Style::default().fg(accent))
         .title_top(
             Line::from(Span::styled(" Keybinds ", Style::default().fg(accent))).left_aligned(),

--- a/ratune/src/ui/queue.rs
+++ b/ratune/src/ui/queue.rs
@@ -1,6 +1,6 @@
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 use ratatui::Frame;
 
 use crate::app::App;
@@ -34,7 +34,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(Style::default().fg(border_color))
         .style(style_with_bg(t.surface));
 
@@ -72,6 +72,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
     let total = app.queue.songs.len();
     let start = app.queue.scroll.min(total.saturating_sub(1));
     let end = (start + visible).min(total);
+    let favorite_prefix = app.theme.icons.favorite_prefix();
     let items: Vec<ListItem> = app.queue.songs[start..end]
         .iter()
         .enumerate()
@@ -82,6 +83,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                 s,
                 app.config.ratings_enabled,
                 &app.config.rating_stars,
+                &favorite_prefix,
             );
 
             let style = if idx == app.queue.cursor {
@@ -116,12 +118,13 @@ fn format_queue_line(
     s: &ratune_subsonic::Song,
     ratings_enabled: bool,
     stars: &crate::config::RatingStarGlyphs,
+    favorite_prefix: &str,
 ) -> String {
     let num = s.track.map(|n| format!("{n:>2}. ")).unwrap_or_default();
     let title = {
         let mut t = String::new();
         if s.starred.is_some() {
-            t.push_str("★ ");
+            t.push_str(favorite_prefix);
         }
         t.push_str(&s.title);
         t
@@ -140,7 +143,7 @@ fn format_queue_line(
         "album" => Some(album.to_string()),
         "duration" => Some(duration.clone()),
         "favorite" => Some(if s.starred.is_some() {
-            "★ ".to_string()
+            favorite_prefix.to_string()
         } else {
             String::new()
         }),

--- a/ratune/src/ui/radio_nowplaying.rs
+++ b/ratune/src/ui/radio_nowplaying.rs
@@ -3,7 +3,7 @@
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 use ratatui::Frame;
 
 use crate::app::App;
@@ -31,7 +31,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(Style::default().fg(border_color))
         .style(style_with_bg(t.surface));
 

--- a/ratune/src/ui/radio_popup.rs
+++ b/ratune/src/ui/radio_popup.rs
@@ -36,7 +36,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
         .title(" Internet Radio ")
         .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
         .style(style_with_bg(t.surface));
 

--- a/ratune/src/ui/status_bar.rs
+++ b/ratune/src/ui/status_bar.rs
@@ -168,7 +168,13 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
             right_w += sep.len() + scrobble_w;
         }
 
-        let host_w = 2 + host_label.len();
+        let conn_icon = if app.server_reachable {
+            t.icons.online.as_str()
+        } else {
+            t.icons.offline.as_str()
+        };
+        let conn_label = format!("{conn_icon} ");
+        let host_w = conn_label.chars().count() + host_label.chars().count();
         let gap = (area.width as usize).saturating_sub(host_w + right_w);
 
         let conn_style = if app.server_reachable {
@@ -177,7 +183,7 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
             Style::default().fg(t.dimmed)
         };
         let mut spans = vec![
-            Span::styled(if app.server_reachable { "● " } else { "○ " }, conn_style),
+            Span::styled(conn_label, conn_style),
             Span::styled(host_label, Style::default().fg(t.dimmed)),
             Span::raw(" ".repeat(gap)),
         ];

--- a/ratune/src/ui/tab_bar.rs
+++ b/ratune/src/ui/tab_bar.rs
@@ -13,9 +13,12 @@ use crate::theme::{style_with_bg, Theme};
 ///
 /// Active tab: `accent` background, `Color::Black` foreground, bold.
 /// Inactive tabs: `theme.dimmed` foreground on `theme.tab_bar`.
-/// Separator: ` │ ` in `theme.dimmed`.
+/// Separator: `theme.icons.tab_separator` (default ` │ `) in `theme.dimmed`.
 pub fn render_tab_bar(f: &mut Frame, area: Rect, active_tab: Tab, accent: Color, theme: &Theme) {
-    let separator = Span::styled(" │ ", Style::default().fg(theme.dimmed));
+    let separator = Span::styled(
+        theme.icons.tab_separator.clone(),
+        Style::default().fg(theme.dimmed),
+    );
 
     let label_home = " Home ";
     let label_browser = " Browse ";

--- a/ratune/src/ui/tracks.rs
+++ b/ratune/src/ui/tracks.rs
@@ -1,6 +1,6 @@
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, ListState};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 use ratatui::Frame;
 
 use crate::app::{App, BrowserColumn};
@@ -33,7 +33,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
+        .border_set(t.border_set)
         .border_style(border_style)
         .style(style_with_bg(t.surface));
 
@@ -64,7 +64,11 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, is_active: bool) {
         Some(LoadingState::Loaded(songs)) => {
             let make_label = |s: &ratune_subsonic::Song| {
                 let num = s.track.map(|n| format!("{n:>2}. ")).unwrap_or_default();
-                let star = if s.starred.is_some() { "★ " } else { "" };
+                let star = if s.starred.is_some() {
+                    app.theme.icons.favorite_prefix()
+                } else {
+                    String::new()
+                };
                 let rating_suffix = if app.config.ratings_enabled {
                     let rating = app.config.rating_stars.format(s.user_rating);
                     if rating.is_empty() {


### PR DESCRIPTION
Enables all icons and borders to be configurable. Sometimes default icons cause issues (see #54).

Added some bonus border options while I was in there (see `sample-config.toml` for more detail)

Example config to make everything ascii (example also available in `sample-config.toml`):

```toml
[theme.border_lines]
type = "ascii"
# top_left = "+"
# top_right = "+"
# bottom_left = "+"
# bottom_right = "+"
# vertical = "|"
# horizontal = "-"

[theme.icon]
playing = "( || )"
paused = "( > )"
stopped = ">"
next_song = ">>"
previous_song = "<<"
mode_shuffle = "><"
mode_loop = "o"
favorite = "*"
rating_filled = "*"
rating_empty = "-"
rating_bracket_open = "["
rating_bracket_close = "]"
tab_separator = " | "
online = "*"
offline = "o"
live = "*"
```

Produces a result that looks like this:
<img width="2518" height="1347" alt="screenshot_2026-07-25_15-40-18" src="https://github.com/user-attachments/assets/04a5033c-d6fa-4957-968a-eeda307db945" />
