### PR TITLE
feat: Add Netease lyrics backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Ratune was built to bring together a combination of features often missing from 
 - **Playback**: Gapless queue, seek, shuffle/unshuffle, and playlist management.
 - **Internet radio**: Stations from your server
 - **Album Art**: Display using Kitty graphics and [ratatui-image](https://github.com/ratatui/ratatui-image) (see link for compatible terminals)
-- **Lyrics**: Synced lyrics via LRCLib (default) or your Subsonic server. Optional on-disk cache for offline use
+- **Lyrics**: Synced lyrics via LRCLib (default), NetEase Cloud Music, or your Subsonic server. Optional on-disk cache for offline use
 - **Offline mode**: Starts without a server when needed; plays cached tracks, browse from library index, and detects reconnect automatically
 - **Visualizer**: FFT spectrum analyzer.
 - **Fuzzy finder**: Optional library index + external picker (fzf/skim) for fast track selection.

--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -435,8 +435,9 @@ location = "right"
 # [lyrics] — lyrics fetch source
 # -----------------------------------------------------------------------------
 #
-# source — "lrclib" (default) | "subsonic"
+# source — "lrclib" (default) | "netease" | "subsonic"
 #   lrclib   — query LRCLib (public API; requests only when the lyrics pane is open)
+#   netease  — query NetEase Cloud Music by title and artist (no login required)
 #   subsonic — query your Subsonic server (getLyricsBySongId / getLyrics; no third party)
 # lrclib_url — LRCLib base URL when source = "lrclib". Default: https://lrclib.net
 # cache_enabled — store lyrics under ~/.cache/ratune/lyrics/ for offline use. Default: true
@@ -445,6 +446,7 @@ location = "right"
 source = "lrclib"
 # lrclib_url = "https://lrclib.net"
 # cache_enabled = false
+# source = "netease"
 # source = "subsonic"
 
 # [ui.nptab.visualizer_pane]

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -2462,6 +2462,12 @@ impl App {
         self.lyrics_scroll = 0;
         let source = self.config.lyrics_source;
         let lrclib_url = self.config.lyrics_lrclib_url.clone();
+        let duration_secs = self
+            .queue
+            .songs
+            .iter()
+            .find(|song| song.id == song_id)
+            .and_then(|song| song.duration);
         let cache_enabled = self.config.lyrics_cache_enabled;
         let client = self.subsonic.clone();
         let tx = self.library_tx.clone();
@@ -2471,10 +2477,13 @@ impl App {
                 source,
                 &lrclib_url,
                 &client,
-                &song_id,
-                &artist,
-                &title,
-                &album,
+                crate::lyrics::LyricsTrack {
+                    song_id: &song_id,
+                    artist: &artist,
+                    title: &title,
+                    album: &album,
+                    duration_secs,
+                },
             )
             .await;
             if cache_enabled {

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -212,7 +212,7 @@ impl Default for CacheSection {
 /// Lyrics fetch settings from config.toml.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LyricsSection {
-    /// Where to fetch lyrics: `lrclib` (default) or `subsonic`.
+    /// Where to fetch lyrics: `lrclib` (default), `netease`, or `subsonic`.
     #[serde(default = "default_lyrics_source")]
     pub source: String,
     /// LRCLib server base URL (used when `source = "lrclib"`). Default: https://lrclib.net
@@ -251,6 +251,8 @@ pub enum LyricsSource {
     /// Public LRCLib API (default).
     #[default]
     LrcLib,
+    /// Unauthenticated NetEase Cloud Music web API.
+    Netease,
     /// Subsonic server (`getLyricsBySongId` / `getLyrics`).
     Subsonic,
 }
@@ -259,6 +261,7 @@ impl LyricsSource {
     pub fn parse(s: &str) -> Option<Self> {
         match s.trim().to_ascii_lowercase().as_str() {
             "lrclib" | "lrc-lib" | "lrc" => Some(Self::LrcLib),
+            "netease" | "netease-cloud-music" | "163" => Some(Self::Netease),
             "subsonic" | "server" => Some(Self::Subsonic),
             _ => None,
         }
@@ -268,6 +271,7 @@ impl LyricsSource {
     pub fn cache_dir_name(self) -> &'static str {
         match self {
             Self::LrcLib => "lrclib",
+            Self::Netease => "netease",
             Self::Subsonic => "subsonic",
         }
     }
@@ -1434,7 +1438,7 @@ pub struct Config {
     pub cache_starred_albums: bool,
     /// Concurrent downloads when prefetching favorite tracks.
     pub cache_starred_parallelism: usize,
-    /// Where to fetch lyrics (`lrclib` or `subsonic`).
+    /// Where to fetch lyrics (`lrclib`, `netease`, or `subsonic`).
     pub lyrics_source: LyricsSource,
     /// LRCLib base URL when `lyrics_source` is `LrcLib`.
     pub lyrics_lrclib_url: String,
@@ -2086,7 +2090,7 @@ enabled     = true
 max_size_gb = 2   # maximum total cache size in gigabytes
 
 [lyrics]
-# source — "lrclib" (default) | "subsonic"
+# source — "lrclib" (default) | "netease" | "subsonic"
 source = "lrclib"
 # lrclib_url — LRCLib base URL when source = "lrclib". Default: https://lrclib.net
 # lrclib_url = "https://lrclib.net"
@@ -2688,8 +2692,10 @@ api_secret_command = "secret-tool lookup service ratune user lastfm|api_secret"
     }
 
     #[test]
-    fn lyrics_source_parses_lrclib_and_subsonic() {
+    fn lyrics_source_parses_supported_values() {
         assert_eq!(LyricsSource::parse("lrclib"), Some(LyricsSource::LrcLib));
+        assert_eq!(LyricsSource::parse("netease"), Some(LyricsSource::Netease));
+        assert_eq!(LyricsSource::parse("163"), Some(LyricsSource::Netease));
         assert_eq!(
             LyricsSource::parse("subsonic"),
             Some(LyricsSource::Subsonic)
@@ -2700,6 +2706,7 @@ api_secret_command = "secret-tool lookup service ratune user lastfm|api_secret"
     #[test]
     fn lyrics_source_cache_dir_names() {
         assert_eq!(LyricsSource::LrcLib.cache_dir_name(), "lrclib");
+        assert_eq!(LyricsSource::Netease.cache_dir_name(), "netease");
         assert_eq!(LyricsSource::Subsonic.cache_dir_name(), "subsonic");
     }
 

--- a/ratune/src/lyrics.rs
+++ b/ratune/src/lyrics.rs
@@ -206,7 +206,6 @@ fn select_netease_song<'a>(
                 .iter()
                 .find(|song| netease_titles_match(&song.name, title))
         })
-        .or_else(|| songs.first())
 }
 
 fn netease_titles_match(candidate: &str, title: &str) -> bool {
@@ -382,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn netease_match_falls_back_to_title_then_first_result() {
+    fn netease_match_falls_back_to_title() {
         let songs = vec![
             NeteaseSong {
                 id: 1,
@@ -401,12 +400,7 @@ mod tests {
                 .id,
             2
         );
-        assert_eq!(
-            select_netease_song(&songs, "Unknown", Some(180))
-                .expect("first result")
-                .id,
-            1
-        );
+        assert!(select_netease_song(&songs, "Unknown", Some(180)).is_none());
     }
 
     #[test]

--- a/ratune/src/lyrics.rs
+++ b/ratune/src/lyrics.rs
@@ -1,11 +1,17 @@
-//! Lyrics fetcher — LRCLib or Subsonic, selected in `[lyrics].source`.
+//! Lyrics fetcher — LRCLib, NetEase, or Subsonic, selected in `[lyrics].source`.
 //!
 //! All errors are soft-failed — callers always receive a `Vec`, possibly empty.
 
 use std::time::Duration;
 
 use ratune_subsonic::{LyricLine, SubsonicClient};
+use reqwest::header::{REFERER, USER_AGENT};
 use serde::Deserialize;
+
+const NETEASE_SEARCH_URL: &str = "https://music.163.com/api/search/get";
+const NETEASE_LYRIC_URL: &str = "https://music.163.com/api/song/lyric";
+const NETEASE_REFERER: &str = "https://music.163.com/";
+const NETEASE_USER_AGENT: &str = concat!("ratune/", env!("CARGO_PKG_VERSION"));
 
 use crate::config::LyricsSource;
 
@@ -16,21 +22,60 @@ struct LrcLibResponse {
     plain_lyrics: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct NeteaseSearchResponse {
+    code: u16,
+    result: Option<NeteaseSearchResult>,
+}
+
+#[derive(Deserialize)]
+struct NeteaseSearchResult {
+    #[serde(default)]
+    songs: Vec<NeteaseSong>,
+}
+
+#[derive(Deserialize)]
+struct NeteaseSong {
+    id: u64,
+    name: String,
+    duration: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct NeteaseLyricsResponse {
+    code: u16,
+    lrc: Option<NeteaseLyrics>,
+}
+
+#[derive(Deserialize)]
+struct NeteaseLyrics {
+    lyric: Option<String>,
+}
+
+pub(crate) struct LyricsTrack<'a> {
+    pub song_id: &'a str,
+    pub artist: &'a str,
+    pub title: &'a str,
+    pub album: &'a str,
+    /// NetEase uses duration to disambiguate different versions of the same track.
+    pub duration_secs: Option<u32>,
+}
+
 /// Fetch lyrics using the configured source.
 pub async fn fetch_lyrics(
     source: LyricsSource,
     lrclib_url: &str,
     client: &SubsonicClient,
-    song_id: &str,
-    artist: &str,
-    title: &str,
-    album: &str,
+    track: LyricsTrack<'_>,
 ) -> Vec<LyricLine> {
     match source {
-        LyricsSource::LrcLib => fetch_lrclib(lrclib_url, artist, title, album)
+        LyricsSource::LrcLib => fetch_lrclib(lrclib_url, track.artist, track.title, track.album)
             .await
             .unwrap_or_default(),
-        LyricsSource::Subsonic => fetch_subsonic(client, song_id, artist, title)
+        LyricsSource::Netease => fetch_netease(track.artist, track.title, track.duration_secs)
+            .await
+            .unwrap_or_default(),
+        LyricsSource::Subsonic => fetch_subsonic(client, track.song_id, track.artist, track.title)
             .await
             .unwrap_or_default(),
     }
@@ -76,6 +121,109 @@ async fn fetch_lrclib(
 
     let body: LrcLibResponse = resp.json().await?;
     Ok(lines_from_lrclib_body(&body))
+}
+
+async fn fetch_netease(
+    artist: &str,
+    title: &str,
+    duration_secs: Option<u32>,
+) -> Result<Vec<LyricLine>, Box<dyn std::error::Error + Send + Sync>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()?;
+    let query = if artist.trim().is_empty() {
+        title.to_string()
+    } else {
+        format!("{title} {artist}")
+    };
+    let response = client
+        .get(NETEASE_SEARCH_URL)
+        .header(USER_AGENT, NETEASE_USER_AGENT)
+        .header(REFERER, NETEASE_REFERER)
+        .query(&[
+            ("s", query.as_str()),
+            ("type", "1"),
+            ("offset", "0"),
+            ("total", "true"),
+            ("limit", "10"),
+        ])
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Ok(vec![]);
+    }
+
+    let body: NeteaseSearchResponse = response.json().await?;
+    if body.code != 200 {
+        return Ok(vec![]);
+    }
+    let songs = body.result.map(|result| result.songs).unwrap_or_default();
+    let Some(song) = select_netease_song(&songs, title, duration_secs) else {
+        return Ok(vec![]);
+    };
+
+    let response = client
+        .get(NETEASE_LYRIC_URL)
+        .header(USER_AGENT, NETEASE_USER_AGENT)
+        .header(REFERER, NETEASE_REFERER)
+        .query(&[
+            ("id", song.id.to_string()),
+            ("lv", "-1".to_string()),
+            ("kv", "-1".to_string()),
+            ("tv", "-1".to_string()),
+        ])
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Ok(vec![]);
+    }
+
+    let body: NeteaseLyricsResponse = response.json().await?;
+    if body.code != 200 {
+        return Ok(vec![]);
+    }
+    Ok(lines_from_netease_body(&body))
+}
+
+fn select_netease_song<'a>(
+    songs: &'a [NeteaseSong],
+    title: &str,
+    duration_secs: Option<u32>,
+) -> Option<&'a NeteaseSong> {
+    let duration_ms = duration_secs.map(|seconds| u64::from(seconds) * 1000);
+    songs
+        .iter()
+        .find(|song| {
+            netease_titles_match(&song.name, title)
+                && duration_ms
+                    .zip(song.duration)
+                    .is_some_and(|(expected, actual)| expected.abs_diff(actual) <= 2_000)
+        })
+        .or_else(|| {
+            songs
+                .iter()
+                .find(|song| netease_titles_match(&song.name, title))
+        })
+        .or_else(|| songs.first())
+}
+
+fn netease_titles_match(candidate: &str, title: &str) -> bool {
+    let candidate = candidate.trim().to_lowercase();
+    let title = title.trim().to_lowercase();
+    !candidate.is_empty()
+        && !title.is_empty()
+        && (candidate.contains(&title) || title.contains(&candidate))
+}
+
+fn lines_from_netease_body(body: &NeteaseLyricsResponse) -> Vec<LyricLine> {
+    body.lrc
+        .as_ref()
+        .and_then(|lrc| lrc.lyric.as_deref())
+        .filter(|lyric| !lyric.trim().is_empty() && lyric.trim() != "暂无歌词")
+        .map(parse_lyrics_text)
+        .unwrap_or_default()
 }
 
 async fn fetch_subsonic(
@@ -138,9 +286,17 @@ fn parse_lrc_line(line: &str) -> Option<LyricLine> {
 
     let mins: u64 = tag[..colon].parse().ok()?;
     let secs: u64 = tag[colon + 1..dot].parse().ok()?;
-    let cs: u64 = tag[dot + 1..].parse().ok()?;
+    let fraction = &tag[dot + 1..];
+    if fraction.is_empty() || !fraction.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let fraction_ms = match fraction.len() {
+        1 => fraction.parse::<u64>().ok()? * 100,
+        2 => fraction.parse::<u64>().ok()? * 10,
+        _ => fraction[..3].parse().ok()?,
+    };
 
-    let ms = (mins * 60 + secs) * 1000 + cs * 10;
+    let ms = (mins * 60 + secs) * 1000 + fraction_ms;
     Some(LyricLine {
         time: Some(Duration::from_millis(ms)),
         text,
@@ -196,12 +352,96 @@ mod tests {
     }
 
     #[test]
+    fn netease_search_response_deserializes() {
+        let body: NeteaseSearchResponse = serde_json::from_str(
+            r#"{"code":200,"result":{"songs":[{"id":42,"name":"Test Song","duration":183000}]}}"#,
+        )
+        .expect("netease search response");
+        let songs = body.result.expect("result").songs;
+        assert_eq!(songs.len(), 1);
+        assert_eq!(songs[0].id, 42);
+        assert_eq!(songs[0].duration, Some(183_000));
+    }
+
+    #[test]
+    fn netease_match_prefers_title_and_duration() {
+        let songs = vec![
+            NeteaseSong {
+                id: 1,
+                name: "Test Song".into(),
+                duration: Some(240_000),
+            },
+            NeteaseSong {
+                id: 2,
+                name: "Test Song (Album Version)".into(),
+                duration: Some(183_500),
+            },
+        ];
+        let matched = select_netease_song(&songs, "test song", Some(183)).expect("match");
+        assert_eq!(matched.id, 2);
+    }
+
+    #[test]
+    fn netease_match_falls_back_to_title_then_first_result() {
+        let songs = vec![
+            NeteaseSong {
+                id: 1,
+                name: "Different Song".into(),
+                duration: Some(180_000),
+            },
+            NeteaseSong {
+                id: 2,
+                name: "Test Song".into(),
+                duration: Some(300_000),
+            },
+        ];
+        assert_eq!(
+            select_netease_song(&songs, "Test Song", Some(180))
+                .expect("title match")
+                .id,
+            2
+        );
+        assert_eq!(
+            select_netease_song(&songs, "Unknown", Some(180))
+                .expect("first result")
+                .id,
+            1
+        );
+    }
+
+    #[test]
+    fn lines_from_netease_body_parses_lrc() {
+        let body = NeteaseLyricsResponse {
+            code: 200,
+            lrc: Some(NeteaseLyrics {
+                lyric: Some("[00:01.50] First\n[00:03.00] Second".into()),
+            }),
+        };
+        let lines = lines_from_netease_body(&body);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].text, "First");
+        assert_eq!(lines[0].time, Some(Duration::from_millis(1500)));
+    }
+
+    #[test]
+    fn lines_from_netease_body_ignores_placeholder() {
+        let body = NeteaseLyricsResponse {
+            code: 200,
+            lrc: Some(NeteaseLyrics {
+                lyric: Some("暂无歌词".into()),
+            }),
+        };
+        assert!(lines_from_netease_body(&body).is_empty());
+    }
+
+    #[test]
     fn parse_lrc_timestamps() {
-        let lrc = "[00:01.50] Hello\n[00:03.00] World";
+        let lrc = "[00:01.50] Hello\n[00:03.684] World";
         let lines = parse_lrc(lrc);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].text, "Hello");
         assert_eq!(lines[0].time, Some(Duration::from_millis(1500)));
+        assert_eq!(lines[1].time, Some(Duration::from_millis(3684)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `netease` as a configurable lyrics source
- Add a `duration_secs` parameter to lyrics, since Netease relies on it to fetch identify songs and lyrics. 


## Note

API flow from [`index-null/cmus-lyric`](https://github.com/index-null/cmus-lyric) (MIT) NetEase Cloud Music's unauthenticated HTTPS search and lyric endpoints is used. 

