### PR TITLE
fix: network issues from performance fixes

### DIFF
--- a/ratune-player/src/engine.rs
+++ b/ratune-player/src/engine.rs
@@ -664,7 +664,10 @@ fn stream_http_client() -> &'static reqwest::blocking::Client {
         reqwest::blocking::Client::builder()
             // Whole request including body (large lossless files over slow links).
             .timeout(Duration::from_secs(900))
-            .connect_timeout(Duration::from_secs(60))
+            // Keep a dead server from monopolizing the player thread. This is no
+            // longer than the app's connectivity probe, so cached commands are not
+            // left queued behind a stale online request after entering offline mode.
+            .connect_timeout(Duration::from_secs(4))
             .pool_idle_timeout(Some(Duration::from_secs(90)))
             .user_agent(concat!("ratune/", env!("CARGO_PKG_VERSION")))
             .build()
@@ -804,7 +807,21 @@ fn download_and_decode(url: &str) -> Result<Decoder<Cursor<Vec<u8>>>> {
         let identity = attempt == 3;
         match fetch_track_bytes(url, identity).and_then(build_symphonia_decoder) {
             Ok(decoder) => return Ok(decoder),
-            Err(e) => last_err = Some(e),
+            Err(e) => {
+                // Retrying an unreachable host four times keeps the single player
+                // thread blocked and prevents a subsequent cached track from
+                // starting. Preserve retries for truncated bodies, HTTP failures,
+                // and decode quirks, but fail fast for connect/timeout errors.
+                let connectivity_failure = e.chain().any(|cause| {
+                    cause
+                        .downcast_ref::<reqwest::Error>()
+                        .is_some_and(|request| request.is_connect() || request.is_timeout())
+                });
+                last_err = Some(e);
+                if connectivity_failure {
+                    break;
+                }
+            }
         }
     }
     Err(last_err.expect("loop runs at least once"))

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -136,6 +136,7 @@ fn humanize_playback_error(message: &str) -> String {
 enum ResolvedPlayback {
     Url(String),
     Cached(PathBuf),
+    UnavailableOffline,
 }
 
 /// Prefix for synthetic [`Song::id`] values built from internet radio stations.
@@ -779,6 +780,27 @@ impl App {
     /// not logged to stderr and corrupt the alternate-screen TUI.
     fn remote_available(&self) -> bool {
         self.server_reachable
+    }
+
+    /// Server name for status-bar and warning text: the configured alias when set,
+    /// otherwise the URL without its scheme. Keeps full URLs (and anything that
+    /// could carry credentials) out of user-visible messages.
+    pub fn server_label(&self) -> String {
+        if let Some(alias) = self
+            .config
+            .server_alias
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return alias.to_string();
+        }
+        self.config
+            .subsonic_url
+            .trim_start_matches("http://")
+            .trim_start_matches("https://")
+            .trim_end_matches('/')
+            .to_string()
     }
 
     pub fn new(config: Config) -> Result<Self> {
@@ -2015,19 +2037,31 @@ impl App {
 
     /// Non-blocking startup Subsonic `ping`. Reachability / auth are applied via
     /// [`LibraryUpdate`] once the TUI is already up.
+    ///
+    /// Uses the short connectivity probe first so offline / no-route startups fail in
+    /// a few seconds instead of waiting on the pooled client's 30s request timeout.
+    /// A full `ping` still runs when the server answers, so auth failures are detected.
     pub fn spawn_startup_ping(&mut self) {
         self.startup_ping_pending = true;
         let client = self.subsonic.clone();
         let tx = self.library_tx.clone();
         tokio::spawn(async move {
-            let update = match client.ping().await {
-                Ok(()) => LibraryUpdate::StartupPingOk,
-                Err(e) if is_auth_failure(e.as_ref()) => LibraryUpdate::StartupPingAuthFailed {
-                    detail: format!("{e:#}"),
-                },
-                Err(e) => LibraryUpdate::StartupPingUnreachable {
-                    detail: format!("{e:#}"),
-                },
+            let update = if !client.is_network_reachable().await {
+                LibraryUpdate::StartupPingUnreachable {
+                    detail: "no response".into(),
+                }
+            } else {
+                match client.ping().await {
+                    Ok(()) => LibraryUpdate::StartupPingOk,
+                    Err(e) if is_auth_failure(e.as_ref()) => LibraryUpdate::StartupPingAuthFailed {
+                        // Auth errors are Subsonic status payloads — safe to show.
+                        detail: format!("{e:#}"),
+                    },
+                    Err(_) => LibraryUpdate::StartupPingUnreachable {
+                        // reqwest error text embeds the request URL (auth token query).
+                        detail: "network error".into(),
+                    },
+                }
             };
             let _ = tx.send(update).await;
         });
@@ -3537,14 +3571,14 @@ impl App {
             }
             LibraryUpdate::StartupPingUnreachable { detail } => {
                 self.startup_ping_pending = false;
-                eprintln!(
-                    "warn: could not reach Subsonic server at {} — starting offline (cache and saved state)",
-                    self.config.subsonic_url
+                // Same path as a mid-session connectivity drop; stderr would corrupt
+                // the alternate screen, so the reason goes to the status bar.
+                self.apply_connectivity_changed(false, false);
+                let label = self.server_label();
+                self.flash_status_secs(
+                    format!("Could not reach {label} ({detail}) — offline mode"),
+                    8,
                 );
-                eprintln!("warn: {detail}");
-                self.server_reachable = false;
-                self.flash_status_secs("Server unreachable — offline (cached content only)", 8);
-                self.on_went_offline();
             }
             LibraryUpdate::BrowseArtistRatings(ratings) => {
                 if let LoadingState::Loaded(artists) = &mut self.library.artists {
@@ -3871,6 +3905,7 @@ impl App {
                                 .player_tx
                                 .send(PlayerCommand::EnqueueNext { url, duration });
                         }
+                        ResolvedPlayback::UnavailableOffline => {}
                     }
                 }
             }
@@ -4149,6 +4184,10 @@ impl App {
                         .player_tx
                         .send(PlayerCommand::PlayUrl { url, duration, gen });
                 }
+                ResolvedPlayback::UnavailableOffline => {
+                    self.playback.player_loaded = false;
+                    self.flash_status_secs("Track is not available in the offline cache", 6);
+                }
             }
         }
     }
@@ -4160,6 +4199,9 @@ impl App {
                 self.cache.touch(&song.id);
                 return ResolvedPlayback::Cached(path);
             }
+        }
+        if !self.remote_available() {
+            return ResolvedPlayback::UnavailableOffline;
         }
         ResolvedPlayback::Url(self.subsonic.stream_url(&song.id, self.config.max_bit_rate))
     }
@@ -6794,6 +6836,13 @@ impl App {
                                 duration: dur,
                                 gen,
                             });
+                        }
+                        ResolvedPlayback::UnavailableOffline => {
+                            self.playback.player_loaded = false;
+                            self.flash_status_secs(
+                                "Track is not available in the offline cache",
+                                6,
+                            );
                         }
                     }
                 }

--- a/ratune/src/ui/status_bar.rs
+++ b/ratune/src/ui/status_bar.rs
@@ -134,28 +134,11 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
     } else {
         let hint = "i — help";
         let sep = "  ·  ";
-        let host_label = if let Some(alias) = app
-            .config
-            .server_alias
-            .as_deref()
-            .filter(|s| !s.trim().is_empty())
-        {
-            if app.server_reachable {
-                alias.to_string()
-            } else {
-                format!("{alias} (offline)")
-            }
+        let server = app.server_label();
+        let host_label = if app.server_reachable {
+            server
         } else {
-            let host = app
-                .config
-                .subsonic_url
-                .trim_start_matches("http://")
-                .trim_start_matches("https://");
-            if app.server_reachable {
-                host.to_string()
-            } else {
-                format!("{host} (offline)")
-            }
+            format!("{server} (offline)")
         };
         let vol_label = format!("{}%", app.config.default_volume);
 


### PR DESCRIPTION
A few issues arose from browse performance fixes in #62.

Main issue was Ratune's handling of offline mode broke with our switch to non-blocking startup ping.

Now, detection of offline is faster on boot and no longer causes improper error msgs to appear at bottom.