### PR TITLE
fix: fill navigation gaps in a few locations

### DIFF
--- a/ratune/src/action.rs
+++ b/ratune/src/action.rs
@@ -80,10 +80,8 @@ pub enum Action {
     RateSong(u8),
     /// Toggle the favorites (starred) browser overlay.
     ToggleFavoritesOverlay,
-    /// Favorites overlay: scroll up.
-    FavoritesScrollUp,
-    /// Favorites overlay: scroll down.
-    FavoritesScrollDown,
+    /// Favorites overlay: move selection (j/k, PageUp/Down, gg/G).
+    FavoritesNavigate(Direction),
     /// Favorites overlay: focus category list.
     FavoritesFocusCategories,
     /// Favorites overlay: focus items list.
@@ -135,10 +133,8 @@ pub enum Action {
     HomeAlbumAddToQueue,
     /// Toggle the playlist browser overlay.
     TogglePlaylistOverlay,
-    /// Scroll up within the playlist overlay (list or tracks pane).
-    PlaylistScrollUp,
-    /// Scroll down within the playlist overlay (list or tracks pane).
-    PlaylistScrollDown,
+    /// Move selection within the playlist overlay (list or tracks pane).
+    PlaylistNavigate(Direction),
     /// Move focus to the tracks pane of the playlist overlay.
     PlaylistFocusTracks,
     /// Move focus back to the playlist list pane of the overlay.
@@ -165,10 +161,8 @@ pub enum Action {
     PlaylistPickerSelect,
     /// Cancel and close the playlist picker.
     PlaylistPickerCancel,
-    /// Scroll up in the playlist picker.
-    PlaylistPickerScrollUp,
-    /// Scroll down in the playlist picker.
-    PlaylistPickerScrollDown,
+    /// Move selection in the playlist picker.
+    PlaylistPickerNavigate(Direction),
     /// Confirm the current text-input field (create / rename).
     PlaylistInputConfirm,
     /// Cancel the current text-input field.

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -36,6 +36,23 @@ use ratune_subsonic::LyricLine;
 
 // ── Sizing helper (used in dispatch for scroll clamping) ──────────────────────
 
+/// Move a list selection index by one row, one page, or to top/bottom.
+fn move_list_index(cur: usize, len: usize, page: usize, dir: Direction) -> usize {
+    if len == 0 {
+        return 0;
+    }
+    let max = len - 1;
+    let page = page.max(1);
+    match dir {
+        Direction::Up => cur.saturating_sub(1),
+        Direction::Down => (cur + 1).min(max),
+        Direction::Top => 0,
+        Direction::Bottom => max,
+        Direction::PageUp => cur.saturating_sub(page),
+        Direction::PageDown => (cur + page).min(max),
+    }
+}
+
 /// Map raw engine/network errors to a short status-bar line (no multiline chains).
 fn humanize_playback_error(message: &str) -> String {
     let raw = message
@@ -476,6 +493,8 @@ pub struct PlaylistPicker {
     /// `true` while a `getPlaylists` fetch is in flight.
     pub loading: bool,
     pub scroll: usize,
+    /// Visible rows in the picker list (excluding borders); updated on render.
+    pub viewport_rows: usize,
 }
 
 // ── App ───────────────────────────────────────────────────────────────────────
@@ -5635,8 +5654,7 @@ impl App {
                 }
             }
             Action::TogglePlaylistOverlay
-            | Action::PlaylistScrollUp
-            | Action::PlaylistScrollDown
+            | Action::PlaylistNavigate(_)
             | Action::PlaylistFocusTracks
             | Action::PlaylistFocusList
             | Action::PlaylistPlayAll
@@ -5652,8 +5670,7 @@ impl App {
             | Action::BrowserAddToPlaylist
             | Action::PlaylistPickerSelect
             | Action::PlaylistPickerCancel
-            | Action::PlaylistPickerScrollUp
-            | Action::PlaylistPickerScrollDown
+            | Action::PlaylistPickerNavigate(_)
             | Action::PlaylistInputConfirm
             | Action::PlaylistInputCancel
             | Action::PlaylistInputChar(_)
@@ -5662,8 +5679,7 @@ impl App {
                 self.handle_playlist_mutation(action);
             }
             Action::ToggleFavoritesOverlay
-            | Action::FavoritesScrollUp
-            | Action::FavoritesScrollDown
+            | Action::FavoritesNavigate(_)
             | Action::FavoritesFocusCategories
             | Action::FavoritesFocusItems
             | Action::FavoritesPlay
@@ -6878,39 +6894,42 @@ impl App {
         self.handle_navigate_browser(dir, steps);
     }
 
+    /// Mouse wheel over the Now Playing sidebar (library queue or radio station list).
+    pub fn navigate_np_sidebar_wheel(&mut self, dir: Direction) {
+        let steps = self.config.browse_mouse_wheel_scroll_lines.max(1);
+        for _ in 0..steps {
+            if self.np_radio_pane_available() {
+                match self.np_pane_focus {
+                    NowPlayingPaneFocus::Radio => self.handle_navigate_radio(dir),
+                    NowPlayingPaneFocus::Queue if !self.queue.songs.is_empty() => {
+                        self.handle_navigate_queue(dir);
+                    }
+                    NowPlayingPaneFocus::Queue => {}
+                }
+            } else if !self.queue.songs.is_empty() {
+                self.handle_navigate_queue(dir);
+            }
+        }
+    }
+
     pub fn navigate_playlist_wheel(&mut self, dir: Direction) {
         let steps = self.config.browse_mouse_wheel_scroll_lines.max(1);
         for _ in 0..steps {
-            let action = match dir {
-                Direction::Up => Action::PlaylistScrollUp,
-                Direction::Down => Action::PlaylistScrollDown,
-                _ => break,
-            };
-            self.handle_playlist_action(action);
+            self.handle_playlist_action(Action::PlaylistNavigate(dir));
         }
     }
 
     pub fn navigate_favorites_wheel(&mut self, dir: Direction) {
         let steps = self.config.browse_mouse_wheel_scroll_lines.max(1);
         for _ in 0..steps {
-            let action = match dir {
-                Direction::Up => Action::FavoritesScrollUp,
-                Direction::Down => Action::FavoritesScrollDown,
-                _ => break,
-            };
-            self.handle_favorites_action(action);
+            self.handle_favorites_action(Action::FavoritesNavigate(dir));
         }
     }
 
     pub fn navigate_playlist_picker_wheel(&mut self, dir: Direction) {
         let steps = self.config.browse_mouse_wheel_scroll_lines.max(1);
         for _ in 0..steps {
-            let action = match dir {
-                Direction::Up => Action::PlaylistPickerScrollUp,
-                Direction::Down => Action::PlaylistPickerScrollDown,
-                _ => break,
-            };
-            self.handle_playlist_mutation(action);
+            self.handle_playlist_mutation(Action::PlaylistPickerNavigate(dir));
         }
     }
 
@@ -7267,36 +7286,39 @@ impl App {
                     }
                 }
             }
-            Action::PlaylistScrollUp => match self.playlist_overlay.focus {
+            Action::PlaylistNavigate(dir) => match self.playlist_overlay.focus {
                 PlaylistFocus::List => {
-                    self.playlist_overlay.selected_playlist_index = self
-                        .playlist_overlay
-                        .selected_playlist_index
-                        .saturating_sub(1);
-                    self.playlist_overlay.selected_track_index = 0;
-                    self.schedule_playlist_tracks_for_selection();
-                }
-                PlaylistFocus::Tracks => {
-                    self.playlist_overlay.selected_track_index =
-                        self.playlist_overlay.selected_track_index.saturating_sub(1);
-                }
-            },
-            Action::PlaylistScrollDown => match self.playlist_overlay.focus {
-                PlaylistFocus::List => {
-                    if let LoadingState::Loaded(ref playlists) = self.playlist_overlay.playlists {
-                        let max = playlists.len().saturating_sub(1);
-                        self.playlist_overlay.selected_playlist_index =
-                            (self.playlist_overlay.selected_playlist_index + 1).min(max);
+                    let len = match &self.playlist_overlay.playlists {
+                        LoadingState::Loaded(playlists) => playlists.len(),
+                        _ => 0,
+                    };
+                    if len == 0 {
+                        return;
+                    }
+                    let page = self.playlist_overlay.list_viewport_rows.max(1);
+                    let next = move_list_index(
+                        self.playlist_overlay.selected_playlist_index,
+                        len,
+                        page,
+                        dir,
+                    );
+                    if next != self.playlist_overlay.selected_playlist_index {
+                        self.playlist_overlay.selected_playlist_index = next;
                         self.playlist_overlay.selected_track_index = 0;
                         self.schedule_playlist_tracks_for_selection();
                     }
                 }
                 PlaylistFocus::Tracks => {
-                    if let LoadingState::Loaded(ref songs) = self.playlist_overlay.tracks {
-                        let max = songs.len().saturating_sub(1);
-                        self.playlist_overlay.selected_track_index =
-                            (self.playlist_overlay.selected_track_index + 1).min(max);
+                    let len = match &self.playlist_overlay.tracks {
+                        LoadingState::Loaded(songs) => songs.len(),
+                        _ => 0,
+                    };
+                    if len == 0 {
+                        return;
                     }
+                    let page = self.playlist_overlay.tracks_viewport_rows.max(1);
+                    self.playlist_overlay.selected_track_index =
+                        move_list_index(self.playlist_overlay.selected_track_index, len, page, dir);
                 }
             },
             Action::PlaylistFocusTracks => {
@@ -7415,32 +7437,30 @@ impl App {
                     }
                 }
             }
-            Action::FavoritesScrollUp => match self.favorites_overlay.focus {
+            Action::FavoritesNavigate(dir) => match self.favorites_overlay.focus {
                 FavoritesFocus::Categories => {
-                    self.favorites_overlay.selected_category_index = self
-                        .favorites_overlay
-                        .selected_category_index
-                        .saturating_sub(1);
-                    self.favorites_overlay.selected_item_index = 0;
-                    self.favorites_overlay.sync_category_from_index();
+                    let len = FavoritesCategory::ALL.len();
+                    let page = self.favorites_overlay.categories_viewport_rows.max(1);
+                    let next = move_list_index(
+                        self.favorites_overlay.selected_category_index,
+                        len,
+                        page,
+                        dir,
+                    );
+                    if next != self.favorites_overlay.selected_category_index {
+                        self.favorites_overlay.selected_category_index = next;
+                        self.favorites_overlay.selected_item_index = 0;
+                        self.favorites_overlay.sync_category_from_index();
+                    }
                 }
                 FavoritesFocus::Items => {
+                    let len = self.favorites_overlay.item_count();
+                    if len == 0 {
+                        return;
+                    }
+                    let page = self.favorites_overlay.items_viewport_rows.max(1);
                     self.favorites_overlay.selected_item_index =
-                        self.favorites_overlay.selected_item_index.saturating_sub(1);
-                }
-            },
-            Action::FavoritesScrollDown => match self.favorites_overlay.focus {
-                FavoritesFocus::Categories => {
-                    let max = FavoritesCategory::ALL.len().saturating_sub(1);
-                    self.favorites_overlay.selected_category_index =
-                        (self.favorites_overlay.selected_category_index + 1).min(max);
-                    self.favorites_overlay.selected_item_index = 0;
-                    self.favorites_overlay.sync_category_from_index();
-                }
-                FavoritesFocus::Items => {
-                    let max = self.favorites_overlay.item_count().saturating_sub(1);
-                    self.favorites_overlay.selected_item_index =
-                        (self.favorites_overlay.selected_item_index + 1).min(max);
+                        move_list_index(self.favorites_overlay.selected_item_index, len, page, dir);
                 }
             },
             Action::FavoritesFocusCategories => {
@@ -7665,6 +7685,7 @@ impl App {
                                 song_id,
                                 loading: false,
                                 scroll: 0,
+                                viewport_rows: 8,
                             });
                         }
                         _ => {
@@ -7674,6 +7695,7 @@ impl App {
                                 song_id,
                                 loading: true,
                                 scroll: 0,
+                                viewport_rows: 8,
                             });
                             self.spawn_fetch_playlists_for_picker();
                         }
@@ -7694,15 +7716,14 @@ impl App {
             Action::PlaylistPickerCancel => {
                 self.playlist_picker = None;
             }
-            Action::PlaylistPickerScrollUp => {
+            Action::PlaylistPickerNavigate(dir) => {
                 if let Some(ref mut picker) = self.playlist_picker {
-                    picker.selected_index = picker.selected_index.saturating_sub(1);
-                }
-            }
-            Action::PlaylistPickerScrollDown => {
-                if let Some(ref mut picker) = self.playlist_picker {
-                    let max = picker.playlists.len().saturating_sub(1);
-                    picker.selected_index = (picker.selected_index + 1).min(max);
+                    let len = picker.playlists.len();
+                    if len == 0 {
+                        return;
+                    }
+                    let page = picker.viewport_rows.max(1);
+                    picker.selected_index = move_list_index(picker.selected_index, len, page, dir);
                 }
             }
             _ => {}

--- a/ratune/src/lib.rs
+++ b/ratune/src/lib.rs
@@ -751,7 +751,12 @@ async fn run_loop(
                             if key.kind == KeyEventKind::Press => {
                                 if app.playlist_picker.is_some() && !app.help_visible {
                                     // Picker is open: highest priority — swallow all keys.
-                                    let action = map_picker_key(key.code, key.modifiers);
+                                    let action = map_picker_key(
+                                        key.code,
+                                        key.modifiers,
+                                        &app.keybinds,
+                                        &mut app.pending_gg,
+                                    );
                                     app.dispatch(action);
                                 } else if app.radio.picker_visible
                                     && !app.radio.input_mode.is_normal()
@@ -804,6 +809,7 @@ async fn run_loop(
                                             &app.favorites_overlay.focus,
                                             &app.keybinds,
                                             app.config.ratings_enabled,
+                                            &mut app.pending_gg,
                                         );
                                         app.dispatch(action);
                                     }
@@ -851,6 +857,7 @@ async fn run_loop(
                                             &app.playlist_overlay.input_mode,
                                             &app.keybinds,
                                             app.config.ratings_enabled,
+                                            &mut app.pending_gg,
                                         );
                                         app.dispatch(action);
                                     }
@@ -1316,19 +1323,31 @@ fn map_favorites_key(
     _focus: &FavoritesFocus,
     kb: &Keybinds,
     ratings_enabled: bool,
+    pending_gg: &mut bool,
 ) -> Action {
     if let Some(action) = map_rate_key(code, modifiers, kb, ratings_enabled) {
         return action;
+    }
+    if let Some(dir) = overlay_list_nav_direction(code, modifiers, kb, pending_gg) {
+        return Action::FavoritesNavigate(dir);
     }
     let shift = modifiers.intersects(KeyModifiers::SHIFT);
     match code {
         KeyCode::Esc => Action::ToggleFavoritesOverlay,
         _ if kb.favorites_overlay.matches(code, modifiers) => Action::ToggleFavoritesOverlay,
         _ if kb.toggle_favorite.matches(code, modifiers) => Action::ToggleFavorite,
-        KeyCode::Char('k') | KeyCode::Up => Action::FavoritesScrollUp,
-        KeyCode::Char('j') | KeyCode::Down => Action::FavoritesScrollDown,
-        KeyCode::Char('h') => Action::FavoritesFocusCategories,
-        KeyCode::Char('l') => Action::FavoritesFocusItems,
+        KeyCode::Left | KeyCode::Char('h') => Action::FavoritesFocusCategories,
+        KeyCode::Right | KeyCode::Char('l') => Action::FavoritesFocusItems,
+        _ if kb.column_left.matches(code, modifiers)
+            || kb.seek_backward.matches(code, modifiers) =>
+        {
+            Action::FavoritesFocusCategories
+        }
+        _ if kb.column_right.matches(code, modifiers)
+            || kb.seek_forward.matches(code, modifiers) =>
+        {
+            Action::FavoritesFocusItems
+        }
         KeyCode::Enter => Action::FavoritesPlay,
         _ => {
             if kb
@@ -1344,6 +1363,69 @@ fn map_favorites_key(
             Action::None
         }
     }
+}
+
+/// Shared list navigation for overlays / pickers: j/k, arrows, PageUp/Down,
+/// Ctrl+u/d, gg (top), G (bottom), and configured `scroll_up` / `scroll_down`.
+fn overlay_list_nav_direction(
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    kb: &Keybinds,
+    pending_gg: &mut bool,
+) -> Option<Direction> {
+    if *pending_gg {
+        *pending_gg = false;
+        if code == KeyCode::Char('g')
+            && !modifiers.intersects(
+                KeyModifiers::CONTROL
+                    | KeyModifiers::ALT
+                    | KeyModifiers::SUPER
+                    | KeyModifiers::HYPER,
+            )
+        {
+            return Some(Direction::Top);
+        }
+        // Otherwise treat this key as a fresh press (fall through).
+    }
+
+    if code == KeyCode::Char('G')
+        && !modifiers.intersects(
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER | KeyModifiers::HYPER,
+        )
+    {
+        return Some(Direction::Bottom);
+    }
+
+    let ctrl = modifiers.intersects(KeyModifiers::CONTROL)
+        && !modifiers.intersects(KeyModifiers::ALT | KeyModifiers::SHIFT);
+    if code == KeyCode::PageUp || (ctrl && matches!(code, KeyCode::Char('u') | KeyCode::Char('U')))
+    {
+        return Some(Direction::PageUp);
+    }
+    if code == KeyCode::PageDown
+        || (ctrl && matches!(code, KeyCode::Char('d') | KeyCode::Char('D')))
+    {
+        return Some(Direction::PageDown);
+    }
+
+    if code == KeyCode::Up || kb.scroll_up.matches(code, modifiers) {
+        return Some(Direction::Up);
+    }
+    if code == KeyCode::Down || kb.scroll_down.matches(code, modifiers) {
+        return Some(Direction::Down);
+    }
+
+    // Lone `g`: wait for second `g` (`gg`) to go to top.
+    if code == KeyCode::Char('g')
+        && !modifiers.intersects(
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER | KeyModifiers::HYPER,
+        )
+    {
+        *pending_gg = true;
+        return None;
+    }
+
+    None
 }
 
 fn map_radio_picker_key(code: KeyCode, modifiers: KeyModifiers, kb: &Keybinds) -> Action {
@@ -1405,6 +1487,7 @@ fn map_playlist_key(
     input_mode: &PlaylistInputMode,
     kb: &Keybinds,
     ratings_enabled: bool,
+    pending_gg: &mut bool,
 ) -> Action {
     match input_mode {
         // ── Text-input modes: feed characters into the buffer ──────────────
@@ -1423,23 +1506,24 @@ fn map_playlist_key(
         },
         // ── Normal navigation / mutation ───────────────────────────────────
         PlaylistInputMode::Normal => {
+            if let Some(dir) = overlay_list_nav_direction(code, modifiers, kb, pending_gg) {
+                return Action::PlaylistNavigate(dir);
+            }
             match code {
                 KeyCode::Esc => Action::TogglePlaylistOverlay,
                 _ if kb.playlist_overlay.matches(code, modifiers) => Action::TogglePlaylistOverlay,
-                KeyCode::Char('k') | KeyCode::Up => Action::PlaylistScrollUp,
-                KeyCode::Char('j') | KeyCode::Down => Action::PlaylistScrollDown,
                 _ if kb.column_left.matches(code, modifiers)
-                    || kb.seek_backward.matches(code, modifiers) =>
+                    || kb.seek_backward.matches(code, modifiers)
+                    || matches!(code, KeyCode::Left | KeyCode::Char('h')) =>
                 {
                     Action::PlaylistFocusList
                 }
                 _ if kb.column_right.matches(code, modifiers)
-                    || kb.seek_forward.matches(code, modifiers) =>
+                    || kb.seek_forward.matches(code, modifiers)
+                    || matches!(code, KeyCode::Right | KeyCode::Char('l')) =>
                 {
                     Action::PlaylistFocusTracks
                 }
-                KeyCode::Char('h') => Action::PlaylistFocusList,
-                KeyCode::Char('l') => Action::PlaylistFocusTracks,
                 // c: create new playlist
                 KeyCode::Char('c') => Action::PlaylistCreate,
                 // X (Shift+x): delete selected playlist
@@ -1490,12 +1574,18 @@ fn map_playlist_key(
 }
 
 /// Translate a key event into an `Action` when the playlist picker popup is open.
-fn map_picker_key(code: KeyCode, _modifiers: KeyModifiers) -> Action {
+fn map_picker_key(
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    kb: &Keybinds,
+    pending_gg: &mut bool,
+) -> Action {
+    if let Some(dir) = overlay_list_nav_direction(code, modifiers, kb, pending_gg) {
+        return Action::PlaylistPickerNavigate(dir);
+    }
     match code {
         KeyCode::Esc => Action::PlaylistPickerCancel,
         KeyCode::Enter => Action::PlaylistPickerSelect,
-        KeyCode::Char('k') | KeyCode::Up => Action::PlaylistPickerScrollUp,
-        KeyCode::Char('j') | KeyCode::Down => Action::PlaylistPickerScrollDown,
         _ => Action::None,
     }
 }
@@ -2112,21 +2202,72 @@ fn handle_browser_overlay_wheel(
 }
 
 fn handle_mouse_wheel(x: u16, y: u16, dir: Direction, app: &mut App, terminal_size: Rect) {
-    if app.active_tab != Tab::Browser {
-        return;
-    }
-
     let areas = ui::layout::build_layout(terminal_size, &ui::layout::layout_options_for_app(app));
+
+    // Playlists / favorites / picker overlays sit on the Browse layout; handle them
+    // before tab-specific scrolling so the wheel always works when they are open.
     if handle_browser_overlay_wheel(x, y, dir, app, areas.center) {
         return;
     }
 
-    let Some(hit) = browser_column_hit(x, y, areas.center, app.browser_browse_mode) else {
+    match app.active_tab {
+        Tab::Browser => {
+            let Some(hit) = browser_column_hit(x, y, areas.center, app.browser_browse_mode) else {
+                return;
+            };
+
+            app.browser_focus = hit.focus;
+            app.navigate_browser_wheel(dir);
+        }
+        Tab::NowPlaying => {
+            handle_nowplaying_wheel(x, y, dir, app, areas.center);
+        }
+        Tab::Home => {}
+    }
+}
+
+fn now_playing_tab_rects(app: &App, center: Rect) -> ui::layout::NowPlayingRects {
+    let show_art = app.config.nowplaying_show_art;
+    let boxed_np = app
+        .config
+        .now_playing_layout
+        .trim()
+        .eq_ignore_ascii_case("boxed");
+    let art_position = ui::layout::placement_from_str(&app.config.nowplaying_art_position)
+        .unwrap_or(ui::layout::Placement::Left);
+    let queue_position = ui::layout::placement_from_str(&app.config.nowplaying_queue_position)
+        .unwrap_or(ui::layout::Placement::Right);
+    let visualizer_position = ui::layout::placement_from_str(&app.config.visualizer_location)
+        .unwrap_or(ui::layout::Placement::Right);
+    let now_playing_position = ui::layout::placement_from_str(&app.config.now_playing_box_location)
+        .unwrap_or(ui::layout::Placement::Right);
+    let lyrics_position =
+        ui::layout::placement_from_str(&app.config.lyrics_location).unwrap_or(queue_position);
+    ui::layout::now_playing_rects(
+        center,
+        show_art,
+        art_position,
+        queue_position,
+        app.config.nowplaying_left_width_percent,
+        app.config.nowplaying_vertical_fill_top_percent,
+        app.visualizer_visible,
+        visualizer_position,
+        app.lyrics_visible,
+        lyrics_position,
+        boxed_np,
+        now_playing_position,
+    )
+}
+
+fn handle_nowplaying_wheel(x: u16, y: u16, dir: Direction, app: &mut App, center: Rect) {
+    let rects = now_playing_tab_rects(app, center);
+    let Some(queue_area) = rects.queue else {
         return;
     };
-
-    app.browser_focus = hit.focus;
-    app.navigate_browser_wheel(dir);
+    if !rect_contains(queue_area, x, y) {
+        return;
+    }
+    app.navigate_np_sidebar_wheel(dir);
 }
 
 // ── Mouse click handler ───────────────────────────────────────────────────────
@@ -2406,42 +2547,14 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
             }
         }
         Tab::NowPlaying => {
-            let show_art = app.config.nowplaying_show_art;
             let boxed_np = app
                 .config
                 .now_playing_layout
                 .trim()
                 .eq_ignore_ascii_case("boxed");
+            let rects = now_playing_tab_rects(app, center);
 
             if boxed_np {
-                let art_position =
-                    ui::layout::placement_from_str(&app.config.nowplaying_art_position)
-                        .unwrap_or(ui::layout::Placement::Left);
-                let queue_position =
-                    ui::layout::placement_from_str(&app.config.nowplaying_queue_position)
-                        .unwrap_or(ui::layout::Placement::Right);
-                let visualizer_position =
-                    ui::layout::placement_from_str(&app.config.visualizer_location)
-                        .unwrap_or(ui::layout::Placement::Right);
-                let now_playing_position =
-                    ui::layout::placement_from_str(&app.config.now_playing_box_location)
-                        .unwrap_or(ui::layout::Placement::Right);
-                let lyrics_position = ui::layout::placement_from_str(&app.config.lyrics_location)
-                    .unwrap_or(queue_position);
-                let rects = ui::layout::now_playing_rects(
-                    center,
-                    show_art,
-                    art_position,
-                    queue_position,
-                    app.config.nowplaying_left_width_percent,
-                    app.config.nowplaying_vertical_fill_top_percent,
-                    app.visualizer_visible,
-                    visualizer_position,
-                    app.lyrics_visible,
-                    lyrics_position,
-                    boxed_np,
-                    now_playing_position,
-                );
                 if let Some(pane) = rects.now_playing {
                     let chrome = ui::now_playing::interaction_rects_pane(app, pane);
                     if let Some(controls_area) = chrome.controls {
@@ -2488,33 +2601,6 @@ fn handle_mouse_click(x: u16, y: u16, app: &mut App, terminal_size: ratatui::lay
                 }
             }
 
-            let art_position = ui::layout::placement_from_str(&app.config.nowplaying_art_position)
-                .unwrap_or(ui::layout::Placement::Left);
-            let queue_position =
-                ui::layout::placement_from_str(&app.config.nowplaying_queue_position)
-                    .unwrap_or(ui::layout::Placement::Right);
-            let visualizer_position =
-                ui::layout::placement_from_str(&app.config.visualizer_location)
-                    .unwrap_or(ui::layout::Placement::Right);
-            let now_playing_position =
-                ui::layout::placement_from_str(&app.config.now_playing_box_location)
-                    .unwrap_or(ui::layout::Placement::Right);
-            let lyrics_position = ui::layout::placement_from_str(&app.config.lyrics_location)
-                .unwrap_or(queue_position);
-            let rects = ui::layout::now_playing_rects(
-                center,
-                show_art,
-                art_position,
-                queue_position,
-                app.config.nowplaying_left_width_percent,
-                app.config.nowplaying_vertical_fill_top_percent,
-                app.visualizer_visible,
-                visualizer_position,
-                app.lyrics_visible,
-                lyrics_position,
-                boxed_np,
-                now_playing_position,
-            );
             let Some(queue_area) = rects.queue else {
                 return;
             };

--- a/ratune/src/state.rs
+++ b/ratune/src/state.rs
@@ -525,6 +525,10 @@ pub struct PlaylistOverlay {
     pub tracks_cache: std::collections::HashMap<String, Vec<ratune_subsonic::Song>>,
     pub list_scroll: usize,
     pub tracks_scroll: usize,
+    /// Visible rows in the playlist list column (excluding borders); updated on render.
+    pub list_viewport_rows: usize,
+    /// Visible rows in the tracks column (excluding borders); updated on render.
+    pub tracks_viewport_rows: usize,
 }
 
 impl Default for PlaylistOverlay {
@@ -541,6 +545,8 @@ impl Default for PlaylistOverlay {
             tracks_cache: std::collections::HashMap::new(),
             list_scroll: 0,
             tracks_scroll: 0,
+            list_viewport_rows: 8,
+            tracks_viewport_rows: 8,
         }
     }
 }
@@ -573,7 +579,7 @@ pub enum FavoritesFocus {
     Items,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct FavoritesOverlay {
     pub visible: bool,
     pub loading: bool,
@@ -588,9 +594,36 @@ pub struct FavoritesOverlay {
     pub selected_item_index: usize,
     pub categories_scroll: usize,
     pub items_scroll: usize,
+    /// Visible rows in the category column (excluding borders); updated on render.
+    pub categories_viewport_rows: usize,
+    /// Visible rows in the items column (excluding borders); updated on render.
+    pub items_viewport_rows: usize,
     pub songs: Vec<ratune_subsonic::Song>,
     pub albums: Vec<ratune_subsonic::Album>,
     pub artists: Vec<ratune_subsonic::Artist>,
+}
+
+impl Default for FavoritesOverlay {
+    fn default() -> Self {
+        Self {
+            visible: false,
+            loading: false,
+            error: None,
+            offline_snapshot: false,
+            snapshot_refreshed_at: None,
+            category: FavoritesCategory::default(),
+            focus: FavoritesFocus::default(),
+            selected_category_index: 0,
+            selected_item_index: 0,
+            categories_scroll: 0,
+            items_scroll: 0,
+            categories_viewport_rows: 8,
+            items_viewport_rows: 8,
+            songs: Vec::new(),
+            albums: Vec::new(),
+            artists: Vec::new(),
+        }
+    }
 }
 
 impl FavoritesOverlay {

--- a/ratune/src/ui/favorites_overlay.rs
+++ b/ratune/src/ui/favorites_overlay.rs
@@ -157,6 +157,7 @@ fn render_categories(
         .style(style_with_bg(theme.background));
 
     let len = FavoritesCategory::ALL.len();
+    overlay.categories_viewport_rows = area.height.saturating_sub(2).max(1) as usize;
     frame.render_stateful_widget(
         list,
         area,
@@ -308,6 +309,7 @@ fn render_items(
     } else {
         None
     };
+    overlay.items_viewport_rows = area.height.saturating_sub(2).max(1) as usize;
     frame.render_stateful_widget(
         list,
         area,

--- a/ratune/src/ui/playlist_overlay.rs
+++ b/ratune/src/ui/playlist_overlay.rs
@@ -225,6 +225,7 @@ fn render_playlist_list(
         LoadingState::Loaded(playlists) => playlists.len(),
         _ => 0,
     };
+    overlay.list_viewport_rows = list_area.height.saturating_sub(2).max(1) as usize;
     frame.render_stateful_widget(
         list,
         list_area,
@@ -347,6 +348,7 @@ fn render_track_list(
         .highlight_symbol("▶ ")
         .style(style_with_bg(theme.background));
 
+    overlay.tracks_viewport_rows = area.height.saturating_sub(2).max(1) as usize;
     frame.render_stateful_widget(
         list,
         area,
@@ -447,6 +449,7 @@ pub fn render_playlist_picker(
         .highlight_symbol("▶ ")
         .style(style_with_bg(theme.background));
 
+    picker.viewport_rows = picker_area.height.saturating_sub(2).max(1) as usize;
     frame.render_stateful_widget(
         list,
         picker_area,

--- a/ratune/src/ui/popup.rs
+++ b/ratune/src/ui/popup.rs
@@ -138,7 +138,9 @@ fn playlist_sections(
     let mut favorites = vec![
         ("F", "Open / close favorites panel (Browse)"),
         ("j / k", "Scroll category / item list"),
-        ("h / l", "Switch between lists"),
+        ("PgUp / PgDn · Ctrl+u / Ctrl+d", "Page scroll"),
+        ("gg / G", "Jump to top / bottom"),
+        ("h / l · ← / →", "Switch between lists"),
         ("Enter / Ctrl+r", "Replace queue and play"),
         ("Shift+A", "Append to queue"),
         ("f", "Toggle favorite"),
@@ -155,7 +157,9 @@ fn playlist_sections(
             vec![
                 ("Shift+P", "Open / close playlist panel"),
                 ("j / k", "Scroll playlist / track list"),
-                ("h / l", "Switch between lists"),
+                ("PgUp / PgDn · Ctrl+u / Ctrl+d", "Page scroll"),
+                ("gg / G", "Jump to top / bottom"),
+                ("h / l · ← / →", "Switch between lists"),
                 ("Enter / Ctrl+r", "Replace queue and play"),
                 ("a", "Append track to queue"),
                 ("A", "Append playlist to queue"),


### PR DESCRIPTION
A number of navigation functionality missing in various places:

- mouse scroll on queue (see #55)
- favorites/playlist keyboard navigation (ie hotkeys like ctrl+d / ctrl+u)