### PR TITLE
Enable multiple selection of lyrics providers

### DIFF
--- a/docs/sample-config.toml
+++ b/docs/sample-config.toml
@@ -435,7 +435,9 @@ location = "right"
 # [lyrics] — lyrics fetch source
 # -----------------------------------------------------------------------------
 #
-# source — "lrclib" (default) | "netease" | "subsonic"
+# source — one provider or an ordered fallback list. Default: "lrclib"
+#   Example: source = ["lrclib", "subsonic", "netease"]
+#   The first provider returning lyrics wins; empty/error/timeout tries the next.
 #   lrclib   — query LRCLib (public API; requests only when the lyrics pane is open)
 #   netease  — query NetEase Cloud Music by title and artist (no login required)
 #   subsonic — query your Subsonic server (getLyricsBySongId / getLyrics; no third party)
@@ -448,6 +450,7 @@ source = "lrclib"
 # cache_enabled = false
 # source = "netease"
 # source = "subsonic"
+# source = ["lrclib", "subsonic", "netease"]
 
 # [ui.nptab.visualizer_pane]
 # enabled — If false, visualizer cannot be opened. Default: true.

--- a/ratune/src/app.rs
+++ b/ratune/src/app.rs
@@ -340,6 +340,7 @@ pub enum LibraryUpdate {
     },
     /// Lyrics fetched for a song; `lines` is empty when the track has no lyrics.
     Lyrics {
+        request_id: u64,
         song_id: String,
         lines: Vec<LyricLine>,
     },
@@ -472,6 +473,22 @@ pub enum LibraryUpdate {
     RadioStations(Result<Vec<InternetRadioStation>, String>),
     /// Create / update / delete internet radio station finished.
     RadioMutation(Result<(), String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LyricsRequest {
+    id: u64,
+    song_id: String,
+}
+
+impl LyricsRequest {
+    fn is_for_song(&self, song_id: &str) -> bool {
+        self.song_id == song_id
+    }
+
+    fn matches_completion(&self, request_id: u64, song_id: &str) -> bool {
+        self.id == request_id && self.song_id == song_id
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -669,6 +686,9 @@ pub struct App {
     pub lyrics_scroll: usize,
     /// True while an async lyrics fetch is in flight.
     pub lyrics_loading: bool,
+    /// Monotonic request generation plus song ID for the active lyrics fetch.
+    lyrics_request_gen: u64,
+    lyrics_request: Option<LyricsRequest>,
 
     // ── Visualizer (Phase 7) ──────────────────────────────────────────────────
     /// Shared ring buffer of the latest decoded f32 audio samples (max 4096).
@@ -933,6 +953,8 @@ impl App {
             lyrics_cache: None,
             lyrics_scroll: 0,
             lyrics_loading: false,
+            lyrics_request_gen: 0,
+            lyrics_request: None,
             sample_buffer,
             spectrum_bands: vec![0.0; 32],
             waveform: Vec::new(),
@@ -2824,11 +2846,11 @@ impl App {
         stations.iter().find(|s| s.id == station_id)
     }
 
-    /// Spawn a task to fetch lyrics from the configured source.
+    /// Spawn a task to fetch lyrics from the configured provider chain.
     ///
     /// No network request is made when lyrics are disabled or the pane is hidden.
-    /// Checks the on-disk cache first. Soft-fails silently — on any error an
-    /// empty `lines` vec is delivered so the UI shows "No lyrics available".
+    /// Each provider checks its positive on-disk cache before a bounded network
+    /// attempt. Errors and empty results advance to the next provider.
     pub fn fetch_lyrics(&mut self, song_id: String, artist: String, title: String, album: String) {
         if !self.config.lyrics_enabled || !self.lyrics_visible {
             return;
@@ -2843,26 +2865,23 @@ impl App {
             return;
         }
 
-        let source_key = self.config.lyrics_source.cache_dir_name();
-        if self.config.lyrics_cache_enabled {
-            if let Some(lines) = self.lyrics_disk_cache.get(source_key, &song_id) {
-                self.lyrics_loading = false;
-                self.lyrics_scroll = 0;
-                self.lyrics_cache = Some((song_id, lines));
-                return;
-            }
-        }
-
-        if !self.remote_available() {
-            self.lyrics_loading = false;
-            self.lyrics_scroll = 0;
-            self.lyrics_cache = Some((song_id, Vec::new()));
+        if self
+            .lyrics_request
+            .as_ref()
+            .is_some_and(|request| request.is_for_song(&song_id))
+        {
             return;
         }
 
+        self.lyrics_request_gen = self.lyrics_request_gen.wrapping_add(1);
+        let request_id = self.lyrics_request_gen;
+        self.lyrics_request = Some(LyricsRequest {
+            id: request_id,
+            song_id: song_id.clone(),
+        });
         self.lyrics_loading = true;
         self.lyrics_scroll = 0;
-        let source = self.config.lyrics_source;
+        let sources = self.config.lyrics_sources.clone();
         let lrclib_url = self.config.lyrics_lrclib_url.clone();
         let duration_secs = self
             .queue
@@ -2871,14 +2890,18 @@ impl App {
             .find(|song| song.id == song_id)
             .and_then(|song| song.duration);
         let cache_enabled = self.config.lyrics_cache_enabled;
+        let network_available = self.remote_available();
         let client = self.subsonic.clone();
         let tx = self.library_tx.clone();
-        let lyrics_dir = self.lyrics_disk_cache.cache_dir_for(source_key);
+        let disk_cache = self.lyrics_disk_cache.clone();
         tokio::spawn(async move {
             let lines = crate::lyrics::fetch_lyrics(
-                source,
+                &sources,
                 &lrclib_url,
                 &client,
+                &disk_cache,
+                cache_enabled,
+                network_available,
                 crate::lyrics::LyricsTrack {
                     song_id: &song_id,
                     artist: &artist,
@@ -2888,10 +2911,13 @@ impl App {
                 },
             )
             .await;
-            if cache_enabled {
-                crate::lyrics_cache::LyricsDiskCache::put_at(&lyrics_dir, &song_id, &lines);
-            }
-            let _ = tx.send(LibraryUpdate::Lyrics { song_id, lines }).await;
+            let _ = tx
+                .send(LibraryUpdate::Lyrics {
+                    request_id,
+                    song_id,
+                    lines,
+                })
+                .await;
         });
     }
 
@@ -3173,10 +3199,28 @@ impl App {
             LibraryUpdate::StatusFlash { msg, secs } => {
                 self.flash_status_secs(msg, secs);
             }
-            LibraryUpdate::Lyrics { song_id, lines } => {
-                self.lyrics_loading = false;
-                self.lyrics_cache = Some((song_id, lines));
-                self.lyrics_scroll = 0;
+            LibraryUpdate::Lyrics {
+                request_id,
+                song_id,
+                lines,
+            } => {
+                let is_active = self
+                    .lyrics_request
+                    .as_ref()
+                    .is_some_and(|request| request.matches_completion(request_id, &song_id));
+                if is_active {
+                    self.lyrics_request = None;
+                    self.lyrics_loading = false;
+                    let is_current_song = self
+                        .playback
+                        .current_song
+                        .as_ref()
+                        .is_some_and(|song| song.id == song_id);
+                    if is_current_song {
+                        self.lyrics_cache = Some((song_id, lines));
+                        self.lyrics_scroll = 0;
+                    }
+                }
             }
             LibraryUpdate::CacheTrack {
                 song_id,
@@ -8473,4 +8517,30 @@ fn sorted_album_song_ids(songs: &[ratune_subsonic::Song]) -> Vec<String> {
         .into_iter()
         .map(|(_, _, id)| id.to_string())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LyricsRequest;
+
+    #[test]
+    fn lyrics_request_suppresses_only_the_same_song() {
+        let request = LyricsRequest {
+            id: 7,
+            song_id: "song-a".into(),
+        };
+        assert!(request.is_for_song("song-a"));
+        assert!(!request.is_for_song("song-b"));
+    }
+
+    #[test]
+    fn lyrics_request_accepts_only_matching_completions() {
+        let request = LyricsRequest {
+            id: 7,
+            song_id: "song-a".into(),
+        };
+        assert!(request.matches_completion(7, "song-a"));
+        assert!(!request.matches_completion(6, "song-a"));
+        assert!(!request.matches_completion(7, "song-b"));
+    }
 }

--- a/ratune/src/config.rs
+++ b/ratune/src/config.rs
@@ -212,9 +212,12 @@ impl Default for CacheSection {
 /// Lyrics fetch settings from config.toml.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LyricsSection {
-    /// Where to fetch lyrics: `lrclib` (default), `netease`, or `subsonic`.
-    #[serde(default = "default_lyrics_source")]
-    pub source: String,
+    /// Ordered lyrics providers. Accepts one string or an array of strings.
+    #[serde(
+        default = "default_lyrics_sources",
+        deserialize_with = "deserialize_lyrics_sources"
+    )]
+    pub source: Vec<String>,
     /// LRCLib server base URL (used when `source = "lrclib"`). Default: https://lrclib.net
     #[serde(default = "default_lrclib_url")]
     pub lrclib_url: String,
@@ -223,8 +226,25 @@ pub struct LyricsSection {
     pub cache_enabled: bool,
 }
 
-fn default_lyrics_source() -> String {
-    "lrclib".into()
+fn default_lyrics_sources() -> Vec<String> {
+    vec!["lrclib".into()]
+}
+
+fn deserialize_lyrics_sources<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    Ok(match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(source) => vec![source],
+        OneOrMany::Many(sources) => sources,
+    })
 }
 
 fn default_lrclib_url() -> String {
@@ -238,7 +258,7 @@ fn default_lyrics_cache_enabled() -> bool {
 impl Default for LyricsSection {
     fn default() -> Self {
         Self {
-            source: default_lyrics_source(),
+            source: default_lyrics_sources(),
             lrclib_url: default_lrclib_url(),
             cache_enabled: default_lyrics_cache_enabled(),
         }
@@ -275,6 +295,20 @@ impl LyricsSource {
             Self::Subsonic => "subsonic",
         }
     }
+}
+
+fn resolve_lyrics_sources(raw: &[String]) -> Vec<LyricsSource> {
+    let mut resolved = Vec::new();
+    for source in raw {
+        let source = LyricsSource::parse(source).unwrap_or(LyricsSource::LrcLib);
+        if !resolved.contains(&source) {
+            resolved.push(source);
+        }
+    }
+    if resolved.is_empty() {
+        resolved.push(LyricsSource::LrcLib);
+    }
+    resolved
 }
 
 // ── [library] — metadata index + fzf picker ───────────────────────────────────
@@ -1438,9 +1472,9 @@ pub struct Config {
     pub cache_starred_albums: bool,
     /// Concurrent downloads when prefetching favorite tracks.
     pub cache_starred_parallelism: usize,
-    /// Where to fetch lyrics (`lrclib`, `netease`, or `subsonic`).
-    pub lyrics_source: LyricsSource,
-    /// LRCLib base URL when `lyrics_source` is `LrcLib`.
+    /// Ordered lyrics providers (`lrclib`, `netease`, or `subsonic`).
+    pub lyrics_sources: Vec<LyricsSource>,
+    /// LRCLib base URL when `lyrics_sources` contains `LrcLib`.
     pub lyrics_lrclib_url: String,
     /// Whether to cache lyrics on disk under `~/.cache/ratune/lyrics/`.
     pub lyrics_cache_enabled: bool,
@@ -1833,8 +1867,7 @@ impl Config {
             cache_starred: file_cfg.cache.cache_starred,
             cache_starred_albums: file_cfg.cache.cache_starred_albums,
             cache_starred_parallelism: file_cfg.cache.cache_starred_parallelism.max(1),
-            lyrics_source: LyricsSource::parse(&file_cfg.lyrics.source)
-                .unwrap_or(LyricsSource::LrcLib),
+            lyrics_sources: resolve_lyrics_sources(&file_cfg.lyrics.source),
             lyrics_lrclib_url: file_cfg.lyrics.lrclib_url,
             lyrics_cache_enabled: file_cfg.lyrics.cache_enabled,
             library_index_enabled: library.enabled,
@@ -2090,7 +2123,9 @@ enabled     = true
 max_size_gb = 2   # maximum total cache size in gigabytes
 
 [lyrics]
-# source — "lrclib" (default) | "netease" | "subsonic"
+# source — one provider or an ordered fallback list. Default: "lrclib"
+#   Example: source = ["lrclib", "subsonic", "netease"]
+#   The first provider returning lyrics wins; empty/error/timeout tries the next.
 source = "lrclib"
 # lrclib_url — LRCLib base URL when source = "lrclib". Default: https://lrclib.net
 # lrclib_url = "https://lrclib.net"
@@ -2719,9 +2754,37 @@ lrclib_url = "https://example.com"
 cache_enabled = false
 "#;
         let fc: FileConfig = toml::from_str(text).expect("toml");
-        assert_eq!(fc.lyrics.source, "subsonic");
+        assert_eq!(fc.lyrics.source, vec!["subsonic"]);
         assert_eq!(fc.lyrics.lrclib_url, "https://example.com");
         assert!(!fc.lyrics.cache_enabled);
+    }
+
+    #[test]
+    fn parses_ordered_lyrics_sources() {
+        let fc: FileConfig =
+            toml::from_str("[lyrics]\nsource = [\"subsonic\", \"lrclib\", \"netease\"]\n")
+                .expect("toml");
+        assert_eq!(fc.lyrics.source, vec!["subsonic", "lrclib", "netease"]);
+    }
+
+    #[test]
+    fn resolves_lyrics_sources_with_defaults_and_stable_deduplication() {
+        let raw = vec![
+            "subsonic".to_string(),
+            "bogus".to_string(),
+            "lrc".to_string(),
+            "netease".to_string(),
+            "server".to_string(),
+        ];
+        assert_eq!(
+            resolve_lyrics_sources(&raw),
+            vec![
+                LyricsSource::Subsonic,
+                LyricsSource::LrcLib,
+                LyricsSource::Netease
+            ]
+        );
+        assert_eq!(resolve_lyrics_sources(&[]), vec![LyricsSource::LrcLib]);
     }
 
     #[test]

--- a/ratune/src/lyrics.rs
+++ b/ratune/src/lyrics.rs
@@ -2,6 +2,7 @@
 //!
 //! All errors are soft-failed — callers always receive a `Vec`, possibly empty.
 
+use std::future::Future;
 use std::time::Duration;
 
 use ratune_subsonic::{LyricLine, SubsonicClient};
@@ -12,8 +13,12 @@ const NETEASE_SEARCH_URL: &str = "https://music.163.com/api/search/get";
 const NETEASE_LYRIC_URL: &str = "https://music.163.com/api/song/lyric";
 const NETEASE_REFERER: &str = "https://music.163.com/";
 const NETEASE_USER_AGENT: &str = concat!("ratune/", env!("CARGO_PKG_VERSION"));
+type LyricsError = Box<dyn std::error::Error + Send + Sync>;
 
 use crate::config::LyricsSource;
+use crate::lyrics_cache::LyricsDiskCache;
+
+const PROVIDER_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -52,6 +57,7 @@ struct NeteaseLyrics {
     lyric: Option<String>,
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct LyricsTrack<'a> {
     pub song_id: &'a str,
     pub artist: &'a str,
@@ -61,23 +67,131 @@ pub(crate) struct LyricsTrack<'a> {
     pub duration_secs: Option<u32>,
 }
 
-/// Fetch lyrics using the configured source.
+/// Fetch lyrics from the configured providers in priority order.
 pub async fn fetch_lyrics(
+    sources: &[LyricsSource],
+    lrclib_url: &str,
+    client: &SubsonicClient,
+    disk_cache: &LyricsDiskCache,
+    cache_enabled: bool,
+    network_available: bool,
+    track: LyricsTrack<'_>,
+) -> Vec<LyricLine> {
+    first_available(
+        sources,
+        PROVIDER_TIMEOUT,
+        track.song_id,
+        |source| async move {
+            let source_key = source.cache_dir_name();
+            if cache_enabled {
+                if let Some(lines) = disk_cache.get(source_key, track.song_id) {
+                    if !lines.is_empty() {
+                        crate::debug::log(format!(
+                            "lyrics[{}]: {source_key} cache hit ({} lines)",
+                            track.song_id,
+                            lines.len()
+                        ));
+                        return Ok::<_, LyricsError>(lines);
+                    }
+                    crate::debug::log(format!(
+                        "lyrics[{}]: {source_key} cache entry is empty; ignoring",
+                        track.song_id
+                    ));
+                } else {
+                    crate::debug::log(format!(
+                        "lyrics[{}]: {source_key} cache miss",
+                        track.song_id
+                    ));
+                }
+            } else {
+                crate::debug::log(format!(
+                    "lyrics[{}]: {source_key} cache disabled",
+                    track.song_id
+                ));
+            }
+
+            if !network_available {
+                crate::debug::log(format!(
+                    "lyrics[{}]: {source_key} network fetch skipped (offline)",
+                    track.song_id
+                ));
+                return Ok::<_, LyricsError>(Vec::new());
+            }
+
+            crate::debug::log(format!(
+                "lyrics[{}]: fetching from {source_key}",
+                track.song_id
+            ));
+            let lines = fetch_lyrics_from_source(source, lrclib_url, client, track).await?;
+            if cache_enabled && !lines.is_empty() {
+                disk_cache.put(source_key, track.song_id, &lines);
+                crate::debug::log(format!(
+                    "lyrics[{}]: cached {} {source_key} lines",
+                    track.song_id,
+                    lines.len()
+                ));
+            }
+            Ok(lines)
+        },
+    )
+    .await
+}
+
+async fn first_available<F, Fut, E>(
+    sources: &[LyricsSource],
+    timeout: Duration,
+    song_id: &str,
+    mut attempt: F,
+) -> Vec<LyricLine>
+where
+    F: FnMut(LyricsSource) -> Fut,
+    Fut: Future<Output = Result<Vec<LyricLine>, E>>,
+{
+    for &source in sources {
+        let source_key = source.cache_dir_name();
+        crate::debug::log(format!("lyrics[{song_id}]: trying {source_key}"));
+        match tokio::time::timeout(timeout, attempt(source)).await {
+            Ok(Ok(lines)) if !lines.is_empty() => {
+                crate::debug::log(format!(
+                    "lyrics[{song_id}]: selected {source_key} ({} lines)",
+                    lines.len()
+                ));
+                return lines;
+            }
+            Ok(Ok(_)) => crate::debug::log(format!(
+                "lyrics[{song_id}]: {source_key} returned no lyrics; falling back"
+            )),
+            Ok(Err(_)) => crate::debug::log(format!(
+                "lyrics[{song_id}]: {source_key} request failed; falling back"
+            )),
+            Err(_) => crate::debug::log(format!(
+                "lyrics[{song_id}]: {source_key} timed out after {:.1}s; falling back",
+                timeout.as_secs_f64()
+            )),
+        }
+    }
+    crate::debug::log(format!(
+        "lyrics[{song_id}]: provider chain exhausted; no lyrics available"
+    ));
+    Vec::new()
+}
+
+async fn fetch_lyrics_from_source(
     source: LyricsSource,
     lrclib_url: &str,
     client: &SubsonicClient,
     track: LyricsTrack<'_>,
-) -> Vec<LyricLine> {
+) -> Result<Vec<LyricLine>, LyricsError> {
     match source {
-        LyricsSource::LrcLib => fetch_lrclib(lrclib_url, track.artist, track.title, track.album)
-            .await
-            .unwrap_or_default(),
-        LyricsSource::Netease => fetch_netease(track.artist, track.title, track.duration_secs)
-            .await
-            .unwrap_or_default(),
-        LyricsSource::Subsonic => fetch_subsonic(client, track.song_id, track.artist, track.title)
-            .await
-            .unwrap_or_default(),
+        LyricsSource::LrcLib => {
+            fetch_lrclib(lrclib_url, track.artist, track.title, track.album).await
+        }
+        LyricsSource::Netease => {
+            fetch_netease(track.artist, track.title, track.duration_secs).await
+        }
+        LyricsSource::Subsonic => {
+            fetch_subsonic(client, track.song_id, track.artist, track.title).await
+        }
     }
 }
 
@@ -452,5 +566,142 @@ mod tests {
         let lines = parse_lyrics_text(text);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].time, Some(Duration::from_millis(2000)));
+    }
+
+    #[tokio::test]
+    async fn ordered_sources_stop_at_first_non_empty_result() {
+        use std::sync::{Arc, Mutex};
+
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&attempts);
+        let lines = first_available(
+            &[
+                LyricsSource::LrcLib,
+                LyricsSource::Subsonic,
+                LyricsSource::Netease,
+            ],
+            Duration::from_secs(1),
+            "test-song",
+            move |source| {
+                let seen = Arc::clone(&seen);
+                async move {
+                    seen.lock().expect("attempts").push(source);
+                    let lines = match source {
+                        LyricsSource::LrcLib => Vec::new(),
+                        LyricsSource::Subsonic => vec![LyricLine {
+                            time: None,
+                            text: "server lyrics".into(),
+                        }],
+                        LyricsSource::Netease => panic!("fallback should have stopped"),
+                    };
+                    Ok::<_, &'static str>(lines)
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(lines[0].text, "server lyrics");
+        assert_eq!(
+            *attempts.lock().expect("attempts"),
+            vec![LyricsSource::LrcLib, LyricsSource::Subsonic]
+        );
+    }
+
+    #[tokio::test]
+    async fn ordered_sources_fall_back_after_errors_and_timeouts() {
+        use std::sync::{Arc, Mutex};
+
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&attempts);
+        let lines = first_available(
+            &[
+                LyricsSource::LrcLib,
+                LyricsSource::Subsonic,
+                LyricsSource::Netease,
+            ],
+            Duration::from_millis(10),
+            "test-song",
+            move |source| {
+                let seen = Arc::clone(&seen);
+                async move {
+                    seen.lock().expect("attempts").push(source);
+                    match source {
+                        LyricsSource::LrcLib => Err("test provider error"),
+                        LyricsSource::Subsonic => {
+                            std::future::pending::<()>().await;
+                            Ok(Vec::new())
+                        }
+                        LyricsSource::Netease => Ok(vec![LyricLine {
+                            time: None,
+                            text: "fallback lyrics".into(),
+                        }]),
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(lines[0].text, "fallback lyrics");
+        assert_eq!(
+            *attempts.lock().expect("attempts"),
+            vec![
+                LyricsSource::LrcLib,
+                LyricsSource::Subsonic,
+                LyricsSource::Netease
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn offline_sources_use_first_positive_cache_entry() {
+        let dir = std::env::temp_dir().join(format!(
+            "ratune-lyrics-ordered-cache-{}",
+            std::process::id()
+        ));
+        let cache = LyricsDiskCache::from_dir(dir.clone());
+        let empty_dir = cache.cache_dir_for("lrclib");
+        LyricsDiskCache::put_at(&empty_dir, "song-1", &[]);
+        cache.put(
+            "subsonic",
+            "song-1",
+            &[LyricLine {
+                time: None,
+                text: "cached server lyrics".into(),
+            }],
+        );
+        cache.put(
+            "netease",
+            "song-1",
+            &[LyricLine {
+                time: None,
+                text: "later cached lyrics".into(),
+            }],
+        );
+        let client =
+            SubsonicClient::new("http://localhost:4533", "user", "pass").expect("subsonic client");
+
+        let lines = fetch_lyrics(
+            &[
+                LyricsSource::LrcLib,
+                LyricsSource::Subsonic,
+                LyricsSource::Netease,
+            ],
+            "https://lrclib.net",
+            &client,
+            &cache,
+            true,
+            false,
+            LyricsTrack {
+                song_id: "song-1",
+                artist: "Artist",
+                title: "Title",
+                album: "Album",
+                duration_secs: Some(180),
+            },
+        )
+        .await;
+
+        assert_eq!(lines[0].text, "cached server lyrics");
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/ratune/src/lyrics_cache.rs
+++ b/ratune/src/lyrics_cache.rs
@@ -28,6 +28,11 @@ pub struct LyricsDiskCache {
 }
 
 impl LyricsDiskCache {
+    #[cfg(test)]
+    pub(crate) fn from_dir(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
     /// Open the lyrics cache directory, creating it when possible.
     pub fn load() -> Self {
         let dir = ratune_cache_dir()
@@ -54,6 +59,15 @@ impl LyricsDiskCache {
         let json = std::fs::read_to_string(path).ok()?;
         let cached: CachedLyrics = serde_json::from_str(&json).ok()?;
         Some(cached.lines.into_iter().map(line_from_cached).collect())
+    }
+
+    /// Write non-empty lyrics under their provider key.
+    pub fn put(&self, source: &str, song_id: &str, lines: &[LyricLine]) {
+        if lines.is_empty() {
+            return;
+        }
+        let dir = self.cache_dir_for(source);
+        Self::put_at(&dir, song_id, lines);
     }
 
     /// Write lyrics to a source-specific directory (for async fetch tasks).
@@ -144,6 +158,16 @@ mod tests {
         let cache = LyricsDiskCache { dir };
         let loaded = cache.get("subsonic", "no-lyrics").expect("cached empty");
         assert!(loaded.is_empty());
+        let _ = std::fs::remove_dir_all(cache.dir);
+    }
+
+    #[test]
+    fn positive_only_put_ignores_empty_lines() {
+        let dir =
+            std::env::temp_dir().join(format!("ratune-lyrics-positive-{}", std::process::id()));
+        let cache = LyricsDiskCache { dir };
+        cache.put("lrclib", "no-lyrics", &[]);
+        assert!(cache.get("lrclib", "no-lyrics").is_none());
         let _ = std::fs::remove_dir_all(cache.dir);
     }
 


### PR DESCRIPTION
Allow users to select multiple lyrics providers. Lookup lyrics in order of providers until it's found in the first one. Also improve lyric caching logic to avoid incorrectly caching failed lookups from server

This is a bit of a specific fix for my usecase, hope it fits the project.

**Disclaimer**: This was done with heavy assistance of agentic LLM coding (Codex). I've reviewed and tested to the best of my knowledge, but I am not that versed in Rust. If any of this does not suit the project guidelines, please let me know. 